### PR TITLE
Add default schema location to `validate` command

### DIFF
--- a/.github/workflows/update-catalog.yaml
+++ b/.github/workflows/update-catalog.yaml
@@ -14,6 +14,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Flux CLI plugin for Kubernetes schema extraction and manifests validation.
 
 ## Available Commands
 
+- `flux-schema validate [paths...]`: Validate Kubernetes manifests against JSON Schemas
+    - `--schema-location`: Template URL or file path for schemas (repeatable, tried in order); use `default` for the Flux catalog
+    - `--skip-missing-schemas`: Skip documents for which no schema can be found
+    - `-v, --verbose`: Print a line for every document, including valid and skipped
 - `flux-schema extract crd [files...]`: Extract JSON Schema from Kubernetes CRD YAMLs
   - `-d, --output-dir`: Directory to write JSON Schema files to (mutually exclusive with `--output-archive`)
   - `-a, --output-archive`: Path to write a gzipped tar archive of JSON Schema files to
@@ -22,14 +26,75 @@ Flux CLI plugin for Kubernetes schema extraction and manifests validation.
 - `flux-schema extract k8s [swagger-file]`: Extract JSON Schema from a Kubernetes OpenAPI v2 swagger document
   - `--version X.Y.Z`: Fetch the swagger from `kubernetes/kubernetes` for the given release tag (mutually exclusive with a swagger file)
   - `-d, --output-dir`, `-f, --output-format`: same as `extract crd`
-- `flux-schema validate [paths...]`: Validate Kubernetes manifests against JSON Schemas
-  - `--schema-location`: Template URL or file path for schemas (repeatable, tried in order)
-  - `--skip-missing-schemas`: Skip documents for which no schema can be found
-  - `-v, --verbose`: Print a line for every document, including valid and skipped
 
-### JSON Schema Extraction
+### Kubernetes Manifests Validation
 
-The `extract crd` command reads Kubernetes CustomResourceDefinition YAML and writes one JSON Schema file per CRD version.
+The validate command reads Kubernetes YAML manifests from one or more files or directories
+and validates each document against a JSON Schema resolved from its `apiVersion` and `kind`.
+
+When no `--schema-location` is given, validate uses the [flux-schema catalog](catalog/README.md),
+which covers the latest stable Kubernetes APIs and the Flux ecosystem CRDs (Flux toolkit
+controllers and the Flux Operator):
+
+```shell
+flux-schema validate ./manifests
+```
+
+To validate against your own schemas, pass `--schema-location` with a Go template:
+
+```shell
+flux-schema validate ./manifests \
+  --schema-location './schemas/{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json'
+```
+
+Template variables are `.Group`, `.GroupPrefix`, `.Kind`, and `.Version`.
+
+The flag is repeatable and locations are tried in order — the first match wins. Pass the
+literal value `default` to include the flux-schema catalog alongside your own schemas:
+
+```shell
+flux-schema validate ./manifests \
+  --schema-location default \
+  --schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.Kind}}_{{.Version}}.json' \
+  --schema-location './schemas/{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json'
+```
+
+Manifests can also be piped via `/dev/stdin`:
+
+```shell
+kustomize build . | flux-schema validate /dev/stdin
+```
+
+Output example with validation errors:
+
+```
+manifests/sources.yaml - Bucket/apps/s3-data is invalid: schema validation failed
+  - /spec: missing property 'bucketName'
+  - /spec/interval: got number, want string
+  - /spec/secretRef/name: got object, want string
+  - /spec: additional properties 'force' not allowed
+manifests/sources.yaml - OCIRepository/apps/podinfo is invalid: YAML parse failed
+  - line 18: key "app.kubernetes.io/name" already set in map
+manifests/sources.yaml - HelmChart/apps/redis is valid
+Summary: 3 resources found in 1 file - Valid: 1, Invalid: 2, Skipped: 0
+```
+
+A non-zero exit code is returned when any document is invalid or errored.
+
+Validation is strict by default:
+
+- YAML documents with duplicate keys are rejected.
+- Documents missing both `metadata.name` and `metadata.generateName` are flagged as invalid
+  matching Kubernetes API behavior.
+- Schemas produced by `flux-schema extract crd` close objects with `additionalProperties: false`,
+  so undocumented fields under `spec` fail validation.
+- String formats `duration`, `date`, `datetime`/`date-time`, and `time` are validated
+  matching Kubernetes API conventions.
+
+### Kubernetes CRD Extraction
+
+The `extract crd` command reads Kubernetes CustomResourceDefinition YAML
+and writes one JSON Schema file per CRD version.
 The input can be a bare CRD, a `List` of CRDs, or a multi-document YAML stream.
 
 Generate schemas for every CRD installed in a cluster, using the
@@ -113,58 +178,3 @@ The emitted schemas are the standalone-strict variant:
 - Optional fields are marked nullable (`type: [<t>, "null"]`), matching the
   Kubernetes API server's behavior of accepting `null` for unset optional values.
 - `apiVersion` and `kind` are injected into every kind's properties and required list.
-
-### Kubernetes Manifests Validation
-
-The validate command reads Kubernetes YAML manifests from one or more files or directories
-and validates each document against a JSON Schema resolved from its `apiVersion` and `kind`.
-Schemas are loaded from `--schema-location` templates, which are tried in order; the first
-match wins.
-
-```shell
-flux-schema validate ./manifests \
-  --schema-location './schemas/{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json'
-```
-
-Output example with validation errors:
-
-```
-manifests/sources.yaml - Bucket/apps/minio is invalid: schema validation failed
-  - /spec: missing property 'bucketName'
-  - /spec/interval: got number, want string
-  - /spec/secretRef/name: got object, want string
-  - /spec: additional properties 'force' not allowed
-manifests/sources.yaml - OCIRepository/apps/podinfo is invalid: YAML parse failed
-  - line 18: key "app.kubernetes.io/name" already set in map
-manifests/sources.yaml - HelmChart/apps/redis is valid
-Summary: 3 resources found in 1 file - Valid: 1, Invalid: 2, Skipped: 0
-```
-
-Validation is strict by default:
-
-- YAML documents with duplicate keys are rejected.
-- Documents missing both `metadata.name` and `metadata.generateName` are flagged as invalid
-  matching Kubernetes API behavior.
-- Schemas produced by `flux-schema extract crd` close objects with `additionalProperties: false`,
-  so undocumented fields under `spec` fail validation.
-- String formats `duration`, `date`, `datetime`/`date-time`, and `time` are validated
-  matching Kubernetes API conventions.
-
-Multiple schema locations are tried in order, so you can combine a remote CRD catalog with
-local overrides:
-
-```shell
-flux-schema validate k8s-*.yaml \
-  --skip-missing-schemas \
-  --schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.Kind}}_{{.Version}}.json' \
-  --schema-location './schemas/{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json'
-```
-
-Manifests can also be piped via `/dev/stdin`:
-
-```shell
-kustomize build . | flux-schema validate /dev/stdin \
-  --schema-location './schemas/{{.Group}}/{{.Kind}}_{{.Version}}.json'
-```
-
-A non-zero exit code is returned when any document is invalid or errored.

--- a/cmd/flux-schema/validate.go
+++ b/cmd/flux-schema/validate.go
@@ -95,11 +95,81 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 	files := make(map[string]struct{})
 	var nValid, nInvalid, nSkipped int
 
-	// Workers process documents concurrently, so results arrive out of order.
-	// Collect them all, then emit sorted by (Source, DocIndex) so CLI output
-	// is deterministic across runs.
-	var collected []validator.Result
+	// Reorder buffer: workers complete documents out of order, but we want
+	// deterministic (source, docIndex) output. For each source we track the
+	// next expected docIndex and a pending map; results for the source at
+	// sourceOrder[currentIdx] flush as soon as their docIndex matches
+	// nextIdx. The validator emits a Final sentinel once a source is fully
+	// drained, which lets currentIdx advance mid-stream — so all sources
+	// stream output in arrival order rather than only the first one.
+	type sourceBuf struct {
+		nextIdx int
+		pending map[int]validator.Result
+	}
+	bufs := map[string]*sourceBuf{}
+	var sourceOrder []string
+	completed := map[string]bool{}
+	currentIdx := 0
+
+	flushContiguous := func(src string) {
+		buf := bufs[src]
+		if buf == nil {
+			return
+		}
+		for {
+			r, ok := buf.pending[buf.nextIdx]
+			if !ok {
+				return
+			}
+			if shouldPrint(r.Status, validateArgs.verbose) {
+				writeResult(cmd, r)
+			}
+			delete(buf.pending, buf.nextIdx)
+			buf.nextIdx++
+		}
+	}
+
+	// flushRemaining drains pending entries past a gap (left by validateDoc
+	// skipping content-free YAML) in sorted docIndex order. Only safe to
+	// call once a source is known to be fully drained.
+	flushRemaining := func(src string) {
+		buf := bufs[src]
+		if buf == nil || len(buf.pending) == 0 {
+			return
+		}
+		indices := make([]int, 0, len(buf.pending))
+		for i := range buf.pending {
+			indices = append(indices, i)
+		}
+		sort.Ints(indices)
+		for _, i := range indices {
+			r := buf.pending[i]
+			if shouldPrint(r.Status, validateArgs.verbose) {
+				writeResult(cmd, r)
+			}
+		}
+		buf.pending = nil
+	}
+
+	tryAdvance := func() {
+		for currentIdx < len(sourceOrder) {
+			src := sourceOrder[currentIdx]
+			flushContiguous(src)
+			if !completed[src] {
+				return
+			}
+			flushRemaining(src)
+			currentIdx++
+		}
+	}
+
 	for r := range v.ValidateSources(ctx, args) {
+		if r.Final {
+			completed[r.Source] = true
+			tryAdvance()
+			continue
+		}
+
 		files[r.Source] = struct{}{}
 		switch r.Status {
 		case validator.StatusValid:
@@ -109,18 +179,24 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 		case validator.StatusSkipped:
 			nSkipped++
 		}
-		collected = append(collected, r)
+
+		if _, ok := bufs[r.Source]; !ok {
+			bufs[r.Source] = &sourceBuf{nextIdx: 1, pending: map[int]validator.Result{}}
+			sourceOrder = append(sourceOrder, r.Source)
+		}
+		bufs[r.Source].pending[r.DocIndex] = r
+		if currentIdx < len(sourceOrder) && sourceOrder[currentIdx] == r.Source {
+			flushContiguous(r.Source)
+		}
 	}
-	sort.SliceStable(collected, func(i, j int) bool {
-		if collected[i].Source != collected[j].Source {
-			return collected[i].Source < collected[j].Source
-		}
-		return collected[i].DocIndex < collected[j].DocIndex
-	})
-	for _, r := range collected {
-		if shouldPrint(r.Status, validateArgs.verbose) {
-			writeResult(cmd, r)
-		}
+
+	// Channel closed: every source we registered should have received a
+	// Final sentinel and tryAdvance should already have flushed and advanced
+	// past it. Defensive flush for any source missed (e.g. ctx cancellation
+	// dropped a sentinel mid-flight).
+	for _, src := range sourceOrder[currentIdx:] {
+		flushContiguous(src)
+		flushRemaining(src)
 	}
 
 	writeSummary(cmd, len(files), nValid+nInvalid+nSkipped, nValid, nInvalid, nSkipped, stdinOnly)

--- a/cmd/flux-schema/validate.go
+++ b/cmd/flux-schema/validate.go
@@ -5,7 +5,9 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -15,19 +17,25 @@ import (
 var validateCmd = &cobra.Command{
 	Use:   "validate [paths...]",
 	Short: "Validate Kubernetes manifests against JSON Schemas",
-	Example: `  # Validate every YAML file under ./manifests against local schemas
+	Example: `  # Validate YAMLs under ./manifests against the default catalog
+  # The default catalog covers the latest stable Kubernetes and Flux APIs
+  # https://github.com/fluxcd/flux-schema/tree/main/catalog
+  flux-schema validate ./manifests --verbose
+
+  # Validate against local schemas only
   flux-schema validate ./manifests \
     --schema-location './schemas/{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json' \
     --skip-missing-schemas
 
-  # Validate files matching glob pattern against a remote CRD catalog with a local fallback
-  flux-schema validate hr-*.yaml \
-    --schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.Kind}}_{{.Version}}.json' \
+  # Combine the default catalog with local CRD schemas (use 'default' as an alias)
+  flux-schema validate ./manifests \
+    --schema-location default \
     --schema-location './schemas/{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json'
 
   # Read manifests from a pipe
   kustomize build . | flux-schema validate /dev/stdin \
-    --schema-location './schemas/{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json'`,
+    --schema-location default \
+    --schema-location './schemas/{{.Group}}/{{.Kind}}_{{.Version}}.json'`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: validateCmdRun,
 }
@@ -38,25 +46,40 @@ type validateFlags struct {
 	verbose            bool
 }
 
+// defaultValidateSchemaLocation points at the flux-schema catalog,
+// covering the latest stable Kubernetes and Flux APIs.
+// It is used when no --schema-location is provided, and is what
+// the literal value "default" expands to in --schema-location.
+const defaultValidateSchemaLocation = "https://raw.githubusercontent.com/fluxcd/flux-schema/main/catalog/latest/{{.Group}}/{{.Kind}}_{{.Version}}.json"
+
 var validateArgs = validateFlags{}
 
 const stdinPath = "/dev/stdin"
 
 func init() {
 	validateCmd.Flags().StringArrayVar(&validateArgs.schemaLocations, "schema-location", nil,
-		"template URL or file path for schemas (repeatable, tried in order); "+
-			"variables: .Group, .GroupPrefix, .Kind, .Version")
+		"template URL or file path for schemas (repeatable); use 'default' for the built-in catalog")
 	validateCmd.Flags().BoolVar(&validateArgs.skipMissingSchemas, "skip-missing-schemas", false,
 		"skip documents for which no schema can be found instead of failing")
 	validateCmd.Flags().BoolVarP(&validateArgs.verbose, "verbose", "v", false,
 		"print a line for every document, including valid and skipped")
-	_ = validateCmd.MarkFlagRequired("schema-location")
 	rootCmd.AddCommand(validateCmd)
 }
 
 func validateCmdRun(cmd *cobra.Command, args []string) error {
+	locations := validateArgs.schemaLocations
+	if len(locations) == 0 {
+		locations = []string{defaultValidateSchemaLocation}
+	} else {
+		expanded, err := expandSchemaLocations(locations)
+		if err != nil {
+			return err
+		}
+		locations = expanded
+	}
+
 	v, err := validator.New(validator.Options{
-		SchemaLocations:    validateArgs.schemaLocations,
+		SchemaLocations:    locations,
 		SkipMissingSchemas: validateArgs.skipMissingSchemas,
 		HTTPTimeout:        rootArgs.timeout,
 	})
@@ -108,6 +131,25 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 	return nil
+}
+
+// expandSchemaLocations replaces every case-insensitive "default" with
+// defaultValidateSchemaLocation, preserving order so the user controls
+// fallback priority (e.g. --schema-location default --schema-location ./local
+// keeps the catalog first).
+func expandSchemaLocations(locations []string) ([]string, error) {
+	out := make([]string, len(locations))
+	for i, loc := range locations {
+		if loc == "" {
+			return nil, fmt.Errorf("--schema-location must not be empty")
+		}
+		if strings.EqualFold(loc, "default") {
+			out[i] = defaultValidateSchemaLocation
+		} else {
+			out[i] = loc
+		}
+	}
+	return out, nil
 }
 
 // shouldPrint returns true when this result should be written to stdout.

--- a/cmd/flux-schema/validate_test.go
+++ b/cmd/flux-schema/validate_test.go
@@ -286,9 +286,33 @@ func TestValidateCmd_InvalidMetadataFixtures(t *testing.T) {
 	g.Expect(out).To(ContainSubstring("Summary: 3 resources found in 1 file - Valid: 0, Invalid: 3, Skipped: 0"))
 }
 
-func TestValidateCmd_RequiresSchemaLocation(t *testing.T) {
+func TestExpandSchemaLocations(t *testing.T) {
 	g := NewWithT(t)
-	_, err := executeCommand([]string{"validate", t.TempDir()})
-	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring(`"schema-location" not set`))
+
+	expand := func(in []string) []string {
+		out, err := expandSchemaLocations(in)
+		g.Expect(err).ToNot(HaveOccurred())
+		return out
+	}
+
+	g.Expect(expand([]string{"default"})).
+		To(Equal([]string{defaultValidateSchemaLocation}))
+
+	g.Expect(expand([]string{"default", "./local/{{.Kind}}.json"})).
+		To(Equal([]string{defaultValidateSchemaLocation, "./local/{{.Kind}}.json"}))
+
+	g.Expect(expand([]string{"./local/{{.Kind}}.json", "default"})).
+		To(Equal([]string{"./local/{{.Kind}}.json", defaultValidateSchemaLocation}))
+
+	g.Expect(expand([]string{"./local/{{.Kind}}.json"})).
+		To(Equal([]string{"./local/{{.Kind}}.json"}))
+
+	g.Expect(expand([]string{"DEFAULT", "Default"})).
+		To(Equal([]string{defaultValidateSchemaLocation, defaultValidateSchemaLocation}))
+
+	_, err := expandSchemaLocations([]string{""})
+	g.Expect(err).To(MatchError(ContainSubstring("--schema-location must not be empty")))
+
+	_, err = expandSchemaLocations([]string{"default", ""})
+	g.Expect(err).To(MatchError(ContainSubstring("--schema-location must not be empty")))
 }

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -60,6 +60,12 @@ func (s Status) String() string {
 }
 
 // Result is the outcome of validating a single YAML document.
+//
+// When Final is true the result is a synthetic source-complete sentinel
+// emitted by ValidateSources after every document for Source has been
+// processed. Sentinels carry only Source; consumers should ignore them
+// for counting and printing and use them solely to advance per-source
+// streaming state.
 type Result struct {
 	Source     string
 	DocIndex   int
@@ -70,6 +76,7 @@ type Result struct {
 	Status     Status
 	Message    string
 	Errors     []ValidationError
+	Final      bool
 }
 
 // ValidationError is one per-field JSON Schema violation.
@@ -146,19 +153,35 @@ type job struct {
 	// pool reports one Result per failed source instead of silently
 	// dropping it.
 	loadErr error
+	// sourceWG counts in-flight jobs for source. Workers Done it when the
+	// job is processed; the per-source waiter goroutine waits on it then
+	// emits a Final sentinel so the consumer can advance its streaming
+	// pointer past this source.
+	sourceWG *sync.WaitGroup
 }
 
 // ValidateSources streams validation results for every document found in
 // paths. Files are walked sequentially by a single producer goroutine;
-// documents are validated by a pool of opts.Workers goroutines. The
-// returned channel is closed once all documents have been processed.
+// documents are validated by a pool of opts.Workers goroutines.
+//
+// After every document for a source has been validated and its Result
+// pushed to the channel, a synthetic Result with Final=true is emitted for
+// that source. Consumers can use these sentinels to advance per-source
+// streaming state (e.g. to start flushing source N+1 as soon as source N
+// is fully drained, instead of buffering until end-of-stream). Sentinels
+// always arrive after every real Result for the same source because the
+// waiter only fires once the per-source WaitGroup hits zero, which only
+// happens after every worker has both pushed its Result and called Done.
+//
+// The returned channel is closed once all documents have been processed
+// and all sentinels have been delivered.
 func (v *Validator) ValidateSources(ctx context.Context, paths []string) <-chan Result {
 	results := make(chan Result, v.opts.Workers*2)
 	jobs := make(chan job, v.opts.Workers*2)
 
-	var wg sync.WaitGroup
+	var workerWG sync.WaitGroup
 	for i := 0; i < v.opts.Workers; i++ {
-		wg.Go(func() {
+		workerWG.Go(func() {
 			for {
 				select {
 				case <-ctx.Done():
@@ -167,50 +190,73 @@ func (v *Validator) ValidateSources(ctx context.Context, paths []string) <-chan 
 					if !ok {
 						return
 					}
-					var r Result
-					if j.loadErr != nil {
-						r = Result{
-							Source:   j.source,
-							DocIndex: j.docIndex,
-							Status:   StatusInvalid,
-							Message:  j.loadErr.Error(),
-						}
-					} else {
-						result, emit := v.validateDoc(ctx, j.source, j.docIndex, j.raw)
-						if !emit {
-							continue
-						}
-						r = result
-					}
-					select {
-					case results <- r:
-					case <-ctx.Done():
-						return
-					}
+					v.runJob(ctx, j, results)
 				}
 			}
 		})
 	}
 
 	go func() {
-		defer close(jobs)
-		for _, path := range paths {
-			if err := v.produceFromPath(ctx, path, jobs); err != nil {
+		var waiterWG sync.WaitGroup
+		spawnWaiter := func(src string, wg *sync.WaitGroup) {
+			waiterWG.Go(func() {
+				wg.Wait()
 				select {
-				case jobs <- job{source: path, loadErr: err}:
+				case results <- Result{Source: src, Final: true}:
 				case <-ctx.Done():
-					return
+				}
+			})
+		}
+
+		for _, path := range paths {
+			if err := v.produceFromPath(ctx, path, jobs, spawnWaiter); err != nil {
+				wg := &sync.WaitGroup{}
+				wg.Add(1)
+				select {
+				case jobs <- job{source: path, loadErr: err, sourceWG: wg}:
+					spawnWaiter(path, wg)
+				case <-ctx.Done():
+					wg.Done()
 				}
 			}
+			if ctx.Err() != nil {
+				break
+			}
 		}
-	}()
 
-	go func() {
-		wg.Wait()
+		close(jobs)
+		workerWG.Wait()
+		waiterWG.Wait()
 		close(results)
 	}()
 
 	return results
+}
+
+// runJob processes one job and always Done's its sourceWG so the per-source
+// waiter can fire even when validation is short-circuited (content-free doc,
+// ctx cancellation).
+func (v *Validator) runJob(ctx context.Context, j job, results chan<- Result) {
+	defer j.sourceWG.Done()
+	var r Result
+	emit := true
+	if j.loadErr != nil {
+		r = Result{
+			Source:   j.source,
+			DocIndex: j.docIndex,
+			Status:   StatusInvalid,
+			Message:  j.loadErr.Error(),
+		}
+	} else {
+		r, emit = v.validateDoc(ctx, j.source, j.docIndex, j.raw)
+	}
+	if !emit {
+		return
+	}
+	select {
+	case results <- r:
+	case <-ctx.Done():
+	}
 }
 
 // ValidateBytes validates an in-memory YAML payload sequentially. Primarily
@@ -235,10 +281,14 @@ func (v *Validator) ValidateBytes(ctx context.Context, source string, data []byt
 }
 
 // produceFromPath opens path (or walks it, if a directory) and streams each
-// YAML document into jobs. Returns a source-level error only for paths that
-// cannot be stat'd or opened; per-document failures are reported via
-// validateDoc inside the worker pool.
-func (v *Validator) produceFromPath(ctx context.Context, path string, jobs chan<- job) error {
+// YAML document into jobs. spawnWaiter is invoked once per discovered file
+// with a per-file WaitGroup the worker pool decrements; the validator then
+// emits a Final sentinel once that file is fully drained.
+//
+// Returns a source-level error only for paths that cannot be stat'd or
+// opened; per-document failures are reported via validateDoc inside the
+// worker pool.
+func (v *Validator) produceFromPath(ctx context.Context, path string, jobs chan<- job, spawnWaiter func(string, *sync.WaitGroup)) error {
 	info, err := os.Stat(path)
 	if err != nil {
 		return err
@@ -258,13 +308,19 @@ func (v *Validator) produceFromPath(ctx context.Context, path string, jobs chan<
 			if ext != extYAML && ext != extYML {
 				return nil
 			}
-			return v.streamFile(ctx, p, jobs)
+			wg := &sync.WaitGroup{}
+			err := v.streamFile(ctx, p, jobs, wg)
+			spawnWaiter(p, wg)
+			return err
 		})
 	}
-	return v.streamFile(ctx, path, jobs)
+	wg := &sync.WaitGroup{}
+	err = v.streamFile(ctx, path, jobs, wg)
+	spawnWaiter(path, wg)
+	return err
 }
 
-func (v *Validator) streamFile(ctx context.Context, path string, jobs chan<- job) error {
+func (v *Validator) streamFile(ctx context.Context, path string, jobs chan<- job, sourceWG *sync.WaitGroup) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err
@@ -281,10 +337,12 @@ func (v *Validator) streamFile(ctx context.Context, path string, jobs chan<- job
 		idx++
 		buf := make([]byte, len(raw))
 		copy(buf, raw)
+		sourceWG.Add(1)
 		select {
 		case <-ctx.Done():
+			sourceWG.Done()
 			return ctx.Err()
-		case jobs <- job{source: path, docIndex: idx, raw: buf}:
+		case jobs <- job{source: path, docIndex: idx, raw: buf, sourceWG: sourceWG}:
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -4,6 +4,7 @@
 package validator
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -546,6 +547,9 @@ spec: {}
 	ch := v.ValidateSources(context.Background(), []string{path})
 	var count int
 	for r := range ch {
+		if r.Final {
+			continue
+		}
 		g.Expect(r.Status).To(Equal(StatusValid), "unexpected status for doc %d: %s %s", r.DocIndex, r.Status, r.Message)
 		count++
 	}
@@ -579,11 +583,64 @@ spec:
 	v := newLocalValidator(t, dir, false)
 	ch := v.ValidateSources(context.Background(), []string{manifestsDir})
 	var count int
+	finals := map[string]bool{}
 	for r := range ch {
+		if r.Final {
+			finals[r.Source] = true
+			continue
+		}
 		g.Expect(r.Status).To(Equal(StatusValid))
 		count++
 	}
 	g.Expect(count).To(Equal(2))
+	// One Final sentinel per discovered file.
+	g.Expect(finals).To(HaveLen(2))
+}
+
+// TestValidateSources_FinalSentinelOrdering pins the streaming protocol:
+// every real Result for a source arrives strictly before that source's
+// Final sentinel. Consumers rely on this to advance per-source streaming
+// state without buffering the entire stream.
+func TestValidateSources_FinalSentinelOrdering(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchema(t, dir)
+
+	manifestsDir := t.TempDir()
+	const docsPerFile = 20
+	for _, name := range []string{"a.yaml", "b.yaml", "c.yaml"} {
+		var buf bytes.Buffer
+		for i := range docsPerFile {
+			if i > 0 {
+				buf.WriteString("---\n")
+			}
+			fmt.Fprintf(&buf, "apiVersion: example.com/v1\nkind: Widget\nmetadata:\n  name: %s-%d\nspec:\n  name: ok\n", name, i)
+		}
+		g.Expect(os.WriteFile(filepath.Join(manifestsDir, name), buf.Bytes(), 0o644)).To(Succeed())
+	}
+
+	v := newLocalValidator(t, dir, false)
+	ch := v.ValidateSources(context.Background(), []string{manifestsDir})
+
+	seen := map[string]int{}
+	for r := range ch {
+		if r.Final {
+			// At sentinel arrival every real Result for r.Source must already
+			// have been delivered.
+			g.Expect(seen[r.Source]).To(Equal(docsPerFile),
+				"final sentinel for %s arrived before all docs", r.Source)
+			seen[r.Source] = -1 // mark as finalized
+			continue
+		}
+		g.Expect(seen[r.Source]).To(BeNumerically(">=", 0),
+			"real result for %s arrived after its final sentinel", r.Source)
+		seen[r.Source]++
+	}
+
+	g.Expect(seen).To(HaveLen(3))
+	for src, count := range seen {
+		g.Expect(count).To(Equal(-1), "no final sentinel for %s", src)
+	}
 }
 
 func TestSplitYAMLError(t *testing.T) {


### PR DESCRIPTION
Add support for `flux-schema validate ./manifests --schema-location default` which expands to `--schema-location https://raw.githubusercontent.com/fluxcd/flux-schema/main/catalog/latest/{{.Group}}/{{.Kind}}_{{.Version}}.json`.