### PR TITLE
Add `--skip-kind` to the validate command 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,10 @@ lint: golangci-lint ## Run golangci linters.
 build: tidy fmt vet ## Build CLI binary.
 	CGO_ENABLED=0 go build -ldflags="-s -w -X main.VERSION=$(VERSION_DEV)" -o ./bin/flux-schema ./cmd/flux-schema/
 
+.PHONY: install
+install: test lint build ## Test, lint, build and copy the binary to GOBIN.
+	cp bin/flux-schema $(GOBIN)
+
 .PHONY: run
 run: build ## Run CLI binary.
 	./bin/flux-schema $(GO_RUN_ARGS)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Flux CLI plugin for Kubernetes schema extraction and manifests validation.
 - `flux-schema validate [paths...]`: Validate Kubernetes manifests against JSON Schemas
     - `--schema-location`: Template URL or file path for schemas (repeatable, tried in order); use `default` for the Flux catalog
     - `--skip-missing-schemas`: Skip documents for which no schema can be found
-    - `-v, --verbose`: Print a line for every document, including valid and skipped
+    - `--skip-kind`: Skip documents matching `Kind` or `apiVersion/Kind` (repeatable)
+    - `-v, --verbose`: Print a line for every document, including valid and skipped ones
 - `flux-schema extract crd [files...]`: Extract JSON Schema from Kubernetes CRD YAMLs
   - `-d, --output-dir`: Directory to write JSON Schema files to (mutually exclusive with `--output-archive`)
   - `-a, --output-archive`: Path to write a gzipped tar archive of JSON Schema files to
@@ -45,13 +46,14 @@ To validate against your own schemas, pass `--schema-location` with a Go templat
 
 ```shell
 flux-schema validate ./manifests \
+  --skip-missing-schemas \
   --schema-location './schemas/{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json'
 ```
 
 Template variables are `.Group`, `.GroupPrefix`, `.Kind`, and `.Version`.
 
-The flag is repeatable and locations are tried in order — the first match wins. Pass the
-literal value `default` to include the flux-schema catalog alongside your own schemas:
+The `--schema-location` flag is repeatable and locations are tried in order — the first match wins.
+Pass the literal value `default` to include the flux-schema catalog alongside your own schemas:
 
 ```shell
 flux-schema validate ./manifests \
@@ -60,10 +62,12 @@ flux-schema validate ./manifests \
   --schema-location './schemas/{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json'
 ```
 
-Manifests can also be piped via `/dev/stdin`:
+Manifests can also be piped via `/dev/stdin` and certain documents skipped with `--skip-kind`:
 
 ```shell
-kustomize build . | flux-schema validate /dev/stdin
+kustomize build . | flux-schema validate /dev/stdin \
+  --skip-kind 'v1/Secret' \
+  --skip-kind 'source.toolkit.fluxcd.io/v1/ExternalArtifact'
 ```
 
 Output example with validation errors:
@@ -77,14 +81,15 @@ manifests/sources.yaml - Bucket/apps/s3-data is invalid: schema validation faile
 manifests/sources.yaml - OCIRepository/apps/podinfo is invalid: YAML parse failed
   - line 18: key "app.kubernetes.io/name" already set in map
 manifests/sources.yaml - HelmChart/apps/redis is valid
-Summary: 3 resources found in 1 file - Valid: 1, Invalid: 2, Skipped: 0
+manifests/sources.yaml - Secret/apps/auth-sops is skipped: kind skipped
+Summary: 4 resources found in 1 file - Valid: 1, Invalid: 2, Skipped: 1
 ```
 
 A non-zero exit code is returned when any document is invalid or errored.
 
 Validation is strict by default:
 
-- YAML documents with duplicate keys are rejected.
+- YAML documents with duplicate keys are rejected matching Flux behavior.
 - Documents missing both `metadata.name` and `metadata.generateName` are flagged as invalid
   matching Kubernetes API behavior.
 - Schemas produced by `flux-schema extract crd` close objects with `additionalProperties: false`,

--- a/catalog/latest/apiextensions.k8s.io/customresourcedefinition_v1.json
+++ b/catalog/latest/apiextensions.k8s.io/customresourcedefinition_v1.json
@@ -360,6 +360,12 @@
                 "items": {
                   "additionalProperties": false,
                   "properties": {
+                    "description": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
                     "format": {
                       "type": [
                         "string",
@@ -468,6 +474,12 @@
                           "null"
                         ]
                       },
+                      "description": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
                       "enum": {
                         "items": {},
                         "type": [
@@ -491,6 +503,12 @@
                       "externalDocs": {
                         "additionalProperties": false,
                         "properties": {
+                          "description": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
                           "url": {
                             "type": [
                               "string",

--- a/catalog/latest/apiextensions.k8s.io/customresourcedefinitionlist_v1.json
+++ b/catalog/latest/apiextensions.k8s.io/customresourcedefinitionlist_v1.json
@@ -373,6 +373,12 @@
                       "items": {
                         "additionalProperties": false,
                         "properties": {
+                          "description": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
                           "format": {
                             "type": [
                               "string",
@@ -481,6 +487,12 @@
                                 "null"
                               ]
                             },
+                            "description": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
                             "enum": {
                               "items": {},
                               "type": [
@@ -504,6 +516,12 @@
                             "externalDocs": {
                               "additionalProperties": false,
                               "properties": {
+                                "description": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
                                 "url": {
                                   "type": [
                                     "string",

--- a/catalog/latest/scheduling.k8s.io/priorityclass_v1.json
+++ b/catalog/latest/scheduling.k8s.io/priorityclass_v1.json
@@ -4,6 +4,12 @@
     "apiVersion": {
       "type": "string"
     },
+    "description": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "globalDefault": {
       "type": [
         "boolean",

--- a/catalog/latest/scheduling.k8s.io/priorityclasslist_v1.json
+++ b/catalog/latest/scheduling.k8s.io/priorityclasslist_v1.json
@@ -14,6 +14,12 @@
               "null"
             ]
           },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "globalDefault": {
             "type": [
               "boolean",

--- a/cmd/flux-schema/validate.go
+++ b/cmd/flux-schema/validate.go
@@ -35,7 +35,12 @@ var validateCmd = &cobra.Command{
   # Read manifests from a pipe
   kustomize build . | flux-schema validate /dev/stdin \
     --schema-location default \
-    --schema-location './schemas/{{.Group}}/{{.Kind}}_{{.Version}}.json'`,
+    --schema-location './schemas/{{.Group}}/{{.Kind}}_{{.Version}}.json'
+
+  # Skip specific kinds by Kind or apiVersion/Kind
+  flux-schema validate ./manifests \
+    --skip-kind Secret \
+    --skip-kind source.toolkit.fluxcd.io/v1/GitRepository`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: validateCmdRun,
 }
@@ -43,6 +48,7 @@ var validateCmd = &cobra.Command{
 type validateFlags struct {
 	schemaLocations    []string
 	skipMissingSchemas bool
+	skipKinds          []string
 	verbose            bool
 }
 
@@ -61,6 +67,8 @@ func init() {
 		"template URL or file path for schemas (repeatable); use 'default' for the built-in catalog")
 	validateCmd.Flags().BoolVar(&validateArgs.skipMissingSchemas, "skip-missing-schemas", false,
 		"skip documents for which no schema can be found instead of failing")
+	validateCmd.Flags().StringArrayVar(&validateArgs.skipKinds, "skip-kind", nil,
+		"skip documents matching Kind or apiVersion/Kind (repeatable)")
 	validateCmd.Flags().BoolVarP(&validateArgs.verbose, "verbose", "v", false,
 		"print a line for every document, including valid and skipped")
 	rootCmd.AddCommand(validateCmd)
@@ -81,6 +89,7 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 	v, err := validator.New(validator.Options{
 		SchemaLocations:    locations,
 		SkipMissingSchemas: validateArgs.skipMissingSchemas,
+		SkipKinds:          validateArgs.skipKinds,
 		HTTPTimeout:        rootArgs.timeout,
 	})
 	if err != nil {

--- a/cmd/flux-schema/validate_test.go
+++ b/cmd/flux-schema/validate_test.go
@@ -286,6 +286,47 @@ func TestValidateCmd_InvalidMetadataFixtures(t *testing.T) {
 	g.Expect(out).To(ContainSubstring("Summary: 3 resources found in 1 file - Valid: 0, Invalid: 3, Skipped: 0"))
 }
 
+// TestValidateCmd_SkipKind exercises all three accepted pattern shapes against
+// the real Flux fixtures: a bare Kind, an apiVersion/Kind, and a
+// group/version/Kind. Each doc that matches is skipped instead of being
+// validated, with a short-circuit line reading "... is skipped: kind skipped".
+func TestValidateCmd_SkipKind(t *testing.T) {
+	g := NewWithT(t)
+
+	reconcilersPath := "./testdata/validate/manifests/valid-reconcilers.yaml"
+	sourcesPath := "./testdata/validate/manifests/valid-sources.yaml"
+
+	out, err := executeCommand([]string{
+		"validate",
+		reconcilersPath,
+		sourcesPath,
+		"--schema-location", "./testdata/validate/schemas/{{ .Group }}/{{ .Kind }}_{{ .Version }}.json",
+		"--skip-kind", "Secret",
+		"--skip-kind", "source.toolkit.fluxcd.io/v1/GitRepository",
+		"--skip-kind", "helm.toolkit.fluxcd.io/v2/HelmRelease",
+		"--verbose",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(out).To(ContainSubstring(sourcesPath + " - Secret/default/minio-bucket-secret is skipped: kind skipped"))
+	g.Expect(out).To(ContainSubstring(" - GitRepository/"))
+	g.Expect(out).To(ContainSubstring("is skipped: kind skipped"))
+	g.Expect(out).To(ContainSubstring(" - HelmRelease/"))
+}
+
+func TestValidateCmd_SkipKind_Invalid(t *testing.T) {
+	g := NewWithT(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	_, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(t.TempDir(), "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--skip-kind", "v1/",
+	})
+	g.Expect(err).To(MatchError(ContainSubstring("skip kind pattern")))
+}
+
 func TestExpandSchemaLocations(t *testing.T) {
 	g := NewWithT(t)
 

--- a/internal/extractor/transformers.go
+++ b/internal/extractor/transformers.go
@@ -16,6 +16,8 @@ import (
 // optional post-process that callers can apply to trim documentation-only
 // fields from the output.
 
+const keyProperties = "properties"
+
 // --- $ref inlining ---
 
 // inlineRefs walks node and replaces every {$ref: "#/definitions/X"} object
@@ -129,10 +131,10 @@ func overlaySiblings(inlined map[string]any, host map[string]any) map[string]any
 // and adds them to required. metadata is left as-is: absent kinds stay absent,
 // and inlined metadata is neither promoted to required nor demoted.
 func injectGVK(schema map[string]any) {
-	props, _ := schema["properties"].(map[string]any)
+	props, _ := schema[keyProperties].(map[string]any)
 	if props == nil {
 		props = map[string]any{}
-		schema["properties"] = props
+		schema[keyProperties] = props
 	}
 
 	required := toStringSlice(schema["required"])
@@ -260,7 +262,7 @@ func nullableOptional(node any) {
 		if preserve, _ := n["x-kubernetes-preserve-unknown-fields"].(bool); preserve {
 			return
 		}
-		props, _ := n["properties"].(map[string]any)
+		props, _ := n[keyProperties].(map[string]any)
 		if props != nil {
 			required := toStringSlice(n["required"])
 			for name, prop := range props {
@@ -279,7 +281,7 @@ func nullableOptional(node any) {
 			}
 		}
 		for k, v := range n {
-			if k == "properties" {
+			if k == keyProperties {
 				continue
 			}
 			nullableOptional(v)
@@ -350,7 +352,7 @@ func closeAdditionalProperties(node any) {
 		if preserve, _ := n["x-kubernetes-preserve-unknown-fields"].(bool); preserve {
 			return
 		}
-		if _, hasProps := n["properties"]; hasProps {
+		if _, hasProps := n[keyProperties]; hasProps {
 			if _, hasAP := n["additionalProperties"]; !hasAP {
 				n["additionalProperties"] = false
 			}
@@ -427,11 +429,24 @@ func keepVendorExtension(k string) bool {
 // them trims the output substantially for native Kubernetes schemas, where
 // descriptions make up the bulk of the payload. This is an optional
 // post-process — the extraction pipeline does not call it automatically.
+//
+// Keys inside "properties", "patternProperties", "$defs", and "definitions"
+// are user-defined property/schema names, not schema keywords, so a field
+// literally named "description" (as JSONSchemaProps has) is preserved and
+// only its metadata siblings underneath are stripped.
 func StripDescriptions(node any) {
 	switch n := node.(type) {
 	case map[string]any:
 		delete(n, "description")
-		for _, v := range n {
+		for k, v := range n {
+			if isSchemaNameMap(k) {
+				if m, ok := v.(map[string]any); ok {
+					for _, child := range m {
+						StripDescriptions(child)
+					}
+					continue
+				}
+			}
 			StripDescriptions(v)
 		}
 	case []any:
@@ -439,6 +454,22 @@ func StripDescriptions(node any) {
 			StripDescriptions(v)
 		}
 	}
+}
+
+// isSchemaNameMap reports whether the value under k is a map of user-defined
+// names to subschemas, rather than a schema itself. Inside such maps, the keys
+// are property or definition names and must not be confused with JSON Schema
+// keywords like "description".
+//
+// "dependentSchemas" (Draft 2019-09+) is deliberately omitted: kube-openapi
+// does not emit it, and CRDs reject it under structural-schema rules, so it
+// never appears in this project's inputs.
+func isSchemaNameMap(k string) bool {
+	switch k {
+	case keyProperties, "patternProperties", "$defs", "definitions":
+		return true
+	}
+	return false
 }
 
 // --- shared across sections ---
@@ -451,7 +482,7 @@ func StripDescriptions(node any) {
 // int-or-string node into a oneOf.
 func isStructuralKey(k string) bool {
 	switch k {
-	case "type", "properties", "items", "required",
+	case "type", keyProperties, "items", "required",
 		"oneOf", "allOf", "anyOf", "not",
 		"additionalProperties",
 		"enum", "format", "pattern",

--- a/internal/extractor/transformers_test.go
+++ b/internal/extractor/transformers_test.go
@@ -112,3 +112,180 @@ func TestStripDescriptions(t *testing.T) {
 	arr := props["items"].([]any)
 	g.Expect(arr[0]).ToNot(HaveKey("description"))
 }
+
+// TestStripDescriptions_PreservesPropertyNamedDescription guards against a
+// regression where a property literally named "description" (as
+// JSONSchemaProps has for CRD openAPIV3Schema) was deleted along with the
+// schema-metadata "description" keyword. The property itself must survive;
+// only its metadata siblings underneath get stripped.
+func TestStripDescriptions_PreservesPropertyNamedDescription(t *testing.T) {
+	g := NewWithT(t)
+	schema := map[string]any{
+		"type":        "object",
+		"description": "root doc",
+		"properties": map[string]any{
+			"description": map[string]any{
+				"type":        "string",
+				"description": "the description field's own doc",
+			},
+			"type": map[string]any{
+				"type":        "string",
+				"description": "the type field's own doc",
+			},
+		},
+		"patternProperties": map[string]any{
+			"^x-": map[string]any{
+				"description": "pattern prop doc",
+			},
+		},
+		"$defs": map[string]any{
+			"description": map[string]any{
+				"type":        "string",
+				"description": "def doc",
+			},
+		},
+		"definitions": map[string]any{
+			"description": map[string]any{
+				"type":        "string",
+				"description": "legacy def doc",
+			},
+		},
+	}
+	StripDescriptions(schema)
+
+	g.Expect(schema).ToNot(HaveKey("description"))
+
+	props := schema["properties"].(map[string]any)
+	g.Expect(props).To(HaveKey("description"), "property named 'description' must be preserved")
+	g.Expect(props["description"]).ToNot(HaveKey("description"))
+	g.Expect(props["description"]).To(HaveKeyWithValue("type", "string"))
+	g.Expect(props).To(HaveKey("type"))
+
+	pp := schema["patternProperties"].(map[string]any)
+	g.Expect(pp).To(HaveKey("^x-"))
+	g.Expect(pp["^x-"]).ToNot(HaveKey("description"))
+
+	defs := schema["$defs"].(map[string]any)
+	g.Expect(defs).To(HaveKey("description"))
+	g.Expect(defs["description"]).ToNot(HaveKey("description"))
+
+	legacyDefs := schema["definitions"].(map[string]any)
+	g.Expect(legacyDefs).To(HaveKey("description"))
+	g.Expect(legacyDefs["description"]).ToNot(HaveKey("description"))
+}
+
+// TestStripDescriptions_DeepNesting guards that a property named "description"
+// is preserved at every level of recursion, not just the top. Mirrors the
+// JSONSchemaProps shape where openAPIV3Schema → properties.foo → properties
+// reaches arbitrary depth.
+func TestStripDescriptions_DeepNesting(t *testing.T) {
+	g := NewWithT(t)
+	schema := map[string]any{
+		"description": "L0",
+		"properties": map[string]any{
+			"description": map[string]any{
+				"description": "L1",
+				"properties": map[string]any{
+					"description": map[string]any{
+						"description": "L2",
+						"type":        "string",
+					},
+				},
+			},
+		},
+	}
+	StripDescriptions(schema)
+
+	l1Props := schema["properties"].(map[string]any)
+	g.Expect(l1Props).To(HaveKey("description"))
+	l1 := l1Props["description"].(map[string]any)
+	g.Expect(l1).ToNot(HaveKey("description"))
+
+	l2Props := l1["properties"].(map[string]any)
+	g.Expect(l2Props).To(HaveKey("description"))
+	l2 := l2Props["description"].(map[string]any)
+	g.Expect(l2).ToNot(HaveKey("description"))
+	g.Expect(l2).To(HaveKeyWithValue("type", "string"))
+}
+
+// TestStripDescriptions_SchemaValuedKeywords confirms that schema-valued
+// keywords (additionalProperties, not, if/then/else, oneOf/anyOf/allOf) still
+// have their "description" metadata stripped — they are schema nodes, not
+// name→schema maps. Mixed with a nested properties map so both paths execute.
+func TestStripDescriptions_SchemaValuedKeywords(t *testing.T) {
+	g := NewWithT(t)
+	schema := map[string]any{
+		"additionalProperties": map[string]any{
+			"description": "addl",
+			"type":        "object",
+			"properties": map[string]any{
+				"description": map[string]any{
+					"description": "nested",
+					"type":        "string",
+				},
+			},
+		},
+		"not": map[string]any{"description": "not-doc", "type": "null"},
+		"if":  map[string]any{"description": "if-doc"},
+		"then": map[string]any{
+			"description": "then-doc",
+			"properties": map[string]any{
+				"description": map[string]any{"description": "then-prop", "type": "string"},
+			},
+		},
+		"else":  map[string]any{"description": "else-doc"},
+		"oneOf": []any{map[string]any{"description": "oneOf-0"}},
+		"anyOf": []any{map[string]any{"description": "anyOf-0"}},
+		"allOf": []any{map[string]any{"description": "allOf-0"}},
+	}
+	StripDescriptions(schema)
+
+	addl := schema["additionalProperties"].(map[string]any)
+	g.Expect(addl).ToNot(HaveKey("description"))
+	addlProps := addl["properties"].(map[string]any)
+	g.Expect(addlProps).To(HaveKey("description"))
+	g.Expect(addlProps["description"]).ToNot(HaveKey("description"))
+
+	for _, k := range []string{"not", "if", "then", "else"} {
+		sub, ok := schema[k].(map[string]any)
+		g.Expect(ok).To(BeTrue(), "key %s should be a map", k)
+		g.Expect(sub).ToNot(HaveKey("description"), "metadata under %s must be stripped", k)
+	}
+	thenProps := schema["then"].(map[string]any)["properties"].(map[string]any)
+	g.Expect(thenProps).To(HaveKey("description"))
+	g.Expect(thenProps["description"]).ToNot(HaveKey("description"))
+
+	for _, k := range []string{"oneOf", "anyOf", "allOf"} {
+		arr := schema[k].([]any)
+		g.Expect(arr[0]).ToNot(HaveKey("description"), "metadata under %s[0] must be stripped", k)
+	}
+}
+
+// TestStripDescriptions_ItemsWithNestedProperties pins the array `items`
+// path: items is a schema node (not a name map), so its own description is
+// stripped, but a property named "description" living under items.properties
+// must still survive. Models `type: array` children of JSONSchemaProps.
+func TestStripDescriptions_ItemsWithNestedProperties(t *testing.T) {
+	g := NewWithT(t)
+	schema := map[string]any{
+		"type": "array",
+		"items": map[string]any{
+			"description": "items-doc",
+			"type":        "object",
+			"properties": map[string]any{
+				"description": map[string]any{
+					"description": "nested under items",
+					"type":        "string",
+				},
+			},
+		},
+	}
+	StripDescriptions(schema)
+
+	items := schema["items"].(map[string]any)
+	g.Expect(items).ToNot(HaveKey("description"))
+	itemsProps := items["properties"].(map[string]any)
+	g.Expect(itemsProps).To(HaveKey("description"))
+	g.Expect(itemsProps["description"]).ToNot(HaveKey("description"))
+	g.Expect(itemsProps["description"]).To(HaveKeyWithValue("type", "string"))
+}

--- a/internal/validator/doc.go
+++ b/internal/validator/doc.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package validator validates Kubernetes YAML manifests against JSON
+// Schemas resolved from one or more schema location templates.
+//
+// # Entry points
+//
+// New returns a Validator configured from Options. ValidateSources walks
+// files and directories and streams Results over a channel; ValidateBytes
+// validates an in-memory payload and returns the Results slice.
+//
+// # YAML handling
+//
+// Multi-document streams are split on "\n---" boundaries. Documents that
+// contain only comments or whitespace are dropped entirely rather than
+// surfaced as skipped, keeping user-visible document numbering aligned
+// with the real resources in each file.
+//
+// YAML is decoded in strict mode, so duplicate keys fail the document.
+// When strict decoding fails, a lenient re-parse recovers apiVersion,
+// kind, namespace, and name for the Result so callers can still render
+// a meaningful identifier for the failing document.
+//
+// # Admission and schema checks
+//
+// For every decoded document the pipeline runs, in order:
+//
+//  1. SkipKinds matching — a pattern of "Kind" or "apiVersion/Kind"
+//     short-circuits validation with StatusSkipped, before the admission
+//     rule so encrypted or sealed manifests that omit metadata.name are
+//     still skipped cleanly.
+//  2. apiVersion/kind presence — missing either field fails the document;
+//     Options.SkipMissingSchemas downgrades this to StatusSkipped.
+//  3. Admission rule — metadata.name or metadata.generateName must be
+//     set, matching kube-apiserver behavior.
+//  4. Schema resolution — each location template is rendered with the
+//     document's group/version/kind and the first matching schema is
+//     compiled and cached. 404 / ENOENT on every location fails the
+//     document unless Options.SkipMissingSchemas is set.
+//  5. JSON Schema validation — the compiled schema is run against the
+//     decoded document; per-field violations are returned as a flat list
+//     of ValidationError with JSON Pointer paths.
+//
+// Schemas produced by the extractor package close objects with
+// additionalProperties: false, so undocumented fields under spec fail
+// validation.
+//
+// # Schema resolution and caching
+//
+// SchemaLoader renders each location template with the document's
+// group/version/kind and loads from http(s) URLs (via retryablehttp,
+// honoring Options.HTTPTimeout) or the local filesystem. Each rendered
+// location is fetched, parsed, and compiled at most once per Validator
+// lifetime, and the compiled *jsonschema.Schema is reused across
+// documents. Compilation uses JSON Schema Draft 2020-12 with the
+// Kubernetes string formats (duration, date, datetime/date-time, time)
+// registered on the compiler — including duration units kube-apiserver
+// accepts but Go's time.ParseDuration rejects (e.g. "2w", "3d").
+//
+// # Concurrency and streaming
+//
+// ValidateSources walks sources sequentially on one producer goroutine
+// and validates documents in parallel on a pool of Options.Workers
+// workers. Results arrive on the returned channel in completion order,
+// which is non-deterministic; each Result carries Source and DocIndex
+// so callers can reorder. After every real Result for a source has been
+// pushed, a synthetic Result with Final=true is emitted for that source
+// so consumers can flush per-source state mid-stream instead of
+// buffering until end-of-stream. The channel is closed once all
+// documents and sentinels have been delivered.
+package validator

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -1,13 +1,6 @@
 // Copyright 2026 The Flux Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Package validator validates Kubernetes YAML manifests against JSON
-// Schemas resolved from one or more --schema-location templates.
-//
-// Validation is strict by default: YAML duplicate keys are rejected,
-// documents missing both metadata.name and metadata.generateName are
-// flagged (kube-apiserver admission rule), and schemas produced by
-// flux-schema extract enforce additionalProperties: false.
 package validator
 
 import (
@@ -17,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"text/template"
@@ -98,6 +92,7 @@ func (r Result) Identifier() string {
 type Options struct {
 	SchemaLocations    []string
 	SkipMissingSchemas bool
+	SkipKinds          []string
 	HTTPClient         *retryablehttp.Client
 	HTTPTimeout        time.Duration
 	Workers            int
@@ -106,8 +101,44 @@ type Options struct {
 // Validator resolves and applies JSON Schemas to Kubernetes manifests.
 // It is safe for concurrent use by multiple goroutines.
 type Validator struct {
-	opts   Options
-	loader *SchemaLoader
+	opts      Options
+	loader    *SchemaLoader
+	skipKinds []skipKindMatcher
+}
+
+// skipKindMatcher matches a document by Kind, optionally scoped to an
+// apiVersion. An empty apiVersion matches any group/version.
+type skipKindMatcher struct {
+	apiVersion string
+	kind       string
+}
+
+// parseSkipKind parses a SkipKinds pattern. Accepted shapes:
+//
+//	Kind              e.g. "Secret"
+//	apiVersion/Kind   e.g. "v1/Secret", "source.toolkit.fluxcd.io/v1/GitRepository"
+func parseSkipKind(s string) (skipKindMatcher, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return skipKindMatcher{}, errors.New("skip kind pattern must not be empty")
+	}
+	parts := strings.Split(s, "/")
+	if slices.Contains(parts, "") {
+		return skipKindMatcher{}, fmt.Errorf("skip kind pattern %q: segments must not be empty", s)
+	}
+	kind := parts[len(parts)-1]
+	var apiVersion string
+	if len(parts) > 1 {
+		apiVersion = strings.Join(parts[:len(parts)-1], "/")
+	}
+	return skipKindMatcher{apiVersion: apiVersion, kind: kind}, nil
+}
+
+func (m skipKindMatcher) matches(apiVersion, kind string) bool {
+	if m.kind != kind {
+		return false
+	}
+	return m.apiVersion == "" || m.apiVersion == apiVersion
 }
 
 // New returns a Validator configured from opts. Each location template is
@@ -139,9 +170,19 @@ func New(opts Options) (*Validator, error) {
 		opts.HTTPClient = c
 	}
 
+	skipKinds := make([]skipKindMatcher, 0, len(opts.SkipKinds))
+	for _, s := range opts.SkipKinds {
+		m, err := parseSkipKind(s)
+		if err != nil {
+			return nil, err
+		}
+		skipKinds = append(skipKinds, m)
+	}
+
 	return &Validator{
-		opts:   opts,
-		loader: NewSchemaLoader(templates, opts.HTTPClient, opts.HTTPTimeout),
+		opts:      opts,
+		loader:    NewSchemaLoader(templates, opts.HTTPClient, opts.HTTPTimeout),
+		skipKinds: skipKinds,
 	}, nil
 }
 
@@ -367,8 +408,8 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 		return r, true
 	}
 	// missingSchemaStatus picks between StatusSkipped and StatusInvalid for
-	// "we can't resolve a schema for this document" cases, honoring the
-	// --skip-missing-schemas flag.
+	// "we can't resolve a schema for this document" cases, honoring
+	// Options.SkipMissingSchemas.
 	missingSchemaStatus := func() Status {
 		if v.opts.SkipMissingSchemas {
 			return StatusSkipped
@@ -378,9 +419,9 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 
 	var doc map[string]any
 	if err := yaml.UnmarshalStrict(raw, &doc); err != nil {
-		// Lenient re-parse so the CLI line can still show Kind/Namespace/Name
-		// for a doc that failed admission (e.g. duplicate keys), rather than
-		// the anonymous "/#1".
+		// Lenient re-parse so callers can still render Kind/Namespace/Name
+		// for a doc that failed admission (e.g. duplicate keys), rather
+		// than the anonymous "/#1".
 		var lenient map[string]any
 		if yaml.Unmarshal(raw, &lenient) == nil && lenient != nil {
 			r.APIVersion, r.Kind, r.Namespace, r.Name = extractIdentity(lenient)
@@ -401,6 +442,15 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 	metadata, _ := doc["metadata"].(map[string]any)
 	name, hasIdentity := computeName(metadata, idx)
 	r.Name = name
+
+	// SkipKinds matching runs before admission and schema checks so a
+	// kind-only entry (e.g. "Secret") also covers sealed/encrypted manifests
+	// that would otherwise fail the name/generateName rule.
+	for _, m := range v.skipKinds {
+		if m.matches(r.APIVersion, r.Kind) {
+			return settle(StatusSkipped, "kind skipped")
+		}
+	}
 
 	if r.APIVersion == "" || r.Kind == "" {
 		return settle(missingSchemaStatus(), "document missing apiVersion/kind")

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -702,6 +702,146 @@ func TestIsContentFree(t *testing.T) {
 	}
 }
 
+func TestParseSkipKind(t *testing.T) {
+	cases := map[string]struct {
+		in         string
+		wantAPIVer string
+		wantKind   string
+		wantErr    bool
+	}{
+		"kind only":             {in: "Secret", wantKind: "Secret"},
+		"core gvk":              {in: "v1/Secret", wantAPIVer: "v1", wantKind: "Secret"},
+		"group gvk":             {in: "source.toolkit.fluxcd.io/v1/GitRepository", wantAPIVer: "source.toolkit.fluxcd.io/v1", wantKind: "GitRepository"},
+		"whitespace trimmed":    {in: "  Secret  ", wantKind: "Secret"},
+		"empty":                 {in: "", wantErr: true},
+		"whitespace only":       {in: "   ", wantErr: true},
+		"trailing slash":        {in: "v1/", wantErr: true},
+		"leading slash":         {in: "/Secret", wantErr: true},
+		"double slash in group": {in: "//Secret", wantErr: true},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+			m, err := parseSkipKind(tc.in)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(m.apiVersion).To(Equal(tc.wantAPIVer))
+			g.Expect(m.kind).To(Equal(tc.wantKind))
+		})
+	}
+}
+
+func TestSkipKindMatcher_Matches(t *testing.T) {
+	g := NewWithT(t)
+	kindOnly, err := parseSkipKind("Secret")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(kindOnly.matches("v1", "Secret")).To(BeTrue())
+	g.Expect(kindOnly.matches("example.com/v1", "Secret")).To(BeTrue())
+	g.Expect(kindOnly.matches("v1", "ConfigMap")).To(BeFalse())
+
+	core, err := parseSkipKind("v1/Secret")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(core.matches("v1", "Secret")).To(BeTrue())
+	g.Expect(core.matches("example.com/v1", "Secret")).To(BeFalse())
+
+	gvk, err := parseSkipKind("source.toolkit.fluxcd.io/v1/GitRepository")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(gvk.matches("source.toolkit.fluxcd.io/v1", "GitRepository")).To(BeTrue())
+	g.Expect(gvk.matches("source.toolkit.fluxcd.io/v1beta2", "GitRepository")).To(BeFalse())
+	g.Expect(gvk.matches("source.toolkit.fluxcd.io/v1", "HelmRepository")).To(BeFalse())
+}
+
+func TestValidateBytes_SkipKind_KindOnly(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	v, err := New(Options{
+		SchemaLocations: []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipKinds:       []string{"Secret"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	doc := []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: s1
+stringData:
+  foo: bar
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusSkipped))
+	g.Expect(results[0].Message).To(Equal("kind skipped"))
+	g.Expect(results[0].Identifier()).To(Equal("Secret/s1"))
+}
+
+func TestValidateBytes_SkipKind_GVKMatchesOnlyExactVersion(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchema(t, dir)
+	v, err := New(Options{
+		SchemaLocations: []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipKinds:       []string{"example.com/v1/Widget"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	skipped := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec:
+  name: ok
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", skipped)
+	g.Expect(results[0].Status).To(Equal(StatusSkipped))
+
+	// A different version must not match; it falls through to normal
+	// resolution and errors out with "schema not found".
+	other := []byte(`apiVersion: example.com/v2
+kind: Widget
+metadata:
+  name: w1
+spec:
+  name: ok
+`)
+	results = v.ValidateBytes(context.Background(), "test.yaml", other)
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Message).To(Equal("schema not found"))
+}
+
+func TestValidateBytes_SkipKind_BypassesAdmissionCheck(t *testing.T) {
+	// Sealed/encrypted manifests often omit metadata.name — --skip-kind must
+	// short-circuit before the name/generateName rule so those docs don't
+	// surface as invalid.
+	g := NewWithT(t)
+	dir := t.TempDir()
+	v, err := New(Options{
+		SchemaLocations: []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipKinds:       []string{"Secret"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	doc := []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  namespace: default
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusSkipped))
+}
+
+func TestNew_RejectsBadSkipKind(t *testing.T) {
+	g := NewWithT(t)
+	_, err := New(Options{
+		SchemaLocations: []string{"./{{ .Kind }}.json"},
+		SkipKinds:       []string{""},
+	})
+	g.Expect(err).To(HaveOccurred())
+}
+
 func TestNew_RejectsBadTemplate(t *testing.T) {
 	g := NewWithT(t)
 	_, err := New(Options{SchemaLocations: []string{"{{ .Unknown }}"}})


### PR DESCRIPTION
Allow skiping documents during validation based on GVK or just Kind.

Example:

```shell
flux-schema validate ./manifests \
  --skip-kind ConfigMap \
  --skip-kind v1/Secret \
  --skip-kind source.toolkit.fluxcd.io/v1/GitRepository
```
