### PR TITLE
Add fail fast mode to the validate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Flux CLI plugin for Kubernetes schema extraction and manifests validation.
     - `--schema-location`: URL or file path for schemas (repeatable, tried in order); `default` points at the built-in catalog
     - `--skip-missing-schemas`: Skip documents for which no schema can be found
     - `--skip-kind`: Skip documents matching `Kind` or `apiVersion/Kind` (repeatable)
+    - `--fail-fast`: Exit after the first invalid document
+    - `--concurrent`: Number of concurrent workers (default 8)
+    - `--insecure-skip-tls-verify`: Disable TLS certificate verification when fetching schemas over HTTPS
     - `-v, --verbose`: Print a line for every document, including valid and skipped ones
 - `flux-schema extract crd [files...]`: Extract JSON Schema from Kubernetes CRD YAMLs
   - `-d, --output-dir`: Directory to write JSON Schema files to (mutually exclusive with `--output-archive`)

--- a/cmd/flux-schema/main_test.go
+++ b/cmd/flux-schema/main_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/fluxcd/flux-schema/internal/flags"
+	"github.com/fluxcd/flux-schema/internal/validator"
 )
 
 var (
@@ -49,7 +50,7 @@ func resetCmdArgs() {
 	versionArgs = versionFlags{output: "text"}
 	extractCRDArgs = extractCRDFlags{ExtractOutput: flags.NewExtractOutput()}
 	extractK8sArgs = extractK8sFlags{ExtractOutput: flags.NewExtractOutput()}
-	validateArgs = validateFlags{}
+	validateArgs = validateFlags{concurrent: validator.DefaultWorkers}
 
 	// pflag.Flag.Changed persists across Execute calls on the shared rootCmd,
 	// which breaks MarkFlagRequired validation in subsequent tests. Clear it

--- a/cmd/flux-schema/validate.go
+++ b/cmd/flux-schema/validate.go
@@ -19,7 +19,7 @@ var validateCmd = &cobra.Command{
 	Short: "Validate Kubernetes manifests against JSON Schemas",
 	Example: `  # Validate YAMLs under ./manifests against the default catalog
   # The default catalog covers the latest stable Kubernetes and Flux APIs
-  # https://github.com/fluxcd/flux-schema/tree/main/catalog
+  # https://github.com/fluxcd/flux-schema/blob/main/catalog/README.md
   flux-schema validate ./manifests --verbose
 
   # Validate against a local schema directory written by 'flux-schema extract'
@@ -31,10 +31,11 @@ var validateCmd = &cobra.Command{
     --schema-location default \
     --schema-location './schemas/{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json'
 
-  # Read manifests from a pipe
+  # Read manifests from a pipe and add remote schema fallback
   kustomize build . | flux-schema validate /dev/stdin \
     --schema-location default \
-    --schema-location ./crd-schemas
+    --schema-location ./crd-schemas \
+    --schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main
 
   # Skip specific kinds by Kind or apiVersion/Kind
   flux-schema validate ./manifests \
@@ -45,45 +46,43 @@ var validateCmd = &cobra.Command{
 }
 
 type validateFlags struct {
-	schemaLocations    []string
-	skipMissingSchemas bool
-	skipKinds          []string
-	verbose            bool
+	schemaLocations       []string
+	skipMissingSchemas    bool
+	skipKinds             []string
+	verbose               bool
+	failFast              bool
+	concurrent            int
+	insecureSkipTLSVerify bool
 }
 
-// defaultValidateSchemaLocation points at the flux-schema catalog,
-// covering the latest stable Kubernetes and Flux APIs.
-// It is used when no --schema-location is provided, and is what
-// the literal value "default" expands to in --schema-location.
-const defaultValidateSchemaLocation = "https://raw.githubusercontent.com/fluxcd/flux-schema/main/catalog/latest/" + defaultSchemaLayout
-
-// defaultSchemaLayout is the Go-template tail appended to any --schema-location
-// value that doesn't already end in .json, so a bare path/URL like
-// "./my-schemas" expands to "./my-schemas/{{.Group}}/{{.Kind}}_{{.Version}}.json".
-// This matches the per-group directory layout that `flux-schema extract` writes
-// by default, so the common case round-trips without a Go template on the flag.
-const defaultSchemaLayout = "{{.Group}}/{{.Kind}}_{{.Version}}.json"
-
-var validateArgs = validateFlags{}
+var validateArgs = validateFlags{
+	concurrent: validator.DefaultWorkers,
+}
 
 const stdinPath = "/dev/stdin"
 
 func init() {
 	validateCmd.Flags().StringArrayVar(&validateArgs.schemaLocations, "schema-location", nil,
-		"URL or file path for schemas (repeatable); bare paths/URLs get the default layout appended; 'default' points at the built-in catalog")
+		"URL or file path for schemas (repeatable); 'default' points at the built-in catalog")
 	validateCmd.Flags().BoolVar(&validateArgs.skipMissingSchemas, "skip-missing-schemas", false,
 		"skip documents for which no schema can be found instead of failing")
 	validateCmd.Flags().StringArrayVar(&validateArgs.skipKinds, "skip-kind", nil,
 		"skip documents matching Kind or apiVersion/Kind (repeatable)")
 	validateCmd.Flags().BoolVarP(&validateArgs.verbose, "verbose", "v", false,
 		"print a line for every document, including valid and skipped")
+	validateCmd.Flags().BoolVar(&validateArgs.failFast, "fail-fast", false,
+		"exit after the first invalid document")
+	validateCmd.Flags().IntVar(&validateArgs.concurrent, "concurrent", validator.DefaultWorkers,
+		"number of concurrent workers")
+	validateCmd.Flags().BoolVar(&validateArgs.insecureSkipTLSVerify, "insecure-skip-tls-verify", false,
+		"disable TLS certificate verification when fetching schemas over HTTPS")
 	rootCmd.AddCommand(validateCmd)
 }
 
 func validateCmdRun(cmd *cobra.Command, args []string) error {
 	locations := validateArgs.schemaLocations
 	if len(locations) == 0 {
-		locations = []string{defaultValidateSchemaLocation}
+		locations = []string{validator.DefaultSchemaLocation}
 	} else {
 		expanded, err := expandSchemaLocations(locations)
 		if err != nil {
@@ -92,11 +91,17 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 		locations = expanded
 	}
 
+	if validateArgs.concurrent < 1 {
+		return fmt.Errorf("--concurrent must be >= 1, got %d", validateArgs.concurrent)
+	}
+
 	v, err := validator.New(validator.Options{
-		SchemaLocations:    locations,
-		SkipMissingSchemas: validateArgs.skipMissingSchemas,
-		SkipKinds:          validateArgs.skipKinds,
-		HTTPTimeout:        rootArgs.timeout,
+		SchemaLocations:       locations,
+		SkipMissingSchemas:    validateArgs.skipMissingSchemas,
+		SkipKinds:             validateArgs.skipKinds,
+		HTTPTimeout:           rootArgs.timeout,
+		Workers:               validateArgs.concurrent,
+		InsecureSkipTLSVerify: validateArgs.insecureSkipTLSVerify,
 	})
 	if err != nil {
 		return err
@@ -203,6 +208,15 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 		if currentIdx < len(sourceOrder) && sourceOrder[currentIdx] == r.Source {
 			flushContiguous(r.Source)
 		}
+
+		// --fail-fast: cancel the validator on the first invalid result.
+		// Workers see ctx.Done() and return; ValidateSources closes the
+		// channel after draining the pool, so the loop exits cleanly and
+		// the defensive flush below prints any buffered invalid result
+		// even when an earlier source never reached its Final sentinel.
+		if validateArgs.failFast && r.Status == validator.StatusInvalid {
+			cancel()
+		}
 	}
 
 	// Channel closed: every source we registered should have received a
@@ -227,10 +241,10 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 // expandSchemaLocations normalizes each --schema-location value so callers can
 // pass either a full Go template or a bare path/URL:
 //
-//   - A case-insensitive literal "default" expands to defaultValidateSchemaLocation.
+//   - A case-insensitive literal "default" expands to validator.DefaultSchemaLocation.
 //   - A value ending in ".json" is assumed to already be a complete template and
 //     is taken verbatim.
-//   - Anything else has defaultSchemaLayout appended under a single "/", so
+//   - Anything else has validator.DefaultSchemaLayout appended under a single "/", so
 //     "./my-schemas" becomes "./my-schemas/{{.Group}}/{{.Kind}}_{{.Version}}.json".
 //     For URLs, the tail is spliced before any "?query" or "#fragment" so the
 //     template lands on the path, not inside the query string.
@@ -238,7 +252,7 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 // Order is preserved so the user controls fallback priority.
 //
 // Note: when no --schema-location is passed the caller uses
-// defaultValidateSchemaLocation directly (see validateCmdRun) and does not go
+// validator.DefaultSchemaLocation directly (see validateCmdRun) and does not go
 // through this function — that default is already a complete template.
 func expandSchemaLocations(locations []string) ([]string, error) {
 	out := make([]string, len(locations))
@@ -247,7 +261,7 @@ func expandSchemaLocations(locations []string) ([]string, error) {
 			return nil, fmt.Errorf("--schema-location must not be empty")
 		}
 		if strings.EqualFold(loc, "default") {
-			out[i] = defaultValidateSchemaLocation
+			out[i] = validator.DefaultSchemaLocation
 			continue
 		}
 		if !strings.HasSuffix(loc, ".json") {
@@ -258,7 +272,7 @@ func expandSchemaLocations(locations []string) ([]string, error) {
 	return out, nil
 }
 
-// appendSchemaLayout appends defaultSchemaLayout to loc, preserving any URL
+// appendSchemaLayout appends validator.DefaultSchemaLayout to loc, preserving any URL
 // query string or fragment. "./schemas" → "./schemas/<layout>";
 // "https://host/catalog?ref=main" → "https://host/catalog/<layout>?ref=main".
 // Trailing "/" and "\" are both stripped so a Windows path like ".\schemas\"
@@ -268,7 +282,7 @@ func appendSchemaLayout(loc string) string {
 	if i := strings.IndexAny(loc, "?#"); i >= 0 {
 		base, tail = loc[:i], loc[i:]
 	}
-	return strings.TrimRight(base, `/\`) + "/" + defaultSchemaLayout + tail
+	return strings.TrimRight(base, `/\`) + "/" + validator.DefaultSchemaLayout + tail
 }
 
 // shouldPrint returns true when this result should be written to stdout.

--- a/cmd/flux-schema/validate_test.go
+++ b/cmd/flux-schema/validate_test.go
@@ -4,11 +4,16 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/gomega"
+
+	"github.com/fluxcd/flux-schema/internal/validator"
 )
 
 // extractWidgetSchema runs the extract crd command on minimalCRDYAML and returns
@@ -336,6 +341,106 @@ func TestValidateCmd_SkipKind(t *testing.T) {
 	g.Expect(out).To(ContainSubstring(" - HelmRelease/"))
 }
 
+// TestValidateCmd_FailFast pins the short-circuit behavior: a multi-doc file
+// containing many invalid documents must still trigger a non-zero exit, but
+// --fail-fast should stop counting well before every document runs. With
+// --concurrent 1 the pool is near-deterministic — we expect exactly 1 or 2
+// invalid lines (one picked up before the cancel fires, plus at most one
+// already in the worker pipeline) and a matching summary count.
+func TestValidateCmd_FailFast(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+
+	// 50 invalid docs — the pool with a single worker will cancel long
+	// before all of them are counted.
+	var body []byte
+	for i := range 50 {
+		if i > 0 {
+			body = append(body, []byte("---\n")...)
+		}
+		body = append(body, []byte(invalidWidget)...)
+	}
+	writeManifest(t, manifestDir, "multi.yaml", string(body))
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--fail-fast",
+		"--concurrent", "1",
+	})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("is invalid: schema validation failed"))
+	// Single-digit invalid count proves fail-fast cut the run short of 50.
+	g.Expect(out).To(MatchRegexp(`Invalid: [1-9],`))
+}
+
+// TestValidateCmd_ConcurrentFlag pins that --concurrent accepts a value and
+// that an invalid (<1) value is rejected with a clear error.
+func TestValidateCmd_ConcurrentFlag(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--concurrent", "2",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("Valid: 1"))
+
+	_, err = executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--concurrent", "0",
+	})
+	g.Expect(err).To(MatchError(ContainSubstring("--concurrent must be >= 1")))
+}
+
+// TestValidateCmd_InsecureSkipTLSVerify points --schema-location at a TLS
+// httptest server backed by a self-signed cert. The default run must fail
+// with a TLS verification error; passing the flag must make it succeed.
+func TestValidateCmd_InsecureSkipTLSVerify(t *testing.T) {
+	g := NewWithT(t)
+
+	schemaBody, err := json.Marshal(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"type": "string"},
+			"kind":       map[string]any{"type": "string"},
+			"metadata":   map[string]any{"type": "object"},
+			"spec":       map[string]any{"type": "object"},
+		},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(schemaBody)
+	}))
+	t.Cleanup(srv.Close)
+
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	// Without --insecure-skip-tls-verify the self-signed cert must be rejected.
+	_, err = executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", srv.URL + "/{{.Kind}}_{{.Version}}.json",
+	})
+	g.Expect(err).To(HaveOccurred())
+
+	// With the flag, the same run succeeds.
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", srv.URL + "/{{.Kind}}_{{.Version}}.json",
+		"--insecure-skip-tls-verify",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("Valid: 1"))
+}
+
 func TestValidateCmd_SkipKind_Invalid(t *testing.T) {
 	g := NewWithT(t)
 	manifestDir := t.TempDir()
@@ -360,10 +465,10 @@ func TestExpandSchemaLocations(t *testing.T) {
 
 	// "default" alias expands to the hosted catalog URL.
 	g.Expect(expand([]string{"default"})).
-		To(Equal([]string{defaultValidateSchemaLocation}))
+		To(Equal([]string{validator.DefaultSchemaLocation}))
 
 	g.Expect(expand([]string{"DEFAULT", "Default"})).
-		To(Equal([]string{defaultValidateSchemaLocation, defaultValidateSchemaLocation}))
+		To(Equal([]string{validator.DefaultSchemaLocation, validator.DefaultSchemaLocation}))
 
 	// Values ending in .json are taken verbatim as full templates.
 	g.Expect(expand([]string{"./local/{{.Kind}}.json"})).
@@ -371,45 +476,45 @@ func TestExpandSchemaLocations(t *testing.T) {
 
 	// Bare paths get the catalog layout appended.
 	g.Expect(expand([]string{"./my-schemas"})).
-		To(Equal([]string{"./my-schemas/" + defaultSchemaLayout}))
+		To(Equal([]string{"./my-schemas/" + validator.DefaultSchemaLayout}))
 
 	// Trailing slashes are collapsed so the result has exactly one separator.
 	g.Expect(expand([]string{"./my-schemas/"})).
-		To(Equal([]string{"./my-schemas/" + defaultSchemaLayout}))
+		To(Equal([]string{"./my-schemas/" + validator.DefaultSchemaLayout}))
 	g.Expect(expand([]string{"./my-schemas///"})).
-		To(Equal([]string{"./my-schemas/" + defaultSchemaLayout}))
+		To(Equal([]string{"./my-schemas/" + validator.DefaultSchemaLayout}))
 
 	// Backslashes are also trimmed so Windows-style paths ("\", "/") produce
 	// a clean single-separator join. Go accepts forward slashes on Windows.
 	g.Expect(expand([]string{`.\my-schemas\`})).
-		To(Equal([]string{`.\my-schemas/` + defaultSchemaLayout}))
+		To(Equal([]string{`.\my-schemas/` + validator.DefaultSchemaLayout}))
 
 	// Bare URLs get the same tail appended; protocol is untouched.
 	g.Expect(expand([]string{"https://example.com/catalog"})).
-		To(Equal([]string{"https://example.com/catalog/" + defaultSchemaLayout}))
+		To(Equal([]string{"https://example.com/catalog/" + validator.DefaultSchemaLayout}))
 
 	// URL query string is preserved on the right of the template tail so the
 	// template lands on the path, not inside the query.
 	g.Expect(expand([]string{"https://example.com/catalog?ref=main"})).
-		To(Equal([]string{"https://example.com/catalog/" + defaultSchemaLayout + "?ref=main"}))
+		To(Equal([]string{"https://example.com/catalog/" + validator.DefaultSchemaLayout + "?ref=main"}))
 
 	// URL fragment is handled the same way as a query string.
 	g.Expect(expand([]string{"https://example.com/catalog#v1"})).
-		To(Equal([]string{"https://example.com/catalog/" + defaultSchemaLayout + "#v1"}))
+		To(Equal([]string{"https://example.com/catalog/" + validator.DefaultSchemaLayout + "#v1"}))
 
 	// Trailing slash before the query is also collapsed.
 	g.Expect(expand([]string{"https://example.com/catalog/?ref=main"})).
-		To(Equal([]string{"https://example.com/catalog/" + defaultSchemaLayout + "?ref=main"}))
+		To(Equal([]string{"https://example.com/catalog/" + validator.DefaultSchemaLayout + "?ref=main"}))
 
 	// Mixed inputs preserve order and apply each rule independently.
 	g.Expect(expand([]string{"default", "./local/{{.Kind}}.json"})).
-		To(Equal([]string{defaultValidateSchemaLocation, "./local/{{.Kind}}.json"}))
+		To(Equal([]string{validator.DefaultSchemaLocation, "./local/{{.Kind}}.json"}))
 
 	g.Expect(expand([]string{"./local/{{.Kind}}.json", "default"})).
-		To(Equal([]string{"./local/{{.Kind}}.json", defaultValidateSchemaLocation}))
+		To(Equal([]string{"./local/{{.Kind}}.json", validator.DefaultSchemaLocation}))
 
 	g.Expect(expand([]string{"default", "./my-schemas"})).
-		To(Equal([]string{defaultValidateSchemaLocation, "./my-schemas/" + defaultSchemaLayout}))
+		To(Equal([]string{validator.DefaultSchemaLocation, "./my-schemas/" + validator.DefaultSchemaLayout}))
 
 	_, err := expandSchemaLocations([]string{""})
 	g.Expect(err).To(MatchError(ContainSubstring("--schema-location must not be empty")))

--- a/internal/validator/defaults.go
+++ b/internal/validator/defaults.go
@@ -1,0 +1,19 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+// DefaultSchemaLocation points at the flux-schema catalog, covering the
+// latest stable Kubernetes and Flux APIs. It is used when no schema location
+// is configured, and is the target that the literal value "default" resolves
+// to in the validate CLI's --schema-location flag.
+const DefaultSchemaLocation = "https://raw.githubusercontent.com/fluxcd/flux-schema/main/catalog/latest/" + DefaultSchemaLayout
+
+// DefaultSchemaLayout is the Go-template tail appended to any schema location
+// value that doesn't already end in ".json", so a bare path/URL like
+// "./my-schemas" expands to "./my-schemas/{{.Group}}/{{.Kind}}_{{.Version}}.json".
+const DefaultSchemaLayout = "{{.Group}}/{{.Kind}}_{{.Version}}.json"
+
+// DefaultWorkers is the fallback concurrency level used
+// by ValidateSources when Options.Workers is left at 0.
+const DefaultWorkers = 8

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -6,8 +6,10 @@ package validator
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
@@ -25,8 +27,6 @@ import (
 )
 
 const (
-	defaultWorkers = 8
-
 	extYAML = ".yaml"
 	extYML  = ".yml"
 )
@@ -89,13 +89,18 @@ func (r Result) Identifier() string {
 }
 
 // Options configures a Validator.
+//
+// InsecureSkipTLSVerify is only applied when HTTPClient is nil and the
+// validator constructs its own client. Callers who supply HTTPClient are
+// responsible for configuring TLS on that client themselves.
 type Options struct {
-	SchemaLocations    []string
-	SkipMissingSchemas bool
-	SkipKinds          []string
-	HTTPClient         *retryablehttp.Client
-	HTTPTimeout        time.Duration
-	Workers            int
+	SchemaLocations       []string
+	SkipMissingSchemas    bool
+	SkipKinds             []string
+	HTTPClient            *retryablehttp.Client
+	HTTPTimeout           time.Duration
+	Workers               int
+	InsecureSkipTLSVerify bool
 }
 
 // Validator resolves and applies JSON Schemas to Kubernetes manifests.
@@ -162,11 +167,14 @@ func New(opts Options) (*Validator, error) {
 		templates[i] = tpl
 	}
 	if opts.Workers <= 0 {
-		opts.Workers = defaultWorkers
+		opts.Workers = DefaultWorkers
 	}
 	if opts.HTTPClient == nil {
 		c := retryablehttp.NewClient()
 		c.Logger = nil
+		if opts.InsecureSkipTLSVerify {
+			applyInsecureTLS(c)
+		}
 		opts.HTTPClient = c
 	}
 
@@ -267,6 +275,14 @@ func (v *Validator) ValidateSources(ctx context.Context, paths []string) <-chan 
 
 		close(jobs)
 		workerWG.Wait()
+		// Drain any jobs that workers left behind when ctx was cancelled:
+		// streamFile calls sourceWG.Add(1) before the send, and a worker's
+		// select may pick <-ctx.Done() over <-jobs even when both are ready,
+		// leaving queued jobs with unbalanced Add counts. Without this drain
+		// per-source waiters would block forever and results would never close.
+		for j := range jobs {
+			j.sourceWG.Done()
+		}
 		waiterWG.Wait()
 		close(results)
 	}()
@@ -570,6 +586,24 @@ func computeName(metadata map[string]any, docIndex int) (string, bool) {
 		return generateName + "{{ generateName }}", true
 	}
 	return fmt.Sprintf("#%d", docIndex), false
+}
+
+// applyInsecureTLS clones the retryablehttp client's underlying transport and
+// enables InsecureSkipVerify on its TLS config. Cloning avoids mutating the
+// shared cleanhttp default transport, which would leak the setting into
+// unrelated HTTP clients in the same process.
+func applyInsecureTLS(c *retryablehttp.Client) {
+	t, ok := c.HTTPClient.Transport.(*http.Transport)
+	if !ok {
+		t = &http.Transport{}
+	} else {
+		t = t.Clone()
+	}
+	if t.TLSClientConfig == nil {
+		t.TLSClientConfig = &tls.Config{}
+	}
+	t.TLSClientConfig.InsecureSkipVerify = true
+	c.HTTPClient.Transport = t
 }
 
 // flattenErrors walks a ValidationError tree and returns one entry per leaf


### PR DESCRIPTION
Add flags to `flux-schema validate`:

- `--fail-fast`: Exit after the first invalid document
- `--concurrent`: Number of concurrent workers (default 8)
- `--insecure-skip-tls-verify`: Disable TLS certificate verification when fetching schemas over HTTPS