### PR TITLE
Add extract command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,47 @@ Flux CLI plugin for Kubernetes schema extraction and manifests validation.
 > This repository is in early development and the plugin system is not yet available in a stable release of Flux.
 > The instructions for installing and using the plugin will be added here when [RFC-0013](https://github.com/fluxcd/flux2/blob/main/rfcs/0013-cli-plugin-system/README.md)
 > has been implemented and released in Flux 2.9 or later.
+
+## Available Commands
+
+### `flux-schema extract`
+
+The extract command reads Kubernetes CustomResourceDefinition YAML and writes one JSON Schema file per CRD version.
+The input can be a bare CRD, a `List` of CRDs, or a multi-document YAML stream.
+
+Generate schemas for every CRD installed in a cluster:
+
+```shell
+kubectl get crds -o yaml > crds.yaml
+flux-schema extract crds.yaml -d ./schemas
+```
+
+By default, files are named `{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json`. The output is compatible with
+`kubeconform` and `kubeval`, making this command a drop-in replacement for kubeconform's
+[openapi2jsonschema.py](https://github.com/yannh/kubeconform/blob/master/scripts/openapi2jsonschema.py) script.
+
+Note that the generated schemas apply the following OpenAPI → JSON Schema transformations:
+
+- Objects with `properties` are closed with `additionalProperties: false`, except under nodes
+  marked with `x-kubernetes-preserve-unknown-fields: true`, which stay open so free-form maps validate correctly.
+- Integer-or-string fields are rewritten to `oneOf: [{type: string}, {type: integer}]`. Both the
+  legacy `format: int-or-string` and the structural `x-kubernetes-int-or-string: true` forms are recognized.
+
+You can supply `--output-format` with a Go template to change the layout, e.g. the
+[CRDs-catalog](https://github.com/datreeio/CRDs-catalog) per-group-directory layout:
+
+```shell
+flux-schema extract crds.yaml \
+  --output-format '{{ .Group }}/{{ .Kind }}_{{ .Version }}.json'
+```
+
+Template variables (all lowercased at render time):
+
+| Variable       | Example                    |
+|----------------|----------------------------|
+| `.Group`       | `source.toolkit.fluxcd.io` |
+| `.GroupPrefix` | `source`                   |
+| `.Kind`        | `gitrepository`            |
+| `.Version`     | `v1`                       |
+
+Nested directories referenced by `--output-format` are created automatically.

--- a/cmd/flux-schema/extract.go
+++ b/cmd/flux-schema/extract.go
@@ -1,0 +1,127 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/fluxcd/flux-schema/internal/extractor"
+	"github.com/fluxcd/flux-schema/internal/tmpl"
+)
+
+const defaultExtractFormat = "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json"
+
+var extractCmd = &cobra.Command{
+	Use:   "extract [crd-file...]",
+	Short: "Extract JSON Schemas from Kubernetes CRD YAML files",
+	Example: `  # Extract schemas using the kubeval / kubeconform layout
+  kubectl get crd ocirepositories.source.toolkit.fluxcd.io -o yaml > oci-crd.yaml
+  flux-schema extract oci-crd.yaml -d ./schemas \
+    --output-format '{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json'
+
+  # Extract in the current dir with one directory per API group
+  kubectl get crds -o yaml > crds.yaml
+  flux-schema extract crds.yaml \
+    --output-format '{{ .Group }}/{{ .Kind }}_{{ .Version }}.json'`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: extractCmdRun,
+}
+
+type extractFlags struct {
+	outputDir    string
+	outputFormat string
+}
+
+var extractArgs = extractFlags{
+	outputDir:    ".",
+	outputFormat: defaultExtractFormat,
+}
+
+func init() {
+	extractCmd.Flags().StringVarP(&extractArgs.outputDir, "output-dir", "d", extractArgs.outputDir,
+		"directory where JSON Schema files are written (created if missing)")
+	extractCmd.Flags().StringVarP(&extractArgs.outputFormat, "output-format", "f", defaultExtractFormat,
+		"Go template for the output file path, relative to --output-dir; "+
+			"variables: .Group, .GroupPrefix, .Kind, .Version")
+	_ = extractCmd.MarkFlagDirname("output-dir")
+	rootCmd.AddCommand(extractCmd)
+}
+
+func extractCmdRun(cmd *cobra.Command, args []string) error {
+	if err := os.MkdirAll(extractArgs.outputDir, 0o755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+
+	var failures []error
+	for _, path := range args {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			failures = append(failures, fmt.Errorf("%s: %w", path, err))
+			continue
+		}
+		crds, errs := extractor.Extract(data)
+		for _, e := range errs {
+			failures = append(failures, fmt.Errorf("%s: %w", path, e))
+		}
+		for _, crd := range crds {
+			if err := writeCRD(cmd, path, crd); err != nil {
+				failures = append(failures, err)
+			}
+		}
+	}
+
+	if len(failures) > 0 {
+		for _, e := range failures {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "FAIL %v\n", e)
+		}
+		return fmt.Errorf("%d error(s) during extraction", len(failures))
+	}
+	return nil
+}
+
+func writeCRD(cmd *cobra.Command, srcPath string, crd extractor.CRD) error {
+	rendered, err := tmpl.Render(extractArgs.outputFormat, tmpl.SchemaVars{
+		Group:   crd.Group,
+		Kind:    crd.Kind,
+		Version: crd.Version,
+	})
+	if err != nil {
+		return fmt.Errorf("%s (%s/%s %s): %w", srcPath, crd.Group, crd.Kind, crd.Version, err)
+	}
+
+	outPath := filepath.Join(extractArgs.outputDir, filepath.FromSlash(rendered))
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(outPath), err)
+	}
+
+	payload, err := marshalSchema(crd.Schema)
+	if err != nil {
+		return fmt.Errorf("%s %s %s: %w", srcPath, crd.Kind, crd.Version, err)
+	}
+	if err := os.WriteFile(outPath, payload, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", outPath, err)
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK   %s -> %s\n", srcPath, outPath)
+	return nil
+}
+
+// marshalSchema encodes a parsed schema as deterministic, pretty-printed JSON.
+// encoding/json sorts map[string]any keys alphabetically, so output is stable across runs.
+func marshalSchema(schema map[string]any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(schema); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/cmd/flux-schema/extract_test.go
+++ b/cmd/flux-schema/extract_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestExtractCmd_DefaultFormat(t *testing.T) {
+	g := NewWithT(t)
+
+	outDir := t.TempDir()
+	input := writeCRDFixture(t)
+
+	_, err := executeCommand([]string{"extract", input, "--output-dir", outDir})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	got, err := os.ReadFile(filepath.Join(outDir, "widget-example-v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(got)).To(Equal(minimalCRDGolden))
+}
+
+func TestExtractCmd_NestedFormatCreatesSubdirs(t *testing.T) {
+	g := NewWithT(t)
+
+	outDir := t.TempDir()
+	input := writeCRDFixture(t)
+
+	_, err := executeCommand([]string{
+		"extract", input,
+		"--output-dir", outDir,
+		"--output-format", "{{ .Group }}/{{ .Kind }}_{{ .Version }}.json",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	got, err := os.ReadFile(filepath.Join(outDir, "example.com", "widget_v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(got)).To(Equal(minimalCRDGolden))
+}
+
+func TestExtractCmd_AutoCreatesOutputDir(t *testing.T) {
+	g := NewWithT(t)
+
+	parent := t.TempDir()
+	outDir := filepath.Join(parent, "does", "not", "exist")
+	input := writeCRDFixture(t)
+
+	_, err := executeCommand([]string{"extract", input, "--output-dir", outDir})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, err = os.Stat(filepath.Join(outDir, "widget-example-v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestExtractCmd_DefaultsOutputDirToCwd(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Chdir(t.TempDir())
+	input := writeCRDFixture(t)
+
+	_, err := executeCommand([]string{"extract", input})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, err = os.Stat("widget-example-v1.json")
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestExtractCmd_NonexistentInput(t *testing.T) {
+	g := NewWithT(t)
+
+	outDir := t.TempDir()
+	_, err := executeCommand([]string{"extract", filepath.Join(outDir, "missing.yaml"), "--output-dir", outDir})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("error(s) during extraction"))
+}
+
+func TestExtractCmd_UnknownTemplateVar(t *testing.T) {
+	g := NewWithT(t)
+
+	outDir := t.TempDir()
+	input := writeCRDFixture(t)
+
+	_, err := executeCommand([]string{
+		"extract", input,
+		"--output-dir", outDir,
+		"--output-format", "{{ .Unknown }}.json",
+	})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("error(s) during extraction"))
+}
+
+// To refresh the testdata fixture and golden file, run:
+//
+//	kubectl get crd helmreleases.helm.toolkit.fluxcd.io -o yaml \
+//	  > cmd/flux-schema/testdata/extract/helmrelease-helm-v2.yaml
+//	make run GO_RUN_ARGS="extract \
+//	  cmd/flux-schema/testdata/extract/helmrelease-helm-v2.yaml \
+//	  --output-dir cmd/flux-schema/testdata/extract"
+func TestExtractCmd_HelmReleaseGolden(t *testing.T) {
+	g := NewWithT(t)
+
+	inputPath := filepath.Join("testdata", "extract", "helmrelease-helm-v2.yaml")
+	goldenPath := filepath.Join("testdata", "extract", "helmrelease-helm-v2.json")
+
+	outDir := t.TempDir()
+	_, err := executeCommand([]string{"extract", inputPath, "--output-dir", outDir})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	got, err := os.ReadFile(filepath.Join(outDir, "helmrelease-helm-v2.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	want, err := os.ReadFile(goldenPath)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(got)).To(Equal(string(want)))
+}
+
+func writeCRDFixture(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fixture.yaml")
+	if err := os.WriteFile(path, []byte(minimalCRDYAML), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+const minimalCRDYAML = `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  names:
+    kind: Widget
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string
+                port:
+                  x-kubernetes-int-or-string: true
+                values:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+`
+
+const minimalCRDGolden = `{
+  "properties": {
+    "spec": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "port": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "values": {
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}
+`

--- a/cmd/flux-schema/main_test.go
+++ b/cmd/flux-schema/main_test.go
@@ -8,6 +8,9 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var (
@@ -42,4 +45,18 @@ func resetCmdArgs() {
 	rootArgs.timeout = timeout
 
 	versionArgs = versionFlags{output: "text"}
+	extractArgs = extractFlags{outputDir: ".", outputFormat: defaultExtractFormat}
+
+	// pflag.Flag.Changed persists across Execute calls on the shared rootCmd,
+	// which breaks MarkFlagRequired validation in subsequent tests. Clear it
+	// for every flag in the command tree.
+	resetFlagChanged(rootCmd)
+}
+
+func resetFlagChanged(cmd *cobra.Command) {
+	cmd.Flags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
+	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
+	for _, sub := range cmd.Commands() {
+		resetFlagChanged(sub)
+	}
 }

--- a/cmd/flux-schema/testdata/extract/helmrelease-helm-v2.json
+++ b/cmd/flux-schema/testdata/extract/helmrelease-helm-v2.json
@@ -1,0 +1,1285 @@
+{
+  "description": "HelmRelease is the Schema for the helmreleases API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "additionalProperties": false,
+      "description": "HelmReleaseSpec defines the desired state of a Helm release.",
+      "properties": {
+        "chart": {
+          "additionalProperties": false,
+          "description": "Chart defines the template of the v1.HelmChart that should be created\nfor this HelmRelease.",
+          "properties": {
+            "metadata": {
+              "additionalProperties": false,
+              "description": "ObjectMeta holds the template for metadata like labels and annotations.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "spec": {
+              "additionalProperties": false,
+              "description": "Spec holds the template for the v1.HelmChartSpec for this HelmRelease.",
+              "properties": {
+                "chart": {
+                  "description": "The name or path the Helm chart is available at in the SourceRef.",
+                  "maxLength": 2048,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "ignoreMissingValuesFiles": {
+                  "description": "IgnoreMissingValuesFiles controls whether to silently ignore missing values files rather than failing.",
+                  "type": "boolean"
+                },
+                "interval": {
+                  "description": "Interval at which to check the v1.Source for updates. Defaults to\n'HelmReleaseSpec.Interval'.",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+                  "type": "string"
+                },
+                "reconcileStrategy": {
+                  "default": "ChartVersion",
+                  "description": "Determines what enables the creation of a new artifact. Valid values are\n('ChartVersion', 'Revision').\nSee the documentation of the values for an explanation on their behavior.\nDefaults to ChartVersion when omitted.",
+                  "enum": [
+                    "ChartVersion",
+                    "Revision"
+                  ],
+                  "type": "string"
+                },
+                "sourceRef": {
+                  "additionalProperties": false,
+                  "description": "The name and namespace of the v1.Source the chart is available at.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "APIVersion of the referent.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent.",
+                      "enum": [
+                        "HelmRepository",
+                        "GitRepository",
+                        "Bucket"
+                      ],
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent.",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "valuesFiles": {
+                  "description": "Alternative list of values files to use as the chart values (values.yaml\nis not included by default), expected to be a relative path in the SourceRef.\nValues files are merged in the order of this list with the last file overriding\nthe first. Ignored when omitted.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "verify": {
+                  "additionalProperties": false,
+                  "description": "Verify contains the secret name containing the trusted public keys\nused to verify the signature and specifies which provider to use to check\nwhether OCI image is authentic.\nThis field is only supported for OCI sources.\nChart dependencies, which are not bundled in the umbrella chart artifact,\nare not verified.",
+                  "properties": {
+                    "provider": {
+                      "default": "cosign",
+                      "description": "Provider specifies the technology used to sign the OCI Helm chart.",
+                      "enum": [
+                        "cosign",
+                        "notation"
+                      ],
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "additionalProperties": false,
+                      "description": "SecretRef specifies the Kubernetes Secret containing the\ntrusted public keys.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "provider"
+                  ],
+                  "type": "object"
+                },
+                "version": {
+                  "default": "*",
+                  "description": "Version semver expression, ignored for charts from v1.GitRepository and\nv1beta2.Bucket sources. Defaults to latest when omitted.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "chart",
+                "sourceRef"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object"
+        },
+        "chartRef": {
+          "additionalProperties": false,
+          "description": "ChartRef holds a reference to a source controller resource containing the\nHelm chart artifact.",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion of the referent.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent.",
+              "enum": [
+                "OCIRepository",
+                "HelmChart",
+                "ExternalArtifact"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent, defaults to the namespace of the Kubernetes\nresource object that contains the reference.",
+              "maxLength": 63,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        "commonMetadata": {
+          "additionalProperties": false,
+          "description": "CommonMetadata specifies the common labels and annotations that are\napplied to all resources. Any existing label or annotation will be\noverridden if its key matches a common one.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Annotations to be added to the object's metadata.",
+              "type": "object"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Labels to be added to the object's metadata.",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "dependsOn": {
+          "description": "DependsOn may contain a DependencyReference slice with\nreferences to HelmRelease resources that must be ready before this HelmRelease\ncan be reconciled.",
+          "items": {
+            "additionalProperties": false,
+            "description": "DependencyReference defines a HelmRelease dependency on another HelmRelease resource.",
+            "properties": {
+              "name": {
+                "description": "Name of the referent.",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace of the referent, defaults to the namespace of the HelmRelease\nresource object that contains the reference.",
+                "type": "string"
+              },
+              "readyExpr": {
+                "description": "ReadyExpr is a CEL expression that can be used to assess the readiness\nof a dependency. When specified, the built-in readiness check\nis replaced by the logic defined in the CEL expression.\nTo make the CEL expression additive to the built-in readiness check,\nthe feature gate `AdditiveCELDependencyCheck` must be set to `true`.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "driftDetection": {
+          "additionalProperties": false,
+          "description": "DriftDetection holds the configuration for detecting and handling\ndifferences between the manifest in the Helm storage and the resources\ncurrently existing in the cluster.",
+          "properties": {
+            "ignore": {
+              "description": "Ignore contains a list of rules for specifying which changes to ignore\nduring diffing.",
+              "items": {
+                "additionalProperties": false,
+                "description": "IgnoreRule defines a rule to selectively disregard specific changes during\nthe drift detection process.",
+                "properties": {
+                  "paths": {
+                    "description": "Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from\nconsideration in a Kubernetes object.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "target": {
+                    "additionalProperties": false,
+                    "description": "Target is a selector for specifying Kubernetes objects to which this\nrule applies.\nIf Target is not set, the Paths will be ignored for all Kubernetes\nobjects within the manifest of the Helm release.",
+                    "properties": {
+                      "annotationSelector": {
+                        "description": "AnnotationSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api\nIt matches with the resource annotations.",
+                        "type": "string"
+                      },
+                      "group": {
+                        "description": "Group is the API group to select resources from.\nTogether with Version and Kind it is capable of unambiguously identifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Kind of the API Group to select resources from.\nTogether with Group and Version it is capable of unambiguously\nidentifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                        "type": "string"
+                      },
+                      "labelSelector": {
+                        "description": "LabelSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api\nIt matches with the resource labels.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name to match resources with.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace to select resources from.",
+                        "type": "string"
+                      },
+                      "version": {
+                        "description": "Version of the API Group to select resources from.\nTogether with Group and Kind it is capable of unambiguously identifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "paths"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "mode": {
+              "description": "Mode defines how differences should be handled between the Helm manifest\nand the manifest currently applied to the cluster.\nIf not explicitly set, it defaults to DiffModeDisabled.",
+              "enum": [
+                "enabled",
+                "warn",
+                "disabled"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "healthCheckExprs": {
+          "description": "HealthCheckExprs is a list of healthcheck expressions for evaluating the\nhealth of custom resources using Common Expression Language (CEL).\nThe expressions are evaluated only when the specific Helm action\ntaking place has wait enabled, i.e. DisableWait is false, and the\n'poller' WaitStrategy is used.",
+          "items": {
+            "additionalProperties": false,
+            "description": "CustomHealthCheck defines the health check for custom resources.",
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion of the custom resource under evaluation.",
+                "type": "string"
+              },
+              "current": {
+                "description": "Current is the CEL expression that determines if the status\nof the custom resource has reached the desired state.",
+                "type": "string"
+              },
+              "failed": {
+                "description": "Failed is the CEL expression that determines if the status\nof the custom resource has failed to reach the desired state.",
+                "type": "string"
+              },
+              "inProgress": {
+                "description": "InProgress is the CEL expression that determines if the status\nof the custom resource has not yet reached the desired state.",
+                "type": "string"
+              },
+              "kind": {
+                "description": "Kind of the custom resource under evaluation.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "apiVersion",
+              "current",
+              "kind"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "install": {
+          "additionalProperties": false,
+          "description": "Install holds the configuration for Helm install actions for this HelmRelease.",
+          "properties": {
+            "crds": {
+              "description": "CRDs upgrade CRDs from the Helm Chart's crds directory according\nto the CRD upgrade policy provided here. Valid values are `Skip`,\n`Create` or `CreateReplace`. Default is `Create` and if omitted\nCRDs are installed but not updated.\n\nSkip: do neither install nor replace (update) any CRDs.\n\nCreate: new CRDs are created, existing CRDs are neither updated nor deleted.\n\nCreateReplace: new CRDs are created, existing CRDs are updated (replaced)\nbut not deleted.\n\nBy default, CRDs are applied (installed) during Helm install action.\nWith this option users can opt in to CRD replace existing CRDs on Helm\ninstall actions, which is not (yet) natively supported by Helm.\nhttps://helm.sh/docs/chart_best_practices/custom_resource_definitions.",
+              "enum": [
+                "Skip",
+                "Create",
+                "CreateReplace"
+              ],
+              "type": "string"
+            },
+            "createNamespace": {
+              "description": "CreateNamespace tells the Helm install action to create the\nHelmReleaseSpec.TargetNamespace if it does not exist yet.\nOn uninstall, the namespace will not be garbage collected.",
+              "type": "boolean"
+            },
+            "disableHooks": {
+              "description": "DisableHooks prevents hooks from running during the Helm install action.",
+              "type": "boolean"
+            },
+            "disableOpenAPIValidation": {
+              "description": "DisableOpenAPIValidation prevents the Helm install action from validating\nrendered templates against the Kubernetes OpenAPI Schema.",
+              "type": "boolean"
+            },
+            "disableSchemaValidation": {
+              "description": "DisableSchemaValidation prevents the Helm install action from validating\nthe values against the JSON Schema.",
+              "type": "boolean"
+            },
+            "disableTakeOwnership": {
+              "description": "DisableTakeOwnership disables taking ownership of existing resources\nduring the Helm install action. Defaults to false.",
+              "type": "boolean"
+            },
+            "disableWait": {
+              "description": "DisableWait disables the waiting for resources to be ready after a Helm\ninstall has been performed.",
+              "type": "boolean"
+            },
+            "disableWaitForJobs": {
+              "description": "DisableWaitForJobs disables waiting for jobs to complete after a Helm\ninstall has been performed.",
+              "type": "boolean"
+            },
+            "remediation": {
+              "additionalProperties": false,
+              "description": "Remediation holds the remediation configuration for when the Helm install\naction for the HelmRelease fails. The default is to not perform any action.",
+              "properties": {
+                "ignoreTestFailures": {
+                  "description": "IgnoreTestFailures tells the controller to skip remediation when the Helm\ntests are run after an install action but fail. Defaults to\n'Test.IgnoreFailures'.",
+                  "type": "boolean"
+                },
+                "remediateLastFailure": {
+                  "description": "RemediateLastFailure tells the controller to remediate the last failure, when\nno retries remain. Defaults to 'false'.",
+                  "type": "boolean"
+                },
+                "retries": {
+                  "description": "Retries is the number of retries that should be attempted on failures before\nbailing. Remediation, using an uninstall, is performed between each attempt.\nDefaults to '0', a negative integer equals to unlimited retries.",
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "replace": {
+              "description": "Replace tells the Helm install action to re-use the 'ReleaseName', but only\nif that name is a deleted release which remains in the history.",
+              "type": "boolean"
+            },
+            "serverSideApply": {
+              "description": "ServerSideApply enables server-side apply for resources during install.\nDefaults to true (or false when UseHelm3Defaults feature gate is enabled).",
+              "type": "boolean"
+            },
+            "skipCRDs": {
+              "description": "SkipCRDs tells the Helm install action to not install any CRDs. By default,\nCRDs are installed if not already present.\n\nDeprecated use CRD policy (`crds`) attribute with value `Skip` instead.",
+              "type": "boolean"
+            },
+            "strategy": {
+              "additionalProperties": false,
+              "description": "Strategy defines the install strategy to use for this HelmRelease.\nDefaults to 'RemediateOnFailure', or 'RetryOnFailure' when the\nDefaultToRetryOnFailure feature gate is enabled.",
+              "properties": {
+                "name": {
+                  "description": "Name of the install strategy.",
+                  "enum": [
+                    "RemediateOnFailure",
+                    "RetryOnFailure"
+                  ],
+                  "type": "string"
+                },
+                "retryInterval": {
+                  "description": "RetryInterval is the interval at which to retry a failed install.\nCan be used only when Name is set to RetryOnFailure.\nDefaults to '5m'.",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": ".retryInterval cannot be set when .name is 'RemediateOnFailure'",
+                  "rule": "!has(self.retryInterval) || self.name != 'RemediateOnFailure'"
+                }
+              ]
+            },
+            "timeout": {
+              "description": "Timeout is the time to wait for any individual Kubernetes operation (like\nJobs for hooks) during the performance of a Helm install action. Defaults to\n'HelmReleaseSpec.Timeout'.",
+              "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "interval": {
+          "description": "Interval at which to reconcile the Helm release.",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+          "type": "string"
+        },
+        "kubeConfig": {
+          "additionalProperties": false,
+          "description": "KubeConfig for reconciling the HelmRelease on a remote cluster.\nWhen used in combination with HelmReleaseSpec.ServiceAccountName,\nforces the controller to act on behalf of that Service Account at the\ntarget cluster.\nIf the --default-service-account flag is set, its value will be used as\na controller level fallback for when HelmReleaseSpec.ServiceAccountName\nis empty.",
+          "properties": {
+            "configMapRef": {
+              "additionalProperties": false,
+              "description": "ConfigMapRef holds an optional name of a ConfigMap that contains\nthe following keys:\n\n- `provider`: the provider to use. One of `aws`, `azure`, `gcp`, or\n   `generic`. Required.\n- `cluster`: the fully qualified resource name of the Kubernetes\n   cluster in the cloud provider API. Not used by the `generic`\n   provider. Required when one of `address` or `ca.crt` is not set.\n- `address`: the address of the Kubernetes API server. Required\n   for `generic`. For the other providers, if not specified, the\n   first address in the cluster resource will be used, and if\n   specified, it must match one of the addresses in the cluster\n   resource.\n   If audiences is not set, will be used as the audience for the\n   `generic` provider.\n- `ca.crt`: the optional PEM-encoded CA certificate for the\n   Kubernetes API server. If not set, the controller will use the\n   CA certificate from the cluster resource.\n- `audiences`: the optional audiences as a list of\n   line-break-separated strings for the Kubernetes ServiceAccount\n   token. Defaults to the `address` for the `generic` provider, or\n   to specific values for the other providers depending on the\n   provider.\n-  `serviceAccountName`: the optional name of the Kubernetes\n   ServiceAccount in the same namespace that should be used\n   for authentication. If not specified, the controller\n   ServiceAccount will be used.\n\nMutually exclusive with SecretRef.",
+              "properties": {
+                "name": {
+                  "description": "Name of the referent.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            },
+            "secretRef": {
+              "additionalProperties": false,
+              "description": "SecretRef holds an optional name of a secret that contains a key with\nthe kubeconfig file as the value. If no key is set, the key will default\nto 'value'. Mutually exclusive with ConfigMapRef.\nIt is recommended that the kubeconfig is self-contained, and the secret\nis regularly updated if credentials such as a cloud-access-token expire.\nCloud specific `cmd-path` auth helpers will not function without adding\nbinaries and credentials to the Pod that is responsible for reconciling\nKubernetes resources. Supported only for the generic provider.",
+              "properties": {
+                "key": {
+                  "description": "Key in the Secret, when not specified an implementation-specific default key is used.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the Secret.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "exactly one of spec.kubeConfig.configMapRef or spec.kubeConfig.secretRef must be specified",
+              "rule": "has(self.configMapRef) || has(self.secretRef)"
+            },
+            {
+              "message": "exactly one of spec.kubeConfig.configMapRef or spec.kubeConfig.secretRef must be specified",
+              "rule": "!has(self.configMapRef) || !has(self.secretRef)"
+            }
+          ]
+        },
+        "maxHistory": {
+          "description": "MaxHistory is the number of revisions saved by Helm for this HelmRelease.\nUse '0' for an unlimited number of revisions; defaults to '5'.",
+          "type": "integer"
+        },
+        "persistentClient": {
+          "description": "PersistentClient tells the controller to use a persistent Kubernetes\nclient for this release. When enabled, the client will be reused for the\nduration of the reconciliation, instead of being created and destroyed\nfor each (step of a) Helm action.\n\nThis can improve performance, but may cause issues with some Helm charts\nthat for example do create Custom Resource Definitions during installation\noutside Helm's CRD lifecycle hooks, which are then not observed to be\navailable by e.g. post-install hooks.\n\nIf not set, it defaults to true.",
+          "type": "boolean"
+        },
+        "postRenderers": {
+          "description": "PostRenderers holds an array of Helm PostRenderers, which will be applied in order\nof their definition.",
+          "items": {
+            "additionalProperties": false,
+            "description": "PostRenderer contains a Helm PostRenderer specification.",
+            "properties": {
+              "kustomize": {
+                "additionalProperties": false,
+                "description": "Kustomization to apply as PostRenderer.",
+                "properties": {
+                  "images": {
+                    "description": "Images is a list of (image name, new name, new tag or digest)\nfor changing image names, tags or digests. This can also be achieved with a\npatch, but this operator is simpler to specify.",
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Image contains an image name, a new name, a new tag or digest, which will replace the original name and tag.",
+                      "properties": {
+                        "digest": {
+                          "description": "Digest is the value used to replace the original image tag.\nIf digest is present NewTag value is ignored.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is a tag-less image name.",
+                          "type": "string"
+                        },
+                        "newName": {
+                          "description": "NewName is the value used to replace the original name.",
+                          "type": "string"
+                        },
+                        "newTag": {
+                          "description": "NewTag is the value used to replace the original tag.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "patches": {
+                    "description": "Strategic merge and JSON patches, defined as inline YAML objects,\ncapable of targeting objects based on kind, label and annotation selectors.",
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should\nbe applied to.",
+                      "properties": {
+                        "patch": {
+                          "description": "Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with\nan array of operation objects.",
+                          "type": "string"
+                        },
+                        "target": {
+                          "additionalProperties": false,
+                          "description": "Target points to the resources that the patch document should be applied to.",
+                          "properties": {
+                            "annotationSelector": {
+                              "description": "AnnotationSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api\nIt matches with the resource annotations.",
+                              "type": "string"
+                            },
+                            "group": {
+                              "description": "Group is the API group to select resources from.\nTogether with Version and Kind it is capable of unambiguously identifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind of the API Group to select resources from.\nTogether with Group and Version it is capable of unambiguously\nidentifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                              "type": "string"
+                            },
+                            "labelSelector": {
+                              "description": "LabelSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api\nIt matches with the resource labels.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name to match resources with.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace to select resources from.",
+                              "type": "string"
+                            },
+                            "version": {
+                              "description": "Version of the API Group to select resources from.\nTogether with Group and Kind it is capable of unambiguously identifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "patch"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "releaseName": {
+          "description": "ReleaseName used for the Helm release. Defaults to a composition of\n'[TargetNamespace-]Name'.",
+          "maxLength": 53,
+          "minLength": 1,
+          "type": "string"
+        },
+        "rollback": {
+          "additionalProperties": false,
+          "description": "Rollback holds the configuration for Helm rollback actions for this HelmRelease.",
+          "properties": {
+            "cleanupOnFail": {
+              "description": "CleanupOnFail allows deletion of new resources created during the Helm\nrollback action when it fails.",
+              "type": "boolean"
+            },
+            "disableHooks": {
+              "description": "DisableHooks prevents hooks from running during the Helm rollback action.",
+              "type": "boolean"
+            },
+            "disableWait": {
+              "description": "DisableWait disables the waiting for resources to be ready after a Helm\nrollback has been performed.",
+              "type": "boolean"
+            },
+            "disableWaitForJobs": {
+              "description": "DisableWaitForJobs disables waiting for jobs to complete after a Helm\nrollback has been performed.",
+              "type": "boolean"
+            },
+            "force": {
+              "description": "Force forces resource updates through a replacement strategy.",
+              "type": "boolean"
+            },
+            "recreate": {
+              "description": "Recreate performs pod restarts for any managed workloads.\n\nDeprecated: This behavior was deprecated in Helm 3:\n  - Deprecation: https://github.com/helm/helm/pull/6463\n  - Removal: https://github.com/helm/helm/pull/31023\nAfter helm-controller was upgraded to the Helm 4 SDK,\nthis field is no longer functional and will print a\nwarning if set to true. It will also be removed in a\nfuture release.",
+              "type": "boolean"
+            },
+            "serverSideApply": {
+              "description": "ServerSideApply enables server-side apply for resources during rollback.\nCan be \"enabled\", \"disabled\", or \"auto\".\nWhen \"auto\", server-side apply usage will be based on the release's previous usage.\nDefaults to \"auto\".",
+              "enum": [
+                "enabled",
+                "disabled",
+                "auto"
+              ],
+              "type": "string"
+            },
+            "timeout": {
+              "description": "Timeout is the time to wait for any individual Kubernetes operation (like\nJobs for hooks) during the performance of a Helm rollback action. Defaults to\n'HelmReleaseSpec.Timeout'.",
+              "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "serviceAccountName": {
+          "description": "The name of the Kubernetes service account to impersonate\nwhen reconciling this HelmRelease.",
+          "maxLength": 253,
+          "minLength": 1,
+          "type": "string"
+        },
+        "storageNamespace": {
+          "description": "StorageNamespace used for the Helm storage.\nDefaults to the namespace of the HelmRelease.",
+          "maxLength": 63,
+          "minLength": 1,
+          "type": "string"
+        },
+        "suspend": {
+          "description": "Suspend tells the controller to suspend reconciliation for this HelmRelease,\nit does not apply to already started reconciliations. Defaults to false.",
+          "type": "boolean"
+        },
+        "targetNamespace": {
+          "description": "TargetNamespace to target when performing operations for the HelmRelease.\nDefaults to the namespace of the HelmRelease.",
+          "maxLength": 63,
+          "minLength": 1,
+          "type": "string"
+        },
+        "test": {
+          "additionalProperties": false,
+          "description": "Test holds the configuration for Helm test actions for this HelmRelease.",
+          "properties": {
+            "enable": {
+              "description": "Enable enables Helm test actions for this HelmRelease after an Helm install\nor upgrade action has been performed.",
+              "type": "boolean"
+            },
+            "filters": {
+              "description": "Filters is a list of tests to run or exclude from running.",
+              "items": {
+                "additionalProperties": false,
+                "description": "Filter holds the configuration for individual Helm test filters.",
+                "properties": {
+                  "exclude": {
+                    "description": "Exclude specifies whether the named test should be excluded.",
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "description": "Name is the name of the test.",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "ignoreFailures": {
+              "description": "IgnoreFailures tells the controller to skip remediation when the Helm tests\nare run but fail. Can be overwritten for tests run after install or upgrade\nactions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.",
+              "type": "boolean"
+            },
+            "timeout": {
+              "description": "Timeout is the time to wait for any individual Kubernetes operation during\nthe performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.",
+              "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "timeout": {
+          "description": "Timeout is the time to wait for any individual Kubernetes operation (like Jobs\nfor hooks) during the performance of a Helm action. Defaults to '5m0s'.",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+          "type": "string"
+        },
+        "uninstall": {
+          "additionalProperties": false,
+          "description": "Uninstall holds the configuration for Helm uninstall actions for this HelmRelease.",
+          "properties": {
+            "deletionPropagation": {
+              "default": "background",
+              "description": "DeletionPropagation specifies the deletion propagation policy when\na Helm uninstall is performed.",
+              "enum": [
+                "background",
+                "foreground",
+                "orphan"
+              ],
+              "type": "string"
+            },
+            "disableHooks": {
+              "description": "DisableHooks prevents hooks from running during the Helm rollback action.",
+              "type": "boolean"
+            },
+            "disableWait": {
+              "description": "DisableWait disables waiting for all the resources to be deleted after\na Helm uninstall is performed.",
+              "type": "boolean"
+            },
+            "keepHistory": {
+              "description": "KeepHistory tells Helm to remove all associated resources and mark the\nrelease as deleted, but retain the release history.",
+              "type": "boolean"
+            },
+            "timeout": {
+              "description": "Timeout is the time to wait for any individual Kubernetes operation (like\nJobs for hooks) during the performance of a Helm uninstall action. Defaults\nto 'HelmReleaseSpec.Timeout'.",
+              "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "upgrade": {
+          "additionalProperties": false,
+          "description": "Upgrade holds the configuration for Helm upgrade actions for this HelmRelease.",
+          "properties": {
+            "cleanupOnFail": {
+              "description": "CleanupOnFail allows deletion of new resources created during the Helm\nupgrade action when it fails.",
+              "type": "boolean"
+            },
+            "crds": {
+              "description": "CRDs upgrade CRDs from the Helm Chart's crds directory according\nto the CRD upgrade policy provided here. Valid values are `Skip`,\n`Create` or `CreateReplace`. Default is `Skip` and if omitted\nCRDs are neither installed nor upgraded.\n\nSkip: do neither install nor replace (update) any CRDs.\n\nCreate: new CRDs are created, existing CRDs are neither updated nor deleted.\n\nCreateReplace: new CRDs are created, existing CRDs are updated (replaced)\nbut not deleted.\n\nBy default, CRDs are not applied during Helm upgrade action. With this\noption users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.\nhttps://helm.sh/docs/chart_best_practices/custom_resource_definitions.",
+              "enum": [
+                "Skip",
+                "Create",
+                "CreateReplace"
+              ],
+              "type": "string"
+            },
+            "disableHooks": {
+              "description": "DisableHooks prevents hooks from running during the Helm upgrade action.",
+              "type": "boolean"
+            },
+            "disableOpenAPIValidation": {
+              "description": "DisableOpenAPIValidation prevents the Helm upgrade action from validating\nrendered templates against the Kubernetes OpenAPI Schema.",
+              "type": "boolean"
+            },
+            "disableSchemaValidation": {
+              "description": "DisableSchemaValidation prevents the Helm upgrade action from validating\nthe values against the JSON Schema.",
+              "type": "boolean"
+            },
+            "disableTakeOwnership": {
+              "description": "DisableTakeOwnership disables taking ownership of existing resources\nduring the Helm upgrade action. Defaults to false.",
+              "type": "boolean"
+            },
+            "disableWait": {
+              "description": "DisableWait disables the waiting for resources to be ready after a Helm\nupgrade has been performed.",
+              "type": "boolean"
+            },
+            "disableWaitForJobs": {
+              "description": "DisableWaitForJobs disables waiting for jobs to complete after a Helm\nupgrade has been performed.",
+              "type": "boolean"
+            },
+            "force": {
+              "description": "Force forces resource updates through a replacement strategy.",
+              "type": "boolean"
+            },
+            "preserveValues": {
+              "description": "PreserveValues will make Helm reuse the last release's values and merge in\noverrides from 'Values'. Setting this flag makes the HelmRelease\nnon-declarative.",
+              "type": "boolean"
+            },
+            "remediation": {
+              "additionalProperties": false,
+              "description": "Remediation holds the remediation configuration for when the Helm upgrade\naction for the HelmRelease fails. The default is to not perform any action.",
+              "properties": {
+                "ignoreTestFailures": {
+                  "description": "IgnoreTestFailures tells the controller to skip remediation when the Helm\ntests are run after an upgrade action but fail.\nDefaults to 'Test.IgnoreFailures'.",
+                  "type": "boolean"
+                },
+                "remediateLastFailure": {
+                  "description": "RemediateLastFailure tells the controller to remediate the last failure, when\nno retries remain. Defaults to 'false' unless 'Retries' is greater than 0.",
+                  "type": "boolean"
+                },
+                "retries": {
+                  "description": "Retries is the number of retries that should be attempted on failures before\nbailing. Remediation, using 'Strategy', is performed between each attempt.\nDefaults to '0', a negative integer equals to unlimited retries.",
+                  "type": "integer"
+                },
+                "strategy": {
+                  "description": "Strategy to use for failure remediation. Defaults to 'rollback'.",
+                  "enum": [
+                    "rollback",
+                    "uninstall"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "serverSideApply": {
+              "description": "ServerSideApply enables server-side apply for resources during upgrade.\nCan be \"enabled\", \"disabled\", or \"auto\".\nWhen \"auto\", server-side apply usage will be based on the release's previous usage.\nDefaults to \"auto\".",
+              "enum": [
+                "enabled",
+                "disabled",
+                "auto"
+              ],
+              "type": "string"
+            },
+            "strategy": {
+              "additionalProperties": false,
+              "description": "Strategy defines the upgrade strategy to use for this HelmRelease.\nDefaults to 'RemediateOnFailure', or 'RetryOnFailure' when the\nDefaultToRetryOnFailure feature gate is enabled.",
+              "properties": {
+                "name": {
+                  "description": "Name of the upgrade strategy.",
+                  "enum": [
+                    "RemediateOnFailure",
+                    "RetryOnFailure"
+                  ],
+                  "type": "string"
+                },
+                "retryInterval": {
+                  "description": "RetryInterval is the interval at which to retry a failed upgrade.\nCan be used only when Name is set to RetryOnFailure.\nDefaults to '5m'.",
+                  "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": ".retryInterval can only be set when .name is 'RetryOnFailure'",
+                  "rule": "!has(self.retryInterval) || self.name == 'RetryOnFailure'"
+                }
+              ]
+            },
+            "timeout": {
+              "description": "Timeout is the time to wait for any individual Kubernetes operation (like\nJobs for hooks) during the performance of a Helm upgrade action. Defaults to\n'HelmReleaseSpec.Timeout'.",
+              "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "values": {
+          "description": "Values holds the values for this Helm release.",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "valuesFrom": {
+          "description": "ValuesFrom holds references to resources containing Helm values for this HelmRelease,\nand information about how they should be merged.",
+          "items": {
+            "additionalProperties": false,
+            "description": "ValuesReference contains a reference to a resource containing Helm values,\nand optionally the key they can be found at.",
+            "properties": {
+              "kind": {
+                "description": "Kind of the values referent, valid values are ('Secret', 'ConfigMap').",
+                "enum": [
+                  "Secret",
+                  "ConfigMap"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the values referent. Should reside in the same namespace as the\nreferring resource.",
+                "maxLength": 253,
+                "minLength": 1,
+                "type": "string"
+              },
+              "optional": {
+                "description": "Optional marks this ValuesReference as optional. When set, a not found error\nfor the values reference is ignored, but any ValuesKey, TargetPath or\ntransient error will still result in a reconciliation failure.",
+                "type": "boolean"
+              },
+              "targetPath": {
+                "description": "TargetPath is the YAML dot notation path the value should be merged at. When\nset, the ValuesKey is expected to be a single flat value. Defaults to 'None',\nwhich results in the values getting merged at the root.",
+                "maxLength": 250,
+                "pattern": "^([a-zA-Z0-9_\\-.\\\\\\/]|\\[[0-9]{1,5}\\])+$",
+                "type": "string"
+              },
+              "valuesKey": {
+                "description": "ValuesKey is the data key where the values.yaml or a specific value can be\nfound at. Defaults to 'values.yaml'.",
+                "maxLength": 253,
+                "pattern": "^[\\-._a-zA-Z0-9]+$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "waitStrategy": {
+          "additionalProperties": false,
+          "description": "WaitStrategy defines Helm's wait strategy for waiting for applied\nresources to become ready.",
+          "properties": {
+            "name": {
+              "description": "Name is Helm's wait strategy for waiting for applied resources to\nbecome ready. One of 'poller' or 'legacy'. The 'poller' strategy uses\nkstatus to poll resource statuses, while the 'legacy' strategy uses\nHelm v3's waiting logic.\nDefaults to 'poller', or to 'legacy' when UseHelm3Defaults feature\ngate is enabled.",
+              "enum": [
+                "poller",
+                "legacy"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "interval"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "either chart or chartRef must be set",
+          "rule": "(has(self.chart) && !has(self.chartRef)) || (!has(self.chart) && has(self.chartRef))"
+        }
+      ]
+    },
+    "status": {
+      "additionalProperties": false,
+      "default": {
+        "observedGeneration": -1
+      },
+      "description": "HelmReleaseStatus defines the observed state of a HelmRelease.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions holds the conditions for the HelmRelease.",
+          "items": {
+            "additionalProperties": false,
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "failures": {
+          "description": "Failures is the reconciliation failure count against the latest desired\nstate. It is reset after a successful reconciliation.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "helmChart": {
+          "description": "HelmChart is the namespaced name of the HelmChart resource created by\nthe controller for the HelmRelease.",
+          "type": "string"
+        },
+        "history": {
+          "description": "History holds the history of Helm releases performed for this HelmRelease\nup to the last successfully completed release.",
+          "items": {
+            "additionalProperties": false,
+            "description": "Snapshot captures a point-in-time copy of the status information for a Helm release,\nas managed by the controller.",
+            "properties": {
+              "action": {
+                "description": "Action is the action that resulted in this snapshot being created.",
+                "type": "string"
+              },
+              "apiVersion": {
+                "description": "APIVersion is the API version of the Snapshot.\nWhen the calculation method of the Digest field is changed, this\nfield will be used to distinguish between the old and new methods.",
+                "type": "string"
+              },
+              "appVersion": {
+                "description": "AppVersion is the chart app version of the release object in storage.",
+                "type": "string"
+              },
+              "chartName": {
+                "description": "ChartName is the chart name of the release object in storage.",
+                "type": "string"
+              },
+              "chartVersion": {
+                "description": "ChartVersion is the chart version of the release object in\nstorage.",
+                "type": "string"
+              },
+              "configDigest": {
+                "description": "ConfigDigest is the checksum of the config (better known as\n\"values\") of the release object in storage.\nIt has the format of `<algo>:<checksum>`.",
+                "type": "string"
+              },
+              "deleted": {
+                "description": "Deleted is when the release was deleted.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "digest": {
+                "description": "Digest is the checksum of the release object in storage.\nIt has the format of `<algo>:<checksum>`.",
+                "type": "string"
+              },
+              "firstDeployed": {
+                "description": "FirstDeployed is when the release was first deployed.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastDeployed": {
+                "description": "LastDeployed is when the release was last deployed.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the release.",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace is the namespace the release is deployed to.",
+                "type": "string"
+              },
+              "ociDigest": {
+                "description": "OCIDigest is the digest of the OCI artifact associated with the release.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status is the current state of the release.",
+                "type": "string"
+              },
+              "testHooks": {
+                "additionalProperties": {
+                  "additionalProperties": false,
+                  "description": "TestHookStatus holds the status information for a test hook as observed\nto be run by the controller.",
+                  "properties": {
+                    "lastCompleted": {
+                      "description": "LastCompleted is the time the test hook last completed.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "lastStarted": {
+                      "description": "LastStarted is the time the test hook was last started.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "phase": {
+                      "description": "Phase the test hook was observed to be in.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": "TestHooks is the list of test hooks for the release as observed to be\nrun by the controller.",
+                "type": "object"
+              },
+              "version": {
+                "description": "Version is the version of the release object in storage.",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "chartName",
+              "chartVersion",
+              "configDigest",
+              "digest",
+              "firstDeployed",
+              "lastDeployed",
+              "name",
+              "namespace",
+              "status",
+              "version"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "installFailures": {
+          "description": "InstallFailures is the install failure count against the latest desired\nstate. It is reset after a successful reconciliation.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "inventory": {
+          "additionalProperties": false,
+          "description": "Inventory contains the list of Kubernetes resource object references\nthat have been applied for this release.",
+          "properties": {
+            "entries": {
+              "description": "Entries of Kubernetes resource object references.",
+              "items": {
+                "additionalProperties": false,
+                "description": "ResourceRef contains the information necessary to locate a resource within a cluster.",
+                "properties": {
+                  "id": {
+                    "description": "ID is the string representation of the Kubernetes resource object's metadata,\nin the format '<namespace>_<name>_<group>_<kind>'.",
+                    "type": "string"
+                  },
+                  "v": {
+                    "description": "Version is the API version of the Kubernetes resource object's kind.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "v"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "entries"
+          ],
+          "type": "object"
+        },
+        "lastAttemptedConfigDigest": {
+          "description": "LastAttemptedConfigDigest is the digest for the config (better known as\n\"values\") of the last reconciliation attempt.",
+          "type": "string"
+        },
+        "lastAttemptedGeneration": {
+          "description": "LastAttemptedGeneration is the last generation the controller attempted\nto reconcile.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "lastAttemptedReleaseAction": {
+          "description": "LastAttemptedReleaseAction is the last release action performed for this\nHelmRelease. It is used to determine the active retry or remediation\nstrategy.",
+          "enum": [
+            "install",
+            "upgrade"
+          ],
+          "type": "string"
+        },
+        "lastAttemptedReleaseActionDuration": {
+          "description": "LastAttemptedReleaseActionDuration is the duration of the last\nrelease action performed for this HelmRelease.",
+          "type": "string"
+        },
+        "lastAttemptedRevision": {
+          "description": "LastAttemptedRevision is the Source revision of the last reconciliation\nattempt. For OCIRepository  sources, the 12 first characters of the digest are\nappended to the chart version e.g. \"1.2.3+1234567890ab\".",
+          "type": "string"
+        },
+        "lastAttemptedRevisionDigest": {
+          "description": "LastAttemptedRevisionDigest is the digest of the last reconciliation attempt.\nThis is only set for OCIRepository sources.",
+          "type": "string"
+        },
+        "lastAttemptedValuesChecksum": {
+          "description": "LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last\nreconciliation attempt.\n\nDeprecated: Use LastAttemptedConfigDigest instead.",
+          "type": "string"
+        },
+        "lastHandledForceAt": {
+          "description": "LastHandledForceAt holds the value of the most recent\nforce request value, so a change of the annotation value\ncan be detected.",
+          "type": "string"
+        },
+        "lastHandledReconcileAt": {
+          "description": "LastHandledReconcileAt holds the value of the most recent\nreconcile request value, so a change of the annotation value\ncan be detected.",
+          "type": "string"
+        },
+        "lastHandledResetAt": {
+          "description": "LastHandledResetAt holds the value of the most recent reset request\nvalue, so a change of the annotation value can be detected.",
+          "type": "string"
+        },
+        "lastReleaseRevision": {
+          "description": "LastReleaseRevision is the revision of the last successful Helm release.\n\nDeprecated: Use History instead.",
+          "type": "integer"
+        },
+        "observedCommonMetadataDigest": {
+          "description": "ObservedCommonMetadataDigest is the digest for the common metadata of\nthe last successful reconciliation attempt.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the last observed generation.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "observedPostRenderersDigest": {
+          "description": "ObservedPostRenderersDigest is the digest for the post-renderers of\nthe last successful reconciliation attempt.",
+          "type": "string"
+        },
+        "storageNamespace": {
+          "description": "StorageNamespace is the namespace of the Helm release storage for the\ncurrent release.",
+          "maxLength": 63,
+          "minLength": 1,
+          "type": "string"
+        },
+        "upgradeFailures": {
+          "description": "UpgradeFailures is the upgrade failure count against the latest desired\nstate. It is reset after a successful reconciliation.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/cmd/flux-schema/testdata/extract/helmrelease-helm-v2.yaml
+++ b/cmd/flux-schema/testdata/extract/helmrelease-helm-v2.yaml
@@ -1,0 +1,1477 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+    kustomize.toolkit.fluxcd.io/prune: Disabled
+    kustomize.toolkit.fluxcd.io/ssa: Ignore
+  creationTimestamp: "2026-02-27T20:35:18Z"
+  generation: 2
+  labels:
+    app.kubernetes.io/component: helm-controller
+    app.kubernetes.io/instance: flux-system
+    app.kubernetes.io/managed-by: flux-operator
+    app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: v2.8.5
+    fluxcd.controlplane.io/name: flux
+    fluxcd.controlplane.io/namespace: flux-system
+  name: helmreleases.helm.toolkit.fluxcd.io
+  resourceVersion: "47985157"
+  uid: 71684e0d-602e-40e3-8880-3655fbb0bba2
+spec:
+  conversion:
+    strategy: None
+  group: helm.toolkit.fluxcd.io
+  names:
+    kind: HelmRelease
+    listKind: HelmReleaseList
+    plural: helmreleases
+    shortNames:
+    - hr
+    singular: helmrelease
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v2
+    schema:
+      openAPIV3Schema:
+        description: HelmRelease is the Schema for the helmreleases API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmReleaseSpec defines the desired state of a Helm release.
+            properties:
+              chart:
+                description: |-
+                  Chart defines the template of the v1.HelmChart that should be created
+                  for this HelmRelease.
+                properties:
+                  metadata:
+                    description: ObjectMeta holds the template for metadata like labels
+                      and annotations.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec holds the template for the v1.HelmChartSpec
+                      for this HelmRelease.
+                    properties:
+                      chart:
+                        description: The name or path the Helm chart is available
+                          at in the SourceRef.
+                        maxLength: 2048
+                        minLength: 1
+                        type: string
+                      ignoreMissingValuesFiles:
+                        description: IgnoreMissingValuesFiles controls whether to
+                          silently ignore missing values files rather than failing.
+                        type: boolean
+                      interval:
+                        description: |-
+                          Interval at which to check the v1.Source for updates. Defaults to
+                          'HelmReleaseSpec.Interval'.
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                      reconcileStrategy:
+                        default: ChartVersion
+                        description: |-
+                          Determines what enables the creation of a new artifact. Valid values are
+                          ('ChartVersion', 'Revision').
+                          See the documentation of the values for an explanation on their behavior.
+                          Defaults to ChartVersion when omitted.
+                        enum:
+                        - ChartVersion
+                        - Revision
+                        type: string
+                      sourceRef:
+                        description: The name and namespace of the v1.Source the chart
+                          is available at.
+                        properties:
+                          apiVersion:
+                            description: APIVersion of the referent.
+                            type: string
+                          kind:
+                            description: Kind of the referent.
+                            enum:
+                            - HelmRepository
+                            - GitRepository
+                            - Bucket
+                            type: string
+                          name:
+                            description: Name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: Namespace of the referent.
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      valuesFiles:
+                        description: |-
+                          Alternative list of values files to use as the chart values (values.yaml
+                          is not included by default), expected to be a relative path in the SourceRef.
+                          Values files are merged in the order of this list with the last file overriding
+                          the first. Ignored when omitted.
+                        items:
+                          type: string
+                        type: array
+                      verify:
+                        description: |-
+                          Verify contains the secret name containing the trusted public keys
+                          used to verify the signature and specifies which provider to use to check
+                          whether OCI image is authentic.
+                          This field is only supported for OCI sources.
+                          Chart dependencies, which are not bundled in the umbrella chart artifact,
+                          are not verified.
+                        properties:
+                          provider:
+                            default: cosign
+                            description: Provider specifies the technology used to
+                              sign the OCI Helm chart.
+                            enum:
+                            - cosign
+                            - notation
+                            type: string
+                          secretRef:
+                            description: |-
+                              SecretRef specifies the Kubernetes Secret containing the
+                              trusted public keys.
+                            properties:
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        required:
+                        - provider
+                        type: object
+                      version:
+                        default: '*'
+                        description: |-
+                          Version semver expression, ignored for charts from v1.GitRepository and
+                          v1beta2.Bucket sources. Defaults to latest when omitted.
+                        type: string
+                    required:
+                    - chart
+                    - sourceRef
+                    type: object
+                required:
+                - spec
+                type: object
+              chartRef:
+                description: |-
+                  ChartRef holds a reference to a source controller resource containing the
+                  Helm chart artifact.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    enum:
+                    - OCIRepository
+                    - HelmChart
+                    - ExternalArtifact
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent, defaults to the namespace of the Kubernetes
+                      resource object that contains the reference.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              commonMetadata:
+                description: |-
+                  CommonMetadata specifies the common labels and annotations that are
+                  applied to all resources. Any existing label or annotation will be
+                  overridden if its key matches a common one.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations to be added to the object's metadata.
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels to be added to the object's metadata.
+                    type: object
+                type: object
+              dependsOn:
+                description: |-
+                  DependsOn may contain a DependencyReference slice with
+                  references to HelmRelease resources that must be ready before this HelmRelease
+                  can be reconciled.
+                items:
+                  description: DependencyReference defines a HelmRelease dependency
+                    on another HelmRelease resource.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent, defaults to the namespace of the HelmRelease
+                        resource object that contains the reference.
+                      type: string
+                    readyExpr:
+                      description: |-
+                        ReadyExpr is a CEL expression that can be used to assess the readiness
+                        of a dependency. When specified, the built-in readiness check
+                        is replaced by the logic defined in the CEL expression.
+                        To make the CEL expression additive to the built-in readiness check,
+                        the feature gate `AdditiveCELDependencyCheck` must be set to `true`.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              driftDetection:
+                description: |-
+                  DriftDetection holds the configuration for detecting and handling
+                  differences between the manifest in the Helm storage and the resources
+                  currently existing in the cluster.
+                properties:
+                  ignore:
+                    description: |-
+                      Ignore contains a list of rules for specifying which changes to ignore
+                      during diffing.
+                    items:
+                      description: |-
+                        IgnoreRule defines a rule to selectively disregard specific changes during
+                        the drift detection process.
+                      properties:
+                        paths:
+                          description: |-
+                            Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from
+                            consideration in a Kubernetes object.
+                          items:
+                            type: string
+                          type: array
+                        target:
+                          description: |-
+                            Target is a selector for specifying Kubernetes objects to which this
+                            rule applies.
+                            If Target is not set, the Paths will be ignored for all Kubernetes
+                            objects within the manifest of the Helm release.
+                          properties:
+                            annotationSelector:
+                              description: |-
+                                AnnotationSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource annotations.
+                              type: string
+                            group:
+                              description: |-
+                                Group is the API group to select resources from.
+                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            kind:
+                              description: |-
+                                Kind of the API Group to select resources from.
+                                Together with Group and Version it is capable of unambiguously
+                                identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource labels.
+                              type: string
+                            name:
+                              description: Name to match resources with.
+                              type: string
+                            namespace:
+                              description: Namespace to select resources from.
+                              type: string
+                            version:
+                              description: |-
+                                Version of the API Group to select resources from.
+                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                          type: object
+                      required:
+                      - paths
+                      type: object
+                    type: array
+                  mode:
+                    description: |-
+                      Mode defines how differences should be handled between the Helm manifest
+                      and the manifest currently applied to the cluster.
+                      If not explicitly set, it defaults to DiffModeDisabled.
+                    enum:
+                    - enabled
+                    - warn
+                    - disabled
+                    type: string
+                type: object
+              healthCheckExprs:
+                description: |-
+                  HealthCheckExprs is a list of healthcheck expressions for evaluating the
+                  health of custom resources using Common Expression Language (CEL).
+                  The expressions are evaluated only when the specific Helm action
+                  taking place has wait enabled, i.e. DisableWait is false, and the
+                  'poller' WaitStrategy is used.
+                items:
+                  description: CustomHealthCheck defines the health check for custom
+                    resources.
+                  properties:
+                    apiVersion:
+                      description: APIVersion of the custom resource under evaluation.
+                      type: string
+                    current:
+                      description: |-
+                        Current is the CEL expression that determines if the status
+                        of the custom resource has reached the desired state.
+                      type: string
+                    failed:
+                      description: |-
+                        Failed is the CEL expression that determines if the status
+                        of the custom resource has failed to reach the desired state.
+                      type: string
+                    inProgress:
+                      description: |-
+                        InProgress is the CEL expression that determines if the status
+                        of the custom resource has not yet reached the desired state.
+                      type: string
+                    kind:
+                      description: Kind of the custom resource under evaluation.
+                      type: string
+                  required:
+                  - apiVersion
+                  - current
+                  - kind
+                  type: object
+                type: array
+              install:
+                description: Install holds the configuration for Helm install actions
+                  for this HelmRelease.
+                properties:
+                  crds:
+                    description: |-
+                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+                      `Create` or `CreateReplace`. Default is `Create` and if omitted
+                      CRDs are installed but not updated.
+
+                      Skip: do neither install nor replace (update) any CRDs.
+
+                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                      but not deleted.
+
+                      By default, CRDs are applied (installed) during Helm install action.
+                      With this option users can opt in to CRD replace existing CRDs on Helm
+                      install actions, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  createNamespace:
+                    description: |-
+                      CreateNamespace tells the Helm install action to create the
+                      HelmReleaseSpec.TargetNamespace if it does not exist yet.
+                      On uninstall, the namespace will not be garbage collected.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm install action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: |-
+                      DisableOpenAPIValidation prevents the Helm install action from validating
+                      rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableSchemaValidation:
+                    description: |-
+                      DisableSchemaValidation prevents the Helm install action from validating
+                      the values against the JSON Schema.
+                    type: boolean
+                  disableTakeOwnership:
+                    description: |-
+                      DisableTakeOwnership disables taking ownership of existing resources
+                      during the Helm install action. Defaults to false.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      install has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      install has been performed.
+                    type: boolean
+                  remediation:
+                    description: |-
+                      Remediation holds the remediation configuration for when the Helm install
+                      action for the HelmRelease fails. The default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: |-
+                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+                          tests are run after an install action but fail. Defaults to
+                          'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: |-
+                          RemediateLastFailure tells the controller to remediate the last failure, when
+                          no retries remain. Defaults to 'false'.
+                        type: boolean
+                      retries:
+                        description: |-
+                          Retries is the number of retries that should be attempted on failures before
+                          bailing. Remediation, using an uninstall, is performed between each attempt.
+                          Defaults to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                    type: object
+                  replace:
+                    description: |-
+                      Replace tells the Helm install action to re-use the 'ReleaseName', but only
+                      if that name is a deleted release which remains in the history.
+                    type: boolean
+                  serverSideApply:
+                    description: |-
+                      ServerSideApply enables server-side apply for resources during install.
+                      Defaults to true (or false when UseHelm3Defaults feature gate is enabled).
+                    type: boolean
+                  skipCRDs:
+                    description: |-
+                      SkipCRDs tells the Helm install action to not install any CRDs. By default,
+                      CRDs are installed if not already present.
+
+                      Deprecated use CRD policy (`crds`) attribute with value `Skip` instead.
+                    type: boolean
+                  strategy:
+                    description: |-
+                      Strategy defines the install strategy to use for this HelmRelease.
+                      Defaults to 'RemediateOnFailure', or 'RetryOnFailure' when the
+                      DefaultToRetryOnFailure feature gate is enabled.
+                    properties:
+                      name:
+                        description: Name of the install strategy.
+                        enum:
+                        - RemediateOnFailure
+                        - RetryOnFailure
+                        type: string
+                      retryInterval:
+                        description: |-
+                          RetryInterval is the interval at which to retry a failed install.
+                          Can be used only when Name is set to RetryOnFailure.
+                          Defaults to '5m'.
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                    required:
+                    - name
+                    type: object
+                    x-kubernetes-validations:
+                    - message: .retryInterval cannot be set when .name is 'RemediateOnFailure'
+                      rule: '!has(self.retryInterval) || self.name != ''RemediateOnFailure'''
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm install action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              interval:
+                description: Interval at which to reconcile the Helm release.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              kubeConfig:
+                description: |-
+                  KubeConfig for reconciling the HelmRelease on a remote cluster.
+                  When used in combination with HelmReleaseSpec.ServiceAccountName,
+                  forces the controller to act on behalf of that Service Account at the
+                  target cluster.
+                  If the --default-service-account flag is set, its value will be used as
+                  a controller level fallback for when HelmReleaseSpec.ServiceAccountName
+                  is empty.
+                properties:
+                  configMapRef:
+                    description: |-
+                      ConfigMapRef holds an optional name of a ConfigMap that contains
+                      the following keys:
+
+                      - `provider`: the provider to use. One of `aws`, `azure`, `gcp`, or
+                         `generic`. Required.
+                      - `cluster`: the fully qualified resource name of the Kubernetes
+                         cluster in the cloud provider API. Not used by the `generic`
+                         provider. Required when one of `address` or `ca.crt` is not set.
+                      - `address`: the address of the Kubernetes API server. Required
+                         for `generic`. For the other providers, if not specified, the
+                         first address in the cluster resource will be used, and if
+                         specified, it must match one of the addresses in the cluster
+                         resource.
+                         If audiences is not set, will be used as the audience for the
+                         `generic` provider.
+                      - `ca.crt`: the optional PEM-encoded CA certificate for the
+                         Kubernetes API server. If not set, the controller will use the
+                         CA certificate from the cluster resource.
+                      - `audiences`: the optional audiences as a list of
+                         line-break-separated strings for the Kubernetes ServiceAccount
+                         token. Defaults to the `address` for the `generic` provider, or
+                         to specific values for the other providers depending on the
+                         provider.
+                      -  `serviceAccountName`: the optional name of the Kubernetes
+                         ServiceAccount in the same namespace that should be used
+                         for authentication. If not specified, the controller
+                         ServiceAccount will be used.
+
+                      Mutually exclusive with SecretRef.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  secretRef:
+                    description: |-
+                      SecretRef holds an optional name of a secret that contains a key with
+                      the kubeconfig file as the value. If no key is set, the key will default
+                      to 'value'. Mutually exclusive with ConfigMapRef.
+                      It is recommended that the kubeconfig is self-contained, and the secret
+                      is regularly updated if credentials such as a cloud-access-token expire.
+                      Cloud specific `cmd-path` auth helpers will not function without adding
+                      binaries and credentials to the Pod that is responsible for reconciling
+                      Kubernetes resources. Supported only for the generic provider.
+                    properties:
+                      key:
+                        description: Key in the Secret, when not specified an implementation-specific
+                          default key is used.
+                        type: string
+                      name:
+                        description: Name of the Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+                x-kubernetes-validations:
+                - message: exactly one of spec.kubeConfig.configMapRef or spec.kubeConfig.secretRef
+                    must be specified
+                  rule: has(self.configMapRef) || has(self.secretRef)
+                - message: exactly one of spec.kubeConfig.configMapRef or spec.kubeConfig.secretRef
+                    must be specified
+                  rule: '!has(self.configMapRef) || !has(self.secretRef)'
+              maxHistory:
+                description: |-
+                  MaxHistory is the number of revisions saved by Helm for this HelmRelease.
+                  Use '0' for an unlimited number of revisions; defaults to '5'.
+                type: integer
+              persistentClient:
+                description: |-
+                  PersistentClient tells the controller to use a persistent Kubernetes
+                  client for this release. When enabled, the client will be reused for the
+                  duration of the reconciliation, instead of being created and destroyed
+                  for each (step of a) Helm action.
+
+                  This can improve performance, but may cause issues with some Helm charts
+                  that for example do create Custom Resource Definitions during installation
+                  outside Helm's CRD lifecycle hooks, which are then not observed to be
+                  available by e.g. post-install hooks.
+
+                  If not set, it defaults to true.
+                type: boolean
+              postRenderers:
+                description: |-
+                  PostRenderers holds an array of Helm PostRenderers, which will be applied in order
+                  of their definition.
+                items:
+                  description: PostRenderer contains a Helm PostRenderer specification.
+                  properties:
+                    kustomize:
+                      description: Kustomization to apply as PostRenderer.
+                      properties:
+                        images:
+                          description: |-
+                            Images is a list of (image name, new name, new tag or digest)
+                            for changing image names, tags or digests. This can also be achieved with a
+                            patch, but this operator is simpler to specify.
+                          items:
+                            description: Image contains an image name, a new name,
+                              a new tag or digest, which will replace the original
+                              name and tag.
+                            properties:
+                              digest:
+                                description: |-
+                                  Digest is the value used to replace the original image tag.
+                                  If digest is present NewTag value is ignored.
+                                type: string
+                              name:
+                                description: Name is a tag-less image name.
+                                type: string
+                              newName:
+                                description: NewName is the value used to replace
+                                  the original name.
+                                type: string
+                              newTag:
+                                description: NewTag is the value used to replace the
+                                  original tag.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        patches:
+                          description: |-
+                            Strategic merge and JSON patches, defined as inline YAML objects,
+                            capable of targeting objects based on kind, label and annotation selectors.
+                          items:
+                            description: |-
+                              Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+                              be applied to.
+                            properties:
+                              patch:
+                                description: |-
+                                  Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+                                  an array of operation objects.
+                                type: string
+                              target:
+                                description: Target points to the resources that the
+                                  patch document should be applied to.
+                                properties:
+                                  annotationSelector:
+                                    description: |-
+                                      AnnotationSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource annotations.
+                                    type: string
+                                  group:
+                                    description: |-
+                                      Group is the API group to select resources from.
+                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind of the API Group to select resources from.
+                                      Together with Group and Version it is capable of unambiguously
+                                      identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  labelSelector:
+                                    description: |-
+                                      LabelSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource labels.
+                                    type: string
+                                  name:
+                                    description: Name to match resources with.
+                                    type: string
+                                  namespace:
+                                    description: Namespace to select resources from.
+                                    type: string
+                                  version:
+                                    description: |-
+                                      Version of the API Group to select resources from.
+                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                type: object
+                            required:
+                            - patch
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                type: array
+              releaseName:
+                description: |-
+                  ReleaseName used for the Helm release. Defaults to a composition of
+                  '[TargetNamespace-]Name'.
+                maxLength: 53
+                minLength: 1
+                type: string
+              rollback:
+                description: Rollback holds the configuration for Helm rollback actions
+                  for this HelmRelease.
+                properties:
+                  cleanupOnFail:
+                    description: |-
+                      CleanupOnFail allows deletion of new resources created during the Helm
+                      rollback action when it fails.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      rollback has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      rollback has been performed.
+                    type: boolean
+                  force:
+                    description: Force forces resource updates through a replacement
+                      strategy.
+                    type: boolean
+                  recreate:
+                    description: |-
+                      Recreate performs pod restarts for any managed workloads.
+
+                      Deprecated: This behavior was deprecated in Helm 3:
+                        - Deprecation: https://github.com/helm/helm/pull/6463
+                        - Removal: https://github.com/helm/helm/pull/31023
+                      After helm-controller was upgraded to the Helm 4 SDK,
+                      this field is no longer functional and will print a
+                      warning if set to true. It will also be removed in a
+                      future release.
+                    type: boolean
+                  serverSideApply:
+                    description: |-
+                      ServerSideApply enables server-side apply for resources during rollback.
+                      Can be "enabled", "disabled", or "auto".
+                      When "auto", server-side apply usage will be based on the release's previous usage.
+                      Defaults to "auto".
+                    enum:
+                    - enabled
+                    - disabled
+                    - auto
+                    type: string
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm rollback action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              serviceAccountName:
+                description: |-
+                  The name of the Kubernetes service account to impersonate
+                  when reconciling this HelmRelease.
+                maxLength: 253
+                minLength: 1
+                type: string
+              storageNamespace:
+                description: |-
+                  StorageNamespace used for the Helm storage.
+                  Defaults to the namespace of the HelmRelease.
+                maxLength: 63
+                minLength: 1
+                type: string
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend reconciliation for this HelmRelease,
+                  it does not apply to already started reconciliations. Defaults to false.
+                type: boolean
+              targetNamespace:
+                description: |-
+                  TargetNamespace to target when performing operations for the HelmRelease.
+                  Defaults to the namespace of the HelmRelease.
+                maxLength: 63
+                minLength: 1
+                type: string
+              test:
+                description: Test holds the configuration for Helm test actions for
+                  this HelmRelease.
+                properties:
+                  enable:
+                    description: |-
+                      Enable enables Helm test actions for this HelmRelease after an Helm install
+                      or upgrade action has been performed.
+                    type: boolean
+                  filters:
+                    description: Filters is a list of tests to run or exclude from
+                      running.
+                    items:
+                      description: Filter holds the configuration for individual Helm
+                        test filters.
+                      properties:
+                        exclude:
+                          description: Exclude specifies whether the named test should
+                            be excluded.
+                          type: boolean
+                        name:
+                          description: Name is the name of the test.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  ignoreFailures:
+                    description: |-
+                      IgnoreFailures tells the controller to skip remediation when the Helm tests
+                      are run but fail. Can be overwritten for tests run after install or upgrade
+                      actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation during
+                      the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              timeout:
+                description: |-
+                  Timeout is the time to wait for any individual Kubernetes operation (like Jobs
+                  for hooks) during the performance of a Helm action. Defaults to '5m0s'.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              uninstall:
+                description: Uninstall holds the configuration for Helm uninstall
+                  actions for this HelmRelease.
+                properties:
+                  deletionPropagation:
+                    default: background
+                    description: |-
+                      DeletionPropagation specifies the deletion propagation policy when
+                      a Helm uninstall is performed.
+                    enum:
+                    - background
+                    - foreground
+                    - orphan
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables waiting for all the resources to be deleted after
+                      a Helm uninstall is performed.
+                    type: boolean
+                  keepHistory:
+                    description: |-
+                      KeepHistory tells Helm to remove all associated resources and mark the
+                      release as deleted, but retain the release history.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm uninstall action. Defaults
+                      to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              upgrade:
+                description: Upgrade holds the configuration for Helm upgrade actions
+                  for this HelmRelease.
+                properties:
+                  cleanupOnFail:
+                    description: |-
+                      CleanupOnFail allows deletion of new resources created during the Helm
+                      upgrade action when it fails.
+                    type: boolean
+                  crds:
+                    description: |-
+                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+                      `Create` or `CreateReplace`. Default is `Skip` and if omitted
+                      CRDs are neither installed nor upgraded.
+
+                      Skip: do neither install nor replace (update) any CRDs.
+
+                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                      but not deleted.
+
+                      By default, CRDs are not applied during Helm upgrade action. With this
+                      option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm upgrade action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: |-
+                      DisableOpenAPIValidation prevents the Helm upgrade action from validating
+                      rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableSchemaValidation:
+                    description: |-
+                      DisableSchemaValidation prevents the Helm upgrade action from validating
+                      the values against the JSON Schema.
+                    type: boolean
+                  disableTakeOwnership:
+                    description: |-
+                      DisableTakeOwnership disables taking ownership of existing resources
+                      during the Helm upgrade action. Defaults to false.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      upgrade has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      upgrade has been performed.
+                    type: boolean
+                  force:
+                    description: Force forces resource updates through a replacement
+                      strategy.
+                    type: boolean
+                  preserveValues:
+                    description: |-
+                      PreserveValues will make Helm reuse the last release's values and merge in
+                      overrides from 'Values'. Setting this flag makes the HelmRelease
+                      non-declarative.
+                    type: boolean
+                  remediation:
+                    description: |-
+                      Remediation holds the remediation configuration for when the Helm upgrade
+                      action for the HelmRelease fails. The default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: |-
+                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+                          tests are run after an upgrade action but fail.
+                          Defaults to 'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: |-
+                          RemediateLastFailure tells the controller to remediate the last failure, when
+                          no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
+                        type: boolean
+                      retries:
+                        description: |-
+                          Retries is the number of retries that should be attempted on failures before
+                          bailing. Remediation, using 'Strategy', is performed between each attempt.
+                          Defaults to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                      strategy:
+                        description: Strategy to use for failure remediation. Defaults
+                          to 'rollback'.
+                        enum:
+                        - rollback
+                        - uninstall
+                        type: string
+                    type: object
+                  serverSideApply:
+                    description: |-
+                      ServerSideApply enables server-side apply for resources during upgrade.
+                      Can be "enabled", "disabled", or "auto".
+                      When "auto", server-side apply usage will be based on the release's previous usage.
+                      Defaults to "auto".
+                    enum:
+                    - enabled
+                    - disabled
+                    - auto
+                    type: string
+                  strategy:
+                    description: |-
+                      Strategy defines the upgrade strategy to use for this HelmRelease.
+                      Defaults to 'RemediateOnFailure', or 'RetryOnFailure' when the
+                      DefaultToRetryOnFailure feature gate is enabled.
+                    properties:
+                      name:
+                        description: Name of the upgrade strategy.
+                        enum:
+                        - RemediateOnFailure
+                        - RetryOnFailure
+                        type: string
+                      retryInterval:
+                        description: |-
+                          RetryInterval is the interval at which to retry a failed upgrade.
+                          Can be used only when Name is set to RetryOnFailure.
+                          Defaults to '5m'.
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                    required:
+                    - name
+                    type: object
+                    x-kubernetes-validations:
+                    - message: .retryInterval can only be set when .name is 'RetryOnFailure'
+                      rule: '!has(self.retryInterval) || self.name == ''RetryOnFailure'''
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              values:
+                description: Values holds the values for this Helm release.
+                x-kubernetes-preserve-unknown-fields: true
+              valuesFrom:
+                description: |-
+                  ValuesFrom holds references to resources containing Helm values for this HelmRelease,
+                  and information about how they should be merged.
+                items:
+                  description: |-
+                    ValuesReference contains a reference to a resource containing Helm values,
+                    and optionally the key they can be found at.
+                  properties:
+                    kind:
+                      description: Kind of the values referent, valid values are ('Secret',
+                        'ConfigMap').
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: |-
+                        Name of the values referent. Should reside in the same namespace as the
+                        referring resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    optional:
+                      description: |-
+                        Optional marks this ValuesReference as optional. When set, a not found error
+                        for the values reference is ignored, but any ValuesKey, TargetPath or
+                        transient error will still result in a reconciliation failure.
+                      type: boolean
+                    targetPath:
+                      description: |-
+                        TargetPath is the YAML dot notation path the value should be merged at. When
+                        set, the ValuesKey is expected to be a single flat value. Defaults to 'None',
+                        which results in the values getting merged at the root.
+                      maxLength: 250
+                      pattern: ^([a-zA-Z0-9_\-.\\\/]|\[[0-9]{1,5}\])+$
+                      type: string
+                    valuesKey:
+                      description: |-
+                        ValuesKey is the data key where the values.yaml or a specific value can be
+                        found at. Defaults to 'values.yaml'.
+                      maxLength: 253
+                      pattern: ^[\-._a-zA-Z0-9]+$
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              waitStrategy:
+                description: |-
+                  WaitStrategy defines Helm's wait strategy for waiting for applied
+                  resources to become ready.
+                properties:
+                  name:
+                    description: |-
+                      Name is Helm's wait strategy for waiting for applied resources to
+                      become ready. One of 'poller' or 'legacy'. The 'poller' strategy uses
+                      kstatus to poll resource statuses, while the 'legacy' strategy uses
+                      Helm v3's waiting logic.
+                      Defaults to 'poller', or to 'legacy' when UseHelm3Defaults feature
+                      gate is enabled.
+                    enum:
+                    - poller
+                    - legacy
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - interval
+            type: object
+            x-kubernetes-validations:
+            - message: either chart or chartRef must be set
+              rule: (has(self.chart) && !has(self.chartRef)) || (!has(self.chart)
+                && has(self.chartRef))
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmReleaseStatus defines the observed state of a HelmRelease.
+            properties:
+              conditions:
+                description: Conditions holds the conditions for the HelmRelease.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failures:
+                description: |-
+                  Failures is the reconciliation failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              helmChart:
+                description: |-
+                  HelmChart is the namespaced name of the HelmChart resource created by
+                  the controller for the HelmRelease.
+                type: string
+              history:
+                description: |-
+                  History holds the history of Helm releases performed for this HelmRelease
+                  up to the last successfully completed release.
+                items:
+                  description: |-
+                    Snapshot captures a point-in-time copy of the status information for a Helm release,
+                    as managed by the controller.
+                  properties:
+                    action:
+                      description: Action is the action that resulted in this snapshot
+                        being created.
+                      type: string
+                    apiVersion:
+                      description: |-
+                        APIVersion is the API version of the Snapshot.
+                        When the calculation method of the Digest field is changed, this
+                        field will be used to distinguish between the old and new methods.
+                      type: string
+                    appVersion:
+                      description: AppVersion is the chart app version of the release
+                        object in storage.
+                      type: string
+                    chartName:
+                      description: ChartName is the chart name of the release object
+                        in storage.
+                      type: string
+                    chartVersion:
+                      description: |-
+                        ChartVersion is the chart version of the release object in
+                        storage.
+                      type: string
+                    configDigest:
+                      description: |-
+                        ConfigDigest is the checksum of the config (better known as
+                        "values") of the release object in storage.
+                        It has the format of `<algo>:<checksum>`.
+                      type: string
+                    deleted:
+                      description: Deleted is when the release was deleted.
+                      format: date-time
+                      type: string
+                    digest:
+                      description: |-
+                        Digest is the checksum of the release object in storage.
+                        It has the format of `<algo>:<checksum>`.
+                      type: string
+                    firstDeployed:
+                      description: FirstDeployed is when the release was first deployed.
+                      format: date-time
+                      type: string
+                    lastDeployed:
+                      description: LastDeployed is when the release was last deployed.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the release.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace the release is deployed
+                        to.
+                      type: string
+                    ociDigest:
+                      description: OCIDigest is the digest of the OCI artifact associated
+                        with the release.
+                      type: string
+                    status:
+                      description: Status is the current state of the release.
+                      type: string
+                    testHooks:
+                      additionalProperties:
+                        description: |-
+                          TestHookStatus holds the status information for a test hook as observed
+                          to be run by the controller.
+                        properties:
+                          lastCompleted:
+                            description: LastCompleted is the time the test hook last
+                              completed.
+                            format: date-time
+                            type: string
+                          lastStarted:
+                            description: LastStarted is the time the test hook was
+                              last started.
+                            format: date-time
+                            type: string
+                          phase:
+                            description: Phase the test hook was observed to be in.
+                            type: string
+                        type: object
+                      description: |-
+                        TestHooks is the list of test hooks for the release as observed to be
+                        run by the controller.
+                      type: object
+                    version:
+                      description: Version is the version of the release object in
+                        storage.
+                      type: integer
+                  required:
+                  - chartName
+                  - chartVersion
+                  - configDigest
+                  - digest
+                  - firstDeployed
+                  - lastDeployed
+                  - name
+                  - namespace
+                  - status
+                  - version
+                  type: object
+                type: array
+              installFailures:
+                description: |-
+                  InstallFailures is the install failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              inventory:
+                description: |-
+                  Inventory contains the list of Kubernetes resource object references
+                  that have been applied for this release.
+                properties:
+                  entries:
+                    description: Entries of Kubernetes resource object references.
+                    items:
+                      description: ResourceRef contains the information necessary
+                        to locate a resource within a cluster.
+                      properties:
+                        id:
+                          description: |-
+                            ID is the string representation of the Kubernetes resource object's metadata,
+                            in the format '<namespace>_<name>_<group>_<kind>'.
+                          type: string
+                        v:
+                          description: Version is the API version of the Kubernetes
+                            resource object's kind.
+                          type: string
+                      required:
+                      - id
+                      - v
+                      type: object
+                    type: array
+                required:
+                - entries
+                type: object
+              lastAttemptedConfigDigest:
+                description: |-
+                  LastAttemptedConfigDigest is the digest for the config (better known as
+                  "values") of the last reconciliation attempt.
+                type: string
+              lastAttemptedGeneration:
+                description: |-
+                  LastAttemptedGeneration is the last generation the controller attempted
+                  to reconcile.
+                format: int64
+                type: integer
+              lastAttemptedReleaseAction:
+                description: |-
+                  LastAttemptedReleaseAction is the last release action performed for this
+                  HelmRelease. It is used to determine the active retry or remediation
+                  strategy.
+                enum:
+                - install
+                - upgrade
+                type: string
+              lastAttemptedReleaseActionDuration:
+                description: |-
+                  LastAttemptedReleaseActionDuration is the duration of the last
+                  release action performed for this HelmRelease.
+                type: string
+              lastAttemptedRevision:
+                description: |-
+                  LastAttemptedRevision is the Source revision of the last reconciliation
+                  attempt. For OCIRepository  sources, the 12 first characters of the digest are
+                  appended to the chart version e.g. "1.2.3+1234567890ab".
+                type: string
+              lastAttemptedRevisionDigest:
+                description: |-
+                  LastAttemptedRevisionDigest is the digest of the last reconciliation attempt.
+                  This is only set for OCIRepository sources.
+                type: string
+              lastAttemptedValuesChecksum:
+                description: |-
+                  LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last
+                  reconciliation attempt.
+
+                  Deprecated: Use LastAttemptedConfigDigest instead.
+                type: string
+              lastHandledForceAt:
+                description: |-
+                  LastHandledForceAt holds the value of the most recent
+                  force request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              lastHandledResetAt:
+                description: |-
+                  LastHandledResetAt holds the value of the most recent reset request
+                  value, so a change of the annotation value can be detected.
+                type: string
+              lastReleaseRevision:
+                description: |-
+                  LastReleaseRevision is the revision of the last successful Helm release.
+
+                  Deprecated: Use History instead.
+                type: integer
+              observedCommonMetadataDigest:
+                description: |-
+                  ObservedCommonMetadataDigest is the digest for the common metadata of
+                  the last successful reconciliation attempt.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              observedPostRenderersDigest:
+                description: |-
+                  ObservedPostRenderersDigest is the digest for the post-renderers of
+                  the last successful reconciliation attempt.
+                type: string
+              storageNamespace:
+                description: |-
+                  StorageNamespace is the namespace of the Helm release storage for the
+                  current release.
+                maxLength: 63
+                minLength: 1
+                type: string
+              upgradeFailures:
+                description: |-
+                  UpgradeFailures is the upgrade failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: HelmRelease
+    listKind: HelmReleaseList
+    plural: helmreleases
+    shortNames:
+    - hr
+    singular: helmrelease
+  conditions:
+  - lastTransitionTime: "2026-02-27T20:35:18Z"
+    message: no conflicts found
+    reason: NoConflicts
+    status: "True"
+    type: NamesAccepted
+  - lastTransitionTime: "2026-02-27T20:35:18Z"
+    message: the initial names have been accepted
+    reason: InitialNamesAccepted
+    status: "True"
+    type: Established
+  storedVersions:
+  - v2

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,14 @@ go 1.26.2
 require (
 	github.com/onsi/gomega v1.39.1
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
+	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
+go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
@@ -37,3 +39,5 @@ golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=
 golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
+sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -1,0 +1,149 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package extractor converts Kubernetes CustomResourceDefinition YAML into
+// per-version JSON Schema documents. It accepts bare CRDs, List-wrapped CRDs,
+// and multi-document YAML (e.g. the output of `kubectl get crds -o yaml`).
+package extractor
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+// CRD is a single CRD version with its transformed openAPIV3Schema.
+// Schema is owned by the CRD instance; the transforms mutate it in place,
+// so callers should treat it as single-use.
+type CRD struct {
+	Group   string
+	Kind    string
+	Version string
+	Schema  map[string]any
+}
+
+// Extract reads a YAML payload and returns one CRD per CRD version found.
+// Errors are aggregated: a failure on one document or version does not stop
+// extraction of the rest.
+func Extract(data []byte) ([]CRD, []error) {
+	var out []CRD
+	var errs []error
+	docIndex := 0
+	for _, raw := range splitYAMLDocs(data) {
+		raw = bytes.TrimSpace(raw)
+		if len(raw) == 0 {
+			continue
+		}
+		docIndex++
+		docs, err := parseDocument(raw)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("document %d: %w", docIndex, err))
+			continue
+		}
+		for _, crd := range docs {
+			crds, cerrs := versionsFromCRD(crd)
+			out = append(out, crds...)
+			for _, cerr := range cerrs {
+				errs = append(errs, fmt.Errorf("document %d: %w", docIndex, cerr))
+			}
+		}
+	}
+	return out, errs
+}
+
+// splitYAMLDocs splits a YAML payload on "\n---" separators,
+// also recognizing a leading "---" at the start of the buffer.
+func splitYAMLDocs(data []byte) [][]byte {
+	data = bytes.TrimPrefix(data, []byte("---\n"))
+	return bytes.Split(data, []byte("\n---"))
+}
+
+// parseDocument decodes a single YAML document and returns the CRDs it contains.
+// A top-level document that is not a mapping is an error.
+func parseDocument(raw []byte) ([]map[string]any, error) {
+	jsonBytes, err := yaml.YAMLToJSON(raw)
+	if err != nil {
+		return nil, fmt.Errorf("YAML parse error: %w", err)
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(jsonBytes))
+	dec.UseNumber()
+
+	var doc any
+	if err := dec.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("JSON decode error: %w", err)
+	}
+
+	m, ok := doc.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("document is not a YAML mapping")
+	}
+
+	return extractCRDs(m), nil
+}
+
+// extractCRDs walks a parsed document and returns every CustomResourceDefinition
+// found, descending into List-style containers via the "items" field.
+func extractCRDs(m map[string]any) []map[string]any {
+	var out []map[string]any
+	if kind, _ := m["kind"].(string); kind == "CustomResourceDefinition" {
+		out = append(out, m)
+	}
+	if items, ok := m["items"].([]any); ok {
+		for _, it := range items {
+			if child, ok := it.(map[string]any); ok {
+				out = append(out, extractCRDs(child)...)
+			}
+		}
+	}
+	return out
+}
+
+// versionsFromCRD extracts each version's openAPIV3Schema and applies the
+// OpenAPI→JSON Schema transformations.
+func versionsFromCRD(crd map[string]any) ([]CRD, []error) {
+	spec, ok := crd["spec"].(map[string]any)
+	if !ok {
+		return nil, []error{fmt.Errorf("CRD missing 'spec'")}
+	}
+	names, _ := spec["names"].(map[string]any)
+	kind, _ := names["kind"].(string)
+	group, _ := spec["group"].(string)
+	if kind == "" || group == "" {
+		return nil, []error{fmt.Errorf("CRD missing spec.names.kind or spec.group")}
+	}
+
+	versions, ok := spec["versions"].([]any)
+	if !ok || len(versions) == 0 {
+		return nil, []error{fmt.Errorf("CRD %s has no spec.versions", kind)}
+	}
+
+	var out []CRD
+	var errs []error
+	for i, v := range versions {
+		vm, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		versionName, _ := vm["name"].(string)
+		schemaHolder, _ := vm["schema"].(map[string]any)
+		schema, _ := schemaHolder["openAPIV3Schema"].(map[string]any)
+		if schema == nil {
+			errs = append(errs, fmt.Errorf("version[%d] %q has no schema.openAPIV3Schema", i, versionName))
+			continue
+		}
+
+		addAdditionalPropertiesFalse(schema, true)
+		transformed, _ := replaceIntOrString(schema).(map[string]any)
+
+		out = append(out, CRD{
+			Group:   group,
+			Kind:    kind,
+			Version: versionName,
+			Schema:  transformed,
+		})
+	}
+	return out, errs
+}

--- a/internal/extractor/extractor_test.go
+++ b/internal/extractor/extractor_test.go
@@ -1,0 +1,259 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package extractor
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+const bareCRD = `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  names:
+    kind: Widget
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string
+`
+
+const listCRDs = `
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: widgets.example.com
+    spec:
+      group: example.com
+      names:
+        kind: Widget
+      versions:
+        - name: v1
+          schema:
+            openAPIV3Schema:
+              type: object
+              properties:
+                spec:
+                  type: object
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: gadgets.example.com
+    spec:
+      group: example.com
+      names:
+        kind: Gadget
+      versions:
+        - name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              type: object
+`
+
+const multiDoc = `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  names:
+    kind: Widget
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: gadgets.example.com
+spec:
+  group: example.com
+  names:
+    kind: Gadget
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+
+const leadingSeparator = `---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  names:
+    kind: Widget
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+
+const missingSchemaOnOneVersion = `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  names:
+    kind: Widget
+  versions:
+    - name: v1alpha1
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+
+func TestExtract_BareCRD(t *testing.T) {
+	g := NewWithT(t)
+	crds, errs := Extract([]byte(bareCRD))
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(crds).To(HaveLen(1))
+	g.Expect(crds[0].Group).To(Equal("example.com"))
+	g.Expect(crds[0].Kind).To(Equal("Widget"))
+	g.Expect(crds[0].Version).To(Equal("v1"))
+	g.Expect(crds[0].Schema).To(HaveKey("properties"))
+}
+
+func TestExtract_List(t *testing.T) {
+	g := NewWithT(t)
+	crds, errs := Extract([]byte(listCRDs))
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(crds).To(HaveLen(2))
+	g.Expect(crds[0].Kind).To(Equal("Widget"))
+	g.Expect(crds[1].Kind).To(Equal("Gadget"))
+	g.Expect(crds[1].Version).To(Equal("v1alpha1"))
+}
+
+func TestExtract_MultiDocument(t *testing.T) {
+	g := NewWithT(t)
+	crds, errs := Extract([]byte(multiDoc))
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(crds).To(HaveLen(2))
+	g.Expect(crds[0].Kind).To(Equal("Widget"))
+	g.Expect(crds[1].Kind).To(Equal("Gadget"))
+}
+
+func TestExtract_LeadingSeparator(t *testing.T) {
+	g := NewWithT(t)
+	crds, errs := Extract([]byte(leadingSeparator))
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(crds).To(HaveLen(1))
+	g.Expect(crds[0].Kind).To(Equal("Widget"))
+}
+
+func TestExtract_MissingSchemaOnOneVersion(t *testing.T) {
+	g := NewWithT(t)
+	crds, errs := Extract([]byte(missingSchemaOnOneVersion))
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0].Error()).To(ContainSubstring(`"v1alpha1" has no schema.openAPIV3Schema`))
+	g.Expect(crds).To(HaveLen(1))
+	g.Expect(crds[0].Version).To(Equal("v1"))
+}
+
+func TestExtract_NonMappingDocumentIsError(t *testing.T) {
+	g := NewWithT(t)
+	_, errs := Extract([]byte("- just\n- a\n- list\n"))
+	g.Expect(errs).ToNot(BeEmpty())
+	g.Expect(errs[0].Error()).To(ContainSubstring("not a YAML mapping"))
+}
+
+func TestExtract_MissingSpec(t *testing.T) {
+	g := NewWithT(t)
+	_, errs := Extract([]byte("apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: x\n"))
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0].Error()).To(ContainSubstring("missing 'spec'"))
+}
+
+func TestAddAdditionalPropertiesFalse_SkipsRoot(t *testing.T) {
+	g := NewWithT(t)
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"spec": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+				},
+			},
+		},
+	}
+	addAdditionalPropertiesFalse(schema, true)
+
+	_, rootHasAP := schema["additionalProperties"]
+	g.Expect(rootHasAP).To(BeFalse(), "root should not have additionalProperties set")
+
+	spec := schema["properties"].(map[string]any)["spec"].(map[string]any)
+	g.Expect(spec["additionalProperties"]).To(BeFalse())
+}
+
+func TestAddAdditionalPropertiesFalse_SkipsPreserveUnknownFields(t *testing.T) {
+	g := NewWithT(t)
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"values": map[string]any{
+				"type":                                 "object",
+				"x-kubernetes-preserve-unknown-fields": true,
+				"properties": map[string]any{
+					"nested": map[string]any{"type": "string"},
+				},
+			},
+		},
+	}
+	addAdditionalPropertiesFalse(schema, true)
+
+	values := schema["properties"].(map[string]any)["values"].(map[string]any)
+	_, valuesHasAP := values["additionalProperties"]
+	g.Expect(valuesHasAP).To(BeFalse(), "preserve-unknown-fields subtree must stay open")
+}
+
+func TestReplaceIntOrString_LegacyFormat(t *testing.T) {
+	g := NewWithT(t)
+	input := map[string]any{
+		"properties": map[string]any{
+			"port": map[string]any{"format": "int-or-string"},
+		},
+	}
+	out := replaceIntOrString(input).(map[string]any)
+	port := out["properties"].(map[string]any)["port"].(map[string]any)
+	g.Expect(port).To(HaveKey("oneOf"))
+}
+
+func TestReplaceIntOrString_StructuralExtension(t *testing.T) {
+	g := NewWithT(t)
+	input := map[string]any{
+		"properties": map[string]any{
+			"port": map[string]any{"x-kubernetes-int-or-string": true},
+		},
+	}
+	out := replaceIntOrString(input).(map[string]any)
+	port := out["properties"].(map[string]any)["port"].(map[string]any)
+	g.Expect(port).To(HaveKey("oneOf"))
+	_, hasExt := port["x-kubernetes-int-or-string"]
+	g.Expect(hasExt).To(BeFalse(), "replacement should not retain the extension")
+}

--- a/internal/extractor/transform.go
+++ b/internal/extractor/transform.go
@@ -1,0 +1,75 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package extractor
+
+// addAdditionalPropertiesFalse recursively walks the schema and, for every
+// object that declares "properties" but not "additionalProperties", sets
+// "additionalProperties": false. Two nodes are left alone:
+//   - the root, when skipRoot is true;
+//   - any node carrying "x-kubernetes-preserve-unknown-fields": true, which
+//     marks a subtree where the API server accepts arbitrary keys (status
+//     subresources, free-form map fields like HelmRelease.spec.values).
+//     Forcing additionalProperties: false there rejects valid documents.
+func addAdditionalPropertiesFalse(node any, skipRoot bool) {
+	m, ok := node.(map[string]any)
+	if !ok {
+		if arr, ok := node.([]any); ok {
+			for _, v := range arr {
+				addAdditionalPropertiesFalse(v, false)
+			}
+		}
+		return
+	}
+	if preserve, _ := m["x-kubernetes-preserve-unknown-fields"].(bool); preserve {
+		return
+	}
+	if _, hasProps := m["properties"]; hasProps && !skipRoot {
+		if _, hasAP := m["additionalProperties"]; !hasAP {
+			m["additionalProperties"] = false
+		}
+	}
+	for _, v := range m {
+		addAdditionalPropertiesFalse(v, false)
+	}
+}
+
+// replaceIntOrString replaces any object that represents a Kubernetes
+// "int-or-string" value with {"oneOf": [{"type": "string"}, {"type": "integer"}]}.
+// Two representations are recognised:
+//   - legacy OpenAPI form: {"format": "int-or-string"};
+//   - structural schema form: {"x-kubernetes-int-or-string": true}.
+func replaceIntOrString(node any) any {
+	switch n := node.(type) {
+	case map[string]any:
+		if isIntOrString(n) {
+			return map[string]any{
+				"oneOf": []any{
+					map[string]any{"type": "string"},
+					map[string]any{"type": "integer"},
+				},
+			}
+		}
+		for k, v := range n {
+			n[k] = replaceIntOrString(v)
+		}
+		return n
+	case []any:
+		for i, v := range n {
+			n[i] = replaceIntOrString(v)
+		}
+		return n
+	default:
+		return n
+	}
+}
+
+func isIntOrString(m map[string]any) bool {
+	if f, ok := m["format"].(string); ok && f == "int-or-string" {
+		return true
+	}
+	if b, ok := m["x-kubernetes-int-or-string"].(bool); ok && b {
+		return true
+	}
+	return false
+}

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package tmpl renders Go text/template strings with the CRD schema
+// variables shared across flux-schema commands.
+package tmpl
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+// SchemaVars carries the variables exposed to output-path templates.
+// All fields are lowercased by Render before rendering, and GroupPrefix
+// is derived from Group when empty.
+type SchemaVars struct {
+	Group       string
+	GroupPrefix string
+	Kind        string
+	Version     string
+}
+
+// Render parses format as a Go text/template and renders it with vars.
+// Unknown template variables produce an error instead of an empty string
+// (missingkey=error). Inputs are lowercased and GroupPrefix is derived
+// from Group (first dot-delimited segment) when unset.
+func Render(format string, vars SchemaVars) (string, error) {
+	if strings.TrimSpace(format) == "" {
+		return "", fmt.Errorf("output format template is empty")
+	}
+
+	tpl, err := template.New("output").Option("missingkey=error").Parse(format)
+	if err != nil {
+		return "", fmt.Errorf("parse template: %w", err)
+	}
+
+	normalised := SchemaVars{
+		Group:       strings.ToLower(vars.Group),
+		GroupPrefix: strings.ToLower(vars.GroupPrefix),
+		Kind:        strings.ToLower(vars.Kind),
+		Version:     strings.ToLower(vars.Version),
+	}
+	if normalised.GroupPrefix == "" {
+		prefix, _, _ := strings.Cut(normalised.Group, ".")
+		normalised.GroupPrefix = prefix
+	}
+
+	var buf bytes.Buffer
+	if err := tpl.Execute(&buf, normalised); err != nil {
+		return "", fmt.Errorf("render template: %w", err)
+	}
+	return buf.String(), nil
+}

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tmpl
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestRender_FlatFormat(t *testing.T) {
+	g := NewWithT(t)
+	got, err := Render("{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json", SchemaVars{
+		Group:   "helm.toolkit.fluxcd.io",
+		Kind:    "HelmRelease",
+		Version: "v2",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(got).To(Equal("helmrelease-helm-v2.json"))
+}
+
+func TestRender_NestedFormatUsesForwardSlash(t *testing.T) {
+	g := NewWithT(t)
+	got, err := Render("{{ .Group }}/{{ .Kind }}_{{ .Version }}.json", SchemaVars{
+		Group:   "Source.Toolkit.FluxCD.io",
+		Kind:    "GitRepository",
+		Version: "V1",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(got).To(Equal("source.toolkit.fluxcd.io/gitrepository_v1.json"))
+}
+
+func TestRender_LowercasesAllVars(t *testing.T) {
+	g := NewWithT(t)
+	got, err := Render("{{ .Group }}|{{ .GroupPrefix }}|{{ .Kind }}|{{ .Version }}", SchemaVars{
+		Group:       "Example.COM",
+		GroupPrefix: "EXAMPLE",
+		Kind:        "Widget",
+		Version:     "V1BETA1",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(got).To(Equal("example.com|example|widget|v1beta1"))
+}
+
+func TestRender_DerivesGroupPrefix(t *testing.T) {
+	g := NewWithT(t)
+	got, err := Render("{{ .GroupPrefix }}", SchemaVars{Group: "source.toolkit.fluxcd.io"})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(got).To(Equal("source"))
+}
+
+func TestRender_UnknownVarErrors(t *testing.T) {
+	g := NewWithT(t)
+	_, err := Render("{{ .Foo }}", SchemaVars{Kind: "Widget"})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("render template"))
+}
+
+func TestRender_EmptyFormatErrors(t *testing.T) {
+	g := NewWithT(t)
+	_, err := Render("   ", SchemaVars{Kind: "Widget"})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("empty"))
+}
+
+func TestRender_InvalidTemplateErrors(t *testing.T) {
+	g := NewWithT(t)
+	_, err := Render("{{ .Kind", SchemaVars{Kind: "Widget"})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("parse template"))
+}


### PR DESCRIPTION

The extract command reads Kubernetes CustomResourceDefinition YAML and writes one JSON Schema file per CRD version.

Generate schemas for every CRD installed in a cluster:

```shell
kubectl get crds -o yaml > crds.yaml
flux-schema extract crds.yaml -d ./schemas
```

By default, files are named `{kind}-{group-prefix}-{version}.json`. The output is compatible with kubeconform and kubeval, making this command a drop-in Go replacement for kubeconform's [openapi2jsonschema.py](https://github.com/yannh/kubeconform/blob/master/scripts/openapi2jsonschema.py) script.

Note that the generated schemas apply the following OpenAPI → JSON Schema transformations:

- Objects with `properties` are closed with `additionalProperties: false`, except under nodes
  marked with `x-kubernetes-preserve-unknown-fields: true`, which stay open so free-form maps validate correctly.
- Integer-or-string fields are rewritten to `oneOf: [{type: string}, {type: integer}]`. Both the
  legacy `format: int-or-string` and the structural `x-kubernetes-int-or-string: true` forms are recognised.

You can supply `--output-format` with a Go template to change the layout, e.g. the [CRDs-catalog](https://github.com/datreeio/CRDs-catalog) per-group-directory layout:

```shell
flux-schema extract crds.yaml \
  --output-format '{{ .Group }}/{{ .Kind }}_{{ .Version }}.json'
```

Template variables (all lowercased at render time):

| Variable       | Example                    |
|----------------|----------------------------|
| `.Group`       | `source.toolkit.fluxcd.io` |
| `.GroupPrefix` | `source`                   |
| `.Kind`        | `gitrepository`            |
| `.Version`     | `v1`                       |

The input can be a bare CRD, a `List` of CRDs, or a multi-document YAML stream.
Nested directories referenced by `--output-format` are created automatically.

xref: https://github.com/yannh/kubeconform/issues/350