### PR TITLE
Add release workflow with SBOM and SLSA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+name: release
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  cli-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # for creating the GitHub release.
+      id-token: write # for creating OIDC tokens for signing.
+      attestations: write # for GitHub Attestations.
+      artifact-metadata: write # for GitHub SLSA provenance.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Setup Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      - name: Version info
+        id: ver
+        run: |
+          VERSION=${GITHUB_REF/refs\/tags\//}
+          echo "SEMVER=${VERSION#v}" >> $GITHUB_OUTPUT
+      - name: Create release
+        id: run-goreleaser
+        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
+        with:
+          version: latest
+          args: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Attest release assets
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-checksums: '${{ github.workspace }}/dist/${{ github.event.repository.name }}_${{ steps.ver.outputs.SEMVER }}_checksums.txt'

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,6 @@ go.work.sum
 # .vscode/
 
 # Temporary files and binaries
+dist/
 plans/
 bin/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,71 @@
+version: 2
+
+# xref: https://goreleaser.com/errors/multiple-tokens/
+force_token: github
+
+# xref: https://goreleaser.com/customization/hooks/
+before:
+  hooks:
+    - go mod download
+
+# xref: https://goreleaser.com/customization/env/
+env:
+  - CGO_ENABLED=0
+
+# xref: https://goreleaser.com/customization/build/
+builds:
+  - <<: &cmd_defaults
+      main: ./cmd/{{ .ProjectName }}
+      ldflags:
+        - -s -w -X main.VERSION={{ .Version }}
+    id: cli
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+  - <<: *cmd_defaults
+    id: cli-windows
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+# xref: https://goreleaser.com/customization/archive/
+archives:
+  - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    id: unix-cli
+    ids:
+      - cli
+    formats: ['tar.gz']
+    files:
+      - LICENSE
+  - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    id: windows-cli
+    ids:
+      - cli-windows
+    formats: ['zip']
+    files:
+      - LICENSE
+
+# xref: https://goreleaser.com/customization/checksum/
+checksum:
+  algorithm: sha256
+
+# xref: https://goreleaser.com/customization/source/
+source:
+  enabled: true
+  name_template: '{{ .ProjectName }}_{{ .Version }}_source_code'
+
+# xref: https://goreleaser.com/customization/sbom/
+sboms:
+  - id: source
+    artifacts: source
+    documents:
+      - "{{ .ProjectName }}_{{ .Version }}_sbom.spdx.json"
+
+# xref: https://goreleaser.com/customization/changelog/
+changelog:
+  use: github-native

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # flux-schema
 
+[![release](https://img.shields.io/github/release/fluxcd/flux-schema/all.svg)](https://github.com/fluxcd/flux-schema/releases)
 [![test](https://github.com/fluxcd/flux-schema/actions/workflows/test.yaml/badge.svg)](https://github.com/fluxcd/flux-schema/actions/workflows/test.yaml)
 [![license](https://img.shields.io/github/license/fluxcd/flux-schema.svg)](https://github.com/fluxcd/flux-schema/blob/main/LICENSE)
+[![slsa](https://slsa.dev/images/gh-badge-level2.svg)](https://github.com/fluxcd/flux-schema/attestations)
 
 Flux CLI plugin for Kubernetes schema extraction and manifests validation.
 


### PR DESCRIPTION
Add GitHub workflow that uses GoReleaser:

- triggers on semver tag (GitHub releases are set to immutable)
- builds amd64/arm64 binaries for macOS, Linux and Windows 
- generates SBOM for the Go dependencies
- creates SLSA attestation for the release assets
