### PR TITLE
Add option to strip description fields from schemas

### DIFF
--- a/.github/workflows/update-catalog.yaml
+++ b/.github/workflows/update-catalog.yaml
@@ -34,9 +34,11 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
           branch: update-catalog-latest
           title: "chore: update catalog/latest"
           commit-message: "chore: update catalog/latest"
+          committer: GitHub <noreply@github.com>
           author: fluxcdbot <fluxcdbot@users.noreply.github.com>
           signoff: true
           body: |

--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ Flux CLI plugin for Kubernetes schema extraction and manifests validation.
   - `-d, --output-dir`: Directory to write JSON Schema files to (mutually exclusive with `--output-archive`)
   - `-a, --output-archive`: Path to write a gzipped tar archive of JSON Schema files to
   - `-f, --output-format`: Go template for output file paths (default: `{{ .Group }}/{{ .Kind }}_{{ .Version }}.json`)
+  - `--strip-description`: Drop `description` fields from the generated schemas to reduce their size
 - `flux-schema extract k8s [swagger-file]`: Extract JSON Schema from a Kubernetes OpenAPI v2 swagger document
   - `--version X.Y.Z`: Fetch the swagger from `kubernetes/kubernetes` for the given release tag (mutually exclusive with a swagger file)
-  - `-d, --output-dir`, `-f, --output-format`: same as `extract crd`
+  - `-d, --output-dir`, `-f, --output-format`, `--strip-description`: same as `extract crd`
 
 ### Kubernetes Manifests Validation
 

--- a/cmd/flux-schema/extract_crd.go
+++ b/cmd/flux-schema/extract_crd.go
@@ -16,10 +16,9 @@ import (
 	"github.com/fluxcd/pkg/tar"
 
 	"github.com/fluxcd/flux-schema/internal/extractor"
+	"github.com/fluxcd/flux-schema/internal/flags"
 	"github.com/fluxcd/flux-schema/internal/tmpl"
 )
-
-const defaultExtractCRDFormat = "{{ .Group }}/{{ .Kind }}_{{ .Version }}.json"
 
 var extractCRDCmd = &cobra.Command{
 	Use:   "crd [files...]",
@@ -41,25 +40,18 @@ var extractCRDCmd = &cobra.Command{
 }
 
 type extractCRDFlags struct {
-	outputDir     string
-	outputFormat  string
+	flags.ExtractOutput
 	outputArchive string
 }
 
 var extractCRDArgs = extractCRDFlags{
-	outputDir:    ".",
-	outputFormat: defaultExtractCRDFormat,
+	ExtractOutput: flags.NewExtractOutput(),
 }
 
 func init() {
-	extractCRDCmd.Flags().StringVarP(&extractCRDArgs.outputDir, "output-dir", "d", extractCRDArgs.outputDir,
-		"directory where JSON Schema files are written (created if missing)")
-	extractCRDCmd.Flags().StringVarP(&extractCRDArgs.outputFormat, "output-format", "f", defaultExtractCRDFormat,
-		"Go template for the output file path, relative to --output-dir; "+
-			"variables: .Group, .GroupPrefix, .Kind, .Version")
+	extractCRDArgs.Register(extractCRDCmd)
 	extractCRDCmd.Flags().StringVarP(&extractCRDArgs.outputArchive, "output-archive", "a", "",
 		"path to a tar.gz file to write all schemas into; mutually exclusive with --output-dir")
-	_ = extractCRDCmd.MarkFlagDirname("output-dir")
 	_ = extractCRDCmd.MarkFlagFilename("output-archive", "tar.gz", "tgz")
 	extractCRDCmd.MarkFlagsMutuallyExclusive("output-dir", "output-archive")
 	extractCmd.AddCommand(extractCRDCmd)
@@ -67,7 +59,7 @@ func init() {
 
 func extractCRDCmdRun(cmd *cobra.Command, args []string) error {
 	archive := extractCRDArgs.outputArchive
-	destDir := extractCRDArgs.outputDir
+	destDir := extractCRDArgs.Dir
 	if archive != "" {
 		if !hasArchiveExt(archive) {
 			return fmt.Errorf("output archive %q must end in .tar.gz or .tgz", archive)
@@ -98,6 +90,11 @@ func extractCRDCmdRun(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		crds, errs := extractor.ExtractCRDs(data)
+		if extractCRDArgs.StripDescription {
+			for _, c := range crds {
+				extractor.StripDescriptions(c.JSON)
+			}
+		}
 		for _, e := range errs {
 			failures = append(failures, fmt.Errorf("%s: %w", path, e))
 		}
@@ -134,7 +131,7 @@ func extractCRDCmdRun(cmd *cobra.Command, args []string) error {
 }
 
 func writeCRDSchema(srcPath string, crd extractor.Schema, destDir string) (string, error) {
-	rendered, err := tmpl.Render(extractCRDArgs.outputFormat, tmpl.SchemaVars{
+	rendered, err := tmpl.Render(extractCRDArgs.Format, tmpl.SchemaVars{
 		Group:   crd.Group,
 		Kind:    crd.Kind,
 		Version: crd.Version,

--- a/cmd/flux-schema/extract_crd_test.go
+++ b/cmd/flux-schema/extract_crd_test.go
@@ -183,6 +183,47 @@ func TestExtractCRDCmd_HelmReleaseGolden(t *testing.T) {
 	g.Expect(string(got)).To(Equal(string(want)))
 }
 
+func TestExtractCRDCmd_StripDescription(t *testing.T) {
+	g := NewWithT(t)
+
+	fixture := `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  names:
+    kind: Widget
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: top-level
+          properties:
+            spec:
+              type: object
+              description: spec block
+              properties:
+                name:
+                  type: string
+                  description: widget name
+`
+	tmp := t.TempDir()
+	input := filepath.Join(tmp, "fixture.yaml")
+	if err := os.WriteFile(input, []byte(fixture), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	outDir := filepath.Join(tmp, "out")
+
+	_, err := executeCommand([]string{"extract", "crd", input, "--output-dir", outDir, "--strip-description"})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	data, err := os.ReadFile(filepath.Join(outDir, "example.com", "widget_v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(data)).ToNot(ContainSubstring(`"description"`))
+}
+
 func writeCRDFixture(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "fixture.yaml")

--- a/cmd/flux-schema/extract_k8s.go
+++ b/cmd/flux-schema/extract_k8s.go
@@ -18,13 +18,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/fluxcd/flux-schema/internal/extractor"
+	"github.com/fluxcd/flux-schema/internal/flags"
 	"github.com/fluxcd/flux-schema/internal/tmpl"
 )
 
-const (
-	defaultExtractK8sFormat = "{{ .Group }}/{{ .Kind }}_{{ .Version }}.json"
-	defaultK8sSwaggerURL    = "https://raw.githubusercontent.com/kubernetes/kubernetes/%s/api/openapi-spec/swagger.json"
-)
+const defaultK8sSwaggerURL = "https://raw.githubusercontent.com/kubernetes/kubernetes/%s/api/openapi-spec/swagger.json"
 
 var extractK8sCmd = &cobra.Command{
 	Use:   "k8s [swagger-file]",
@@ -43,25 +41,18 @@ var extractK8sCmd = &cobra.Command{
 }
 
 type extractK8sFlags struct {
-	outputDir    string
-	outputFormat string
-	k8sVersion   string
+	flags.ExtractOutput
+	k8sVersion string
 }
 
 var extractK8sArgs = extractK8sFlags{
-	outputDir:    ".",
-	outputFormat: defaultExtractK8sFormat,
+	ExtractOutput: flags.NewExtractOutput(),
 }
 
 func init() {
-	extractK8sCmd.Flags().StringVarP(&extractK8sArgs.outputDir, "output-dir", "d", extractK8sArgs.outputDir,
-		"directory where JSON Schema files are written (created if missing)")
-	extractK8sCmd.Flags().StringVarP(&extractK8sArgs.outputFormat, "output-format", "f", defaultExtractK8sFormat,
-		"Go template for the output file path, relative to --output-dir; "+
-			"variables: .Group, .GroupPrefix, .Kind, .Version")
+	extractK8sArgs.Register(extractK8sCmd)
 	extractK8sCmd.Flags().StringVar(&extractK8sArgs.k8sVersion, "version", "",
 		"Kubernetes release tag (e.g. 1.35.0) to fetch the upstream swagger from kubernetes/kubernetes")
-	_ = extractK8sCmd.MarkFlagDirname("output-dir")
 	extractCmd.AddCommand(extractK8sCmd)
 }
 
@@ -100,7 +91,7 @@ func extractK8sCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	destDir := extractK8sArgs.outputDir
+	destDir := extractK8sArgs.Dir
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		return fmt.Errorf("create output dir: %w", err)
 	}
@@ -108,6 +99,12 @@ func extractK8sCmdRun(cmd *cobra.Command, args []string) error {
 	cmd.Printf("reading %s\n", source)
 
 	schemas, errs := extractor.ExtractOpenAPI(data)
+
+	if extractK8sArgs.StripDescription {
+		for _, s := range schemas {
+			extractor.StripDescriptions(s.JSON)
+		}
+	}
 
 	var failures []error
 	for _, e := range errs {
@@ -137,7 +134,7 @@ func extractK8sCmdRun(cmd *cobra.Command, args []string) error {
 }
 
 func writeK8sSchema(schema extractor.Schema, destDir string) (string, error) {
-	rendered, err := tmpl.Render(extractK8sArgs.outputFormat, tmpl.SchemaVars{
+	rendered, err := tmpl.Render(extractK8sArgs.Format, tmpl.SchemaVars{
 		Group:   schema.Group,
 		Kind:    schema.Kind,
 		Version: schema.Version,

--- a/cmd/flux-schema/extract_k8s_test.go
+++ b/cmd/flux-schema/extract_k8s_test.go
@@ -58,9 +58,26 @@ func TestExtractK8sCmd_File(t *testing.T) {
 
 	data, err := os.ReadFile(filepath.Join(outDir, "example.com", "widget_v1.json"))
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(string(data)).To(ContainSubstring(`"$schema"`))
 	g.Expect(string(data)).To(ContainSubstring(`"apiVersion"`))
 	g.Expect(string(data)).To(ContainSubstring(`"kind"`))
+	g.Expect(string(data)).ToNot(ContainSubstring(`"$schema"`))
+	// Descriptions are preserved by default (the injectGVK step adds them to
+	// apiVersion/kind); stripping is opt-in via --strip-description.
+	g.Expect(string(data)).To(ContainSubstring(`"description"`))
+}
+
+func TestExtractK8sCmd_StripDescription(t *testing.T) {
+	g := NewWithT(t)
+
+	outDir := t.TempDir()
+	input := writeSwaggerFixture(t)
+
+	_, err := executeCommand([]string{"extract", "k8s", input, "--output-dir", outDir, "--strip-description"})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	data, err := os.ReadFile(filepath.Join(outDir, "example.com", "widget_v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(data)).ToNot(ContainSubstring(`"description"`))
 }
 
 func TestExtractK8sCmd_NoInput(t *testing.T) {

--- a/cmd/flux-schema/main_test.go
+++ b/cmd/flux-schema/main_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/fluxcd/flux-schema/internal/flags"
 )
 
 var (
@@ -45,8 +47,8 @@ func resetCmdArgs() {
 	rootArgs.timeout = timeout
 
 	versionArgs = versionFlags{output: "text"}
-	extractCRDArgs = extractCRDFlags{outputDir: ".", outputFormat: defaultExtractCRDFormat}
-	extractK8sArgs = extractK8sFlags{outputDir: ".", outputFormat: defaultExtractK8sFormat}
+	extractCRDArgs = extractCRDFlags{ExtractOutput: flags.NewExtractOutput()}
+	extractK8sArgs = extractK8sFlags{ExtractOutput: flags.NewExtractOutput()}
 	validateArgs = validateFlags{}
 
 	// pflag.Flag.Changed persists across Execute calls on the shared rootCmd,

--- a/internal/extractor/openapi.go
+++ b/internal/extractor/openapi.go
@@ -83,8 +83,6 @@ func ExtractOpenAPI(data []byte) ([]Schema, []error) {
 	return out, errs
 }
 
-const jsonSchemaURI = "http://json-schema.org/schema#"
-
 func readGVKs(def map[string]any) []GVK {
 	raw, ok := def["x-kubernetes-group-version-kind"].([]any)
 	if !ok {
@@ -142,11 +140,9 @@ func buildSchema(name string, def map[string]any, defs map[string]any) (map[stri
 	//    keys alongside apiVersion/kind/metadata/spec/... are rejected.
 	closeAdditionalProperties(inlined)
 
-	// 7. Strip remaining x-kubernetes-* extensions (keep preserve-unknown-fields).
+	// 7. Strip remaining x-kubernetes-* extensions (keep preserve-unknown-fields
+	//    and validations).
 	stripVendorExtensions(inlined)
-
-	// 8. Inject $schema so editors auto-detect.
-	inlined["$schema"] = jsonSchemaURI
 
 	return inlined, nil
 }

--- a/internal/extractor/openapi_test.go
+++ b/internal/extractor/openapi_test.go
@@ -120,7 +120,7 @@ func TestExtractOpenAPI_IntOrString(t *testing.T) {
 					"port": map[string]any{
 						"type":                       "string",
 						"format":                     "int-or-string",
-						"description":                "a port",
+						"default":                    "80",
 						"x-kubernetes-int-or-string": true,
 					},
 				},
@@ -138,7 +138,7 @@ func TestExtractOpenAPI_IntOrString(t *testing.T) {
 	props := out[0].JSON["properties"].(map[string]any)
 	port := props["port"].(map[string]any)
 	g.Expect(port).To(HaveKey("oneOf"))
-	g.Expect(port["description"]).To(Equal("a port"), "sibling description survives the rewrite")
+	g.Expect(port["default"]).To(Equal("80"), "metadata sibling survives the rewrite")
 	g.Expect(port).ToNot(HaveKey("type"))
 	g.Expect(port).ToNot(HaveKey("format"))
 	g.Expect(port).ToNot(HaveKey("x-kubernetes-int-or-string"))
@@ -434,11 +434,9 @@ func TestExtractOpenAPI_GVKInjection(t *testing.T) {
 	props := schema["properties"].(map[string]any)
 	apiVersion := props["apiVersion"].(map[string]any)
 	g.Expect(apiVersion["type"]).To(Equal("string"))
-	g.Expect(apiVersion["description"]).To(ContainSubstring("APIVersion"))
 
 	kind := props["kind"].(map[string]any)
 	g.Expect(kind["type"]).To(Equal("string"))
-	g.Expect(kind["description"]).To(ContainSubstring("Kind"))
 
 	required := schema["required"].([]any)
 	g.Expect(required).To(ContainElement("apiVersion"))
@@ -453,8 +451,8 @@ func TestExtractOpenAPI_GVKInjectionIdempotent(t *testing.T) {
 			"example.v1.Widget": map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"apiVersion": map[string]any{"type": "string", "description": "custom"},
-					"kind":       map[string]any{"type": "string", "description": "custom"},
+					"apiVersion": map[string]any{"type": "string", "default": "custom/v1"},
+					"kind":       map[string]any{"type": "string", "default": "Widget"},
 				},
 				"x-kubernetes-group-version-kind": []any{
 					map[string]any{"group": "example.com", "version": "v1", "kind": "Widget"},
@@ -467,9 +465,9 @@ func TestExtractOpenAPI_GVKInjectionIdempotent(t *testing.T) {
 
 	props := out[0].JSON["properties"].(map[string]any)
 	apiVersion := props["apiVersion"].(map[string]any)
-	g.Expect(apiVersion["description"]).To(Equal("custom"))
+	g.Expect(apiVersion["default"]).To(Equal("custom/v1"))
 	kind := props["kind"].(map[string]any)
-	g.Expect(kind["description"]).To(Equal("custom"))
+	g.Expect(kind["default"]).To(Equal("Widget"))
 }
 
 func TestExtractOpenAPI_NoMetadataForBinding(t *testing.T) {
@@ -495,20 +493,20 @@ func TestExtractOpenAPI_NoMetadataForBinding(t *testing.T) {
 	g.Expect(required).ToNot(ContainElement("metadata"))
 }
 
-func TestExtractOpenAPI_RefSiblingDescriptionWins(t *testing.T) {
+func TestExtractOpenAPI_RefSiblingMetadataWins(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
 			"example.v1.Helper": map[string]any{
-				"type":        "object",
-				"description": "shared description",
+				"type":    "object",
+				"default": "shared",
 			},
 			"example.v1.Widget": map[string]any{
 				"type": "object",
 				"properties": map[string]any{
 					"helper": map[string]any{
-						"$ref":        "#/definitions/example.v1.Helper",
-						"description": "contextual description",
+						"$ref":    "#/definitions/example.v1.Helper",
+						"default": "contextual",
 					},
 				},
 				"required": []any{"helper"},
@@ -522,7 +520,7 @@ func TestExtractOpenAPI_RefSiblingDescriptionWins(t *testing.T) {
 	g.Expect(errs).To(BeEmpty())
 
 	helper := out[0].JSON["properties"].(map[string]any)["helper"].(map[string]any)
-	g.Expect(helper["description"]).To(Equal("contextual description"))
+	g.Expect(helper["default"]).To(Equal("contextual"))
 }
 
 func TestExtractOpenAPI_RefSiblingTypeLoses(t *testing.T) {
@@ -619,6 +617,7 @@ func TestExtractOpenAPI_MissingRefIsError(t *testing.T) {
 	g.Expect(out).To(HaveLen(1))
 
 	broken := out[0].JSON["properties"].(map[string]any)["broken"].(map[string]any)
+	g.Expect(broken["type"]).To(Equal("object"))
 	g.Expect(broken["description"]).To(ContainSubstring("unresolved $ref"))
 }
 
@@ -636,7 +635,14 @@ func TestExtractOpenAPI_StripsVendorExtensions(t *testing.T) {
 						"x-kubernetes-patch-strategy":  "merge",
 						"x-kubernetes-patch-merge-key": "name",
 					},
+					"count": map[string]any{
+						"type": "integer",
+						"x-kubernetes-validations": []any{
+							map[string]any{"rule": "self >= 0", "message": "must be non-negative"},
+						},
+					},
 				},
+				"required": []any{"count"},
 				"x-kubernetes-group-version-kind": []any{
 					map[string]any{"group": "example.com", "version": "v1", "kind": "Widget"},
 				},
@@ -654,14 +660,26 @@ func TestExtractOpenAPI_StripsVendorExtensions(t *testing.T) {
 	g.Expect(list).ToNot(HaveKey("x-kubernetes-list-map-keys"))
 	g.Expect(list).ToNot(HaveKey("x-kubernetes-patch-strategy"))
 	g.Expect(list).ToNot(HaveKey("x-kubernetes-patch-merge-key"))
+
+	// CEL validations are retained so the API server's rules survive in the
+	// extracted schema.
+	count := out[0].JSON["properties"].(map[string]any)["count"].(map[string]any)
+	g.Expect(count).To(HaveKey("x-kubernetes-validations"))
 }
 
-func TestExtractOpenAPI_SchemaURIInjected(t *testing.T) {
+func TestExtractOpenAPI_PreservesDescriptions(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
 			"example.v1.Widget": map[string]any{
-				"type": "object",
+				"type":        "object",
+				"description": "top-level description",
+				"properties": map[string]any{
+					"name": map[string]any{
+						"type":        "string",
+						"description": "property description",
+					},
+				},
 				"x-kubernetes-group-version-kind": []any{
 					map[string]any{"group": "example.com", "version": "v1", "kind": "Widget"},
 				},
@@ -670,7 +688,11 @@ func TestExtractOpenAPI_SchemaURIInjected(t *testing.T) {
 	}
 	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
-	g.Expect(out[0].JSON["$schema"]).To(Equal("http://json-schema.org/schema#"))
+
+	// Extraction keeps descriptions; stripping is an opt-in post-process.
+	g.Expect(out[0].JSON["description"]).To(Equal("top-level description"))
+	name := out[0].JSON["properties"].(map[string]any)["name"].(map[string]any)
+	g.Expect(name["description"]).To(Equal("property description"))
 }
 
 func TestExtractOpenAPI_SortedOutput(t *testing.T) {

--- a/internal/extractor/transformers.go
+++ b/internal/extractor/transformers.go
@@ -12,7 +12,9 @@ import (
 
 // Functions in this file follow the buildSchema pipeline order:
 // inlineRefs → injectGVK → replaceIntOrString → nullableOptional →
-// closeAdditionalProperties → stripVendorExtensions.
+// closeAdditionalProperties → stripVendorExtensions. StripDescriptions is an
+// optional post-process that callers can apply to trim documentation-only
+// fields from the output.
 
 // --- $ref inlining ---
 
@@ -383,9 +385,10 @@ func closeAdditionalPropertiesChildren(node any) {
 
 // --- vendor extension stripping ---
 
-// stripVendorExtensions removes every x-kubernetes-* key from the tree except
-// x-kubernetes-preserve-unknown-fields, which carries structural meaning for
-// downstream validators.
+// stripVendorExtensions removes x-kubernetes-* keys from the tree except those
+// that carry validation semantics: x-kubernetes-preserve-unknown-fields (keeps
+// subtrees open for server-side unknown fields) and x-kubernetes-validations
+// (CEL rules enforced by the API server).
 func stripVendorExtensions(node any) {
 	switch n := node.(type) {
 	case map[string]any:
@@ -393,7 +396,7 @@ func stripVendorExtensions(node any) {
 			if !strings.HasPrefix(k, "x-kubernetes-") {
 				continue
 			}
-			if k == "x-kubernetes-preserve-unknown-fields" {
+			if keepVendorExtension(k) {
 				continue
 			}
 			delete(n, k)
@@ -404,6 +407,36 @@ func stripVendorExtensions(node any) {
 	case []any:
 		for _, v := range n {
 			stripVendorExtensions(v)
+		}
+	}
+}
+
+func keepVendorExtension(k string) bool {
+	switch k {
+	case "x-kubernetes-preserve-unknown-fields",
+		"x-kubernetes-validations":
+		return true
+	}
+	return false
+}
+
+// --- description stripping ---
+
+// StripDescriptions removes every "description" key from the tree. Descriptions
+// are documentation-only and don't affect JSON Schema validation; dropping
+// them trims the output substantially for native Kubernetes schemas, where
+// descriptions make up the bulk of the payload. This is an optional
+// post-process — the extraction pipeline does not call it automatically.
+func StripDescriptions(node any) {
+	switch n := node.(type) {
+	case map[string]any:
+		delete(n, "description")
+		for _, v := range n {
+			StripDescriptions(v)
+		}
+	case []any:
+		for _, v := range n {
+			StripDescriptions(v)
 		}
 	}
 }

--- a/internal/extractor/transformers_test.go
+++ b/internal/extractor/transformers_test.go
@@ -89,3 +89,26 @@ func TestReplaceIntOrString_StructuralExtension(t *testing.T) {
 	_, hasExt := port["x-kubernetes-int-or-string"]
 	g.Expect(hasExt).To(BeFalse(), "replacement should not retain the extension")
 }
+
+func TestStripDescriptions(t *testing.T) {
+	g := NewWithT(t)
+	schema := map[string]any{
+		"type":        "object",
+		"description": "root",
+		"properties": map[string]any{
+			"name": map[string]any{
+				"type":        "string",
+				"description": "prop",
+			},
+			"items": []any{
+				map[string]any{"description": "inside-array"},
+			},
+		},
+	}
+	StripDescriptions(schema)
+	g.Expect(schema).ToNot(HaveKey("description"))
+	props := schema["properties"].(map[string]any)
+	g.Expect(props["name"]).ToNot(HaveKey("description"))
+	arr := props["items"].([]any)
+	g.Expect(arr[0]).ToNot(HaveKey("description"))
+}

--- a/internal/flags/extract.go
+++ b/internal/flags/extract.go
@@ -1,0 +1,40 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package flags
+
+import "github.com/spf13/cobra"
+
+// DefaultExtractFormat is the per-group output-path template.
+const DefaultExtractFormat = "{{ .Group }}/{{ .Kind }}_{{ .Version }}.json"
+
+// ExtractOutput holds the output-shaping flags that
+// are identical across `extract k8s` and `extract crd`.
+type ExtractOutput struct {
+	Dir              string
+	Format           string
+	StripDescription bool
+}
+
+// NewExtractOutput returns an ExtractOutput populated with the default values
+// used when no flags are passed: current directory, per-group output template,
+// descriptions preserved.
+func NewExtractOutput() ExtractOutput {
+	return ExtractOutput{
+		Dir:    ".",
+		Format: DefaultExtractFormat,
+	}
+}
+
+// Register wires -d/--output-dir, -f/--output-format and --strip-description
+// onto cmd with completion hints and help text.
+func (e *ExtractOutput) Register(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&e.Dir, "output-dir", "d", e.Dir,
+		"directory where JSON Schema files are written (created if missing)")
+	cmd.Flags().StringVarP(&e.Format, "output-format", "f", e.Format,
+		"Go template for the output file path, relative to --output-dir; "+
+			"variables: .Group, .GroupPrefix, .Kind, .Version")
+	cmd.Flags().BoolVar(&e.StripDescription, "strip-description", e.StripDescription,
+		"strip description fields from the extracted schemas to reduce their size")
+	_ = cmd.MarkFlagDirname("output-dir")
+}

--- a/scripts/gen-crd-schemas.sh
+++ b/scripts/gen-crd-schemas.sh
@@ -82,6 +82,7 @@ mkdir -p "$dir"
 kubectl kustomize "https://github.com/${repo}/config/crd?ref=${version}" | \
   flux-schema extract crd /dev/stdin \
     -f '{{ .Group }}/{{ .Kind }}_{{ .Version }}.json' \
+    --strip-description \
     -d "$dir"
 
 if [[ "${GITHUB_ACTIONS:-}" == "true" && -n "${GITHUB_ENV:-}" ]]; then

--- a/scripts/gen-flux-schemas.sh
+++ b/scripts/gen-flux-schemas.sh
@@ -74,6 +74,7 @@ echo "Extracting schemas for ${FLUX_REPO}@${version} into ${dir}"
 cat <<EOF | flux-operator build instance -f - | \
   flux-schema extract crd /dev/stdin \
     -f '{{ .Group }}/{{ .Kind }}_{{ .Version }}.json' \
+    --strip-description \
     -d "$dir"
 apiVersion: fluxcd.controlplane.io/v1
 kind: FluxInstance

--- a/scripts/gen-k8s-schemas.sh
+++ b/scripts/gen-k8s-schemas.sh
@@ -65,6 +65,7 @@ echo "Extracting schemas for ${K8S_REPO}@v${version} into ${dir}"
 
 flux-schema extract k8s --version "${version}" \
   -f '{{ .Group }}/{{ .Kind }}_{{ .Version }}.json' \
+  --strip-description \
   -d "$dir"
 
 if [[ "${GITHUB_ACTIONS:-}" == "true" && -n "${GITHUB_ENV:-}" ]]; then


### PR DESCRIPTION
Add `--strip-description` flag to `extract` commands to reduce the official catalog size in half.