### PR TITLE
Add support for config file to set default validate flags

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,10 +21,17 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
+      - name: Setup Flux CLI
+        uses: fluxcd/flux2/action@04acaec6161ac4fb1a82ffafa88901c03271d34f # v2.8.6
       - name: Run tests
         run: make test
       - name: Run linters
         run: make lint
+      - name: Build binary
+        run: make build
+      - name: Run smoke test
+        run: |
+          flux install --export | ./bin/flux-schema validate -v --schema-location ./catalog/latest
       - name: Check if working tree is dirty
         run: |
           if [[ $(git diff --stat) != '' ]]; then

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Flux CLI plugin for Kubernetes schema extraction and manifests validation.
     - `--concurrent`: Number of concurrent workers (default 8)
     - `--insecure-skip-tls-verify`: Disable TLS certificate verification when fetching schemas over HTTPS
     - `-v, --verbose`: Print a line for every document, including valid and skipped ones
+    - `--config`: Path to a YAML file supplying default values for validate flags (env: `FLUX_SCHEMA_CONFIG`)
 - `flux-schema extract crd [files...]`: Extract JSON Schema from Kubernetes CRD YAMLs
   - `-d, --output-dir`: Directory to write JSON Schema files to (mutually exclusive with `--output-archive`)
   - `-a, --output-archive`: Path to write a gzipped tar archive of JSON Schema files to
@@ -38,8 +39,8 @@ The validate command reads Kubernetes YAML manifests from one or more files or d
 and validates each document against a JSON Schema resolved from its `apiVersion` and `kind`.
 
 When no `--schema-location` is given, validate uses the [flux-schema catalog](catalog/README.md),
-which covers the latest stable Kubernetes APIs and the Flux ecosystem CRDs (Flux toolkit
-controllers and the Flux Operator):
+which covers the latest Kubernetes APIs, the stable channel of Gateway API,
+and the Flux CRDs (controllers and operator):
 
 ```shell
 flux-schema validate ./manifests
@@ -63,7 +64,7 @@ flux-schema validate ./manifests \
 
 Template variables are `.Group`, `.GroupPrefix`, `.Kind`, and `.Version`.
 
-The `--schema-location` flag is repeatable and locations are tried in order — the first match wins.
+The `--schema-location` flag is repeatable and locations are tried in order (the first match wins).
 Pass the literal value `default` to include the flux-schema catalog alongside your own schemas:
 
 ```shell
@@ -98,7 +99,7 @@ Summary: 4 resources found in 1 file - Valid: 1, Invalid: 2, Skipped: 1
 
 A non-zero exit code is returned when any document is invalid or errored.
 
-Validation is strict by default:
+#### Validation rules
 
 - YAML documents with duplicate keys are rejected matching Flux behavior.
 - Documents missing both `metadata.name` and `metadata.generateName` are flagged as invalid
@@ -107,6 +108,42 @@ Validation is strict by default:
   so undocumented fields under `spec` fail validation.
 - String formats `duration`, `date`, `datetime`/`date-time`, and `time` are validated
   matching Kubernetes API conventions.
+
+#### Config file
+
+Flag values can be pre-set in a YAML config file and referenced with `--config`
+or with the `FLUX_SCHEMA_CONFIG` environment variable.
+This keeps long invocations out of CI scripts and makes validation reproducible
+across developers:
+
+```shell
+flux-schema validate ./manifests --config .flux-schema.yaml
+```
+
+The file has a `version` (required, must be `"1"`) and a `validate` section
+whose keys mirror the CLI flag names:
+
+```yaml
+version: "1"
+validate:
+  schema-location:
+    - default
+    - https://raw.githubusercontent.com/datreeio/CRDs-catalog/main
+  skip-kind:
+    - v1/Secret
+    - source.toolkit.fluxcd.io/v1/ExternalArtifact
+  skip-missing-schemas: false
+  verbose: true
+  fail-fast: false
+  concurrent: 8
+  insecure-skip-tls-verify: false
+```
+
+Rules:
+
+- CLI flags override config values. Setting `--verbose=false` wins over `verbose: true` in the file.
+- Setting `--config` overrides `FLUX_SCHEMA_CONFIG`. When both are set, the flag wins and the env var is ignored.
+- Manifest paths stay positional. The config file configures how to validate; paths are given on the command line.
 
 ### Kubernetes CRD Extraction
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ flux-schema validate ./manifests \
   --schema-location './schemas/{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json'
 ```
 
-Manifests can also be piped via `/dev/stdin` and certain documents skipped with `--skip-kind`:
+Manifests can also be piped in and certain documents skipped with `--skip-kind`:
 
 ```shell
-kustomize build . | flux-schema validate /dev/stdin \
+kustomize build . | flux-schema validate \
   --skip-kind 'v1/Secret' \
   --skip-kind 'source.toolkit.fluxcd.io/v1/ExternalArtifact'
 ```
@@ -118,7 +118,7 @@ Generate schemas for every CRD installed in a cluster, using the
 per-group-directory layout:
 
 ```shell
-kubectl get crds -o yaml | flux-schema extract crd /dev/stdin -d ./schemas
+kubectl get crds -o yaml | flux-schema extract crd -d ./schemas
 ```
 
 You can supply `-f, --output-format` with a Go template to change the layout, e.g. the
@@ -135,7 +135,7 @@ To bundle the schemas into a gzipped tar archive instead of writing to a directo
 use `-a, --output-archive`:
 
 ```shell
-kustomize build config/crd | flux-schema extract crd /dev/stdin -a dist/crd-schemas.tar.gz
+kustomize build config/crd | flux-schema extract crd -a dist/crd-schemas.tar.gz
 ```
 
 The archive path must end in `.tar.gz` or `.tgz`, and its parent directory is created if missing.
@@ -178,7 +178,7 @@ flux-schema extract k8s --version 1.35.0 -d ./schemas
 Supply the swagger file from the cluster:
 
 ```shell
-kubectl get --raw /openapi/v2 | flux-schema extract k8s /dev/stdin -d ./schemas
+kubectl get --raw /openapi/v2 | flux-schema extract k8s -d ./schemas
 ```
 
 The same `-f, --output-format` template used by `extract crd` works here, so the

--- a/cmd/flux-schema/config.go
+++ b/cmd/flux-schema/config.go
@@ -1,0 +1,81 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+)
+
+const supportedConfigVersion = "1"
+
+// envConfigFile names the environment variable that points at a default
+// --config path. The CLI flag wins when both are set.
+const envConfigFile = "FLUX_SCHEMA_CONFIG"
+
+type configFile struct {
+	Version  string          `json:"version"`
+	Validate *validateConfig `json:"validate,omitempty"`
+}
+
+type validateConfig struct {
+	SchemaLocations       []string `json:"schema-location,omitempty"`
+	SkipMissingSchemas    bool     `json:"skip-missing-schemas,omitempty"`
+	SkipKinds             []string `json:"skip-kind,omitempty"`
+	Verbose               bool     `json:"verbose,omitempty"`
+	FailFast              bool     `json:"fail-fast,omitempty"`
+	Concurrent            *int     `json:"concurrent,omitempty"`
+	InsecureSkipTLSVerify bool     `json:"insecure-skip-tls-verify,omitempty"`
+}
+
+func loadConfigFile(path string) (*configFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var cfg configFile
+	if err := yaml.UnmarshalStrict(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if cfg.Version != supportedConfigVersion {
+		return nil, fmt.Errorf("config %s: unsupported version %q (want %q)",
+			path, cfg.Version, supportedConfigVersion)
+	}
+	return &cfg, nil
+}
+
+// applyValidateConfig copies cfg values into args for flags not set on the CLI,
+// giving CLI > config > defaults precedence. Nil cfg is a no-op so callers can
+// pass cfg.Validate directly without a nil check.
+func applyValidateConfig(cmd *cobra.Command, cfg *validateConfig, args *validateFlags) {
+	if cfg == nil {
+		return
+	}
+	flags := cmd.Flags()
+
+	if cfg.SchemaLocations != nil && !flags.Changed("schema-location") {
+		args.schemaLocations = cfg.SchemaLocations
+	}
+	if !flags.Changed("skip-missing-schemas") {
+		args.skipMissingSchemas = cfg.SkipMissingSchemas
+	}
+	if cfg.SkipKinds != nil && !flags.Changed("skip-kind") {
+		args.skipKinds = cfg.SkipKinds
+	}
+	if !flags.Changed("verbose") {
+		args.verbose = cfg.Verbose
+	}
+	if !flags.Changed("fail-fast") {
+		args.failFast = cfg.FailFast
+	}
+	if cfg.Concurrent != nil && !flags.Changed("concurrent") {
+		args.concurrent = *cfg.Concurrent
+	}
+	if !flags.Changed("insecure-skip-tls-verify") {
+		args.insecureSkipTLSVerify = cfg.InsecureSkipTLSVerify
+	}
+}

--- a/cmd/flux-schema/extract_crd.go
+++ b/cmd/flux-schema/extract_crd.go
@@ -33,9 +33,8 @@ var extractCRDCmd = &cobra.Command{
     --output-format '{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json'
 
   # Extract all schemas and store them in a tar.gz archive
-  kustomize build config/crd | flux-schema extract crd /dev/stdin \
+  kustomize build config/crd | flux-schema extract crd \
     --output-archive dist/crd-schemas.tar.gz`,
-	Args: cobra.MinimumNArgs(1),
 	RunE: extractCRDCmdRun,
 }
 
@@ -58,6 +57,11 @@ func init() {
 }
 
 func extractCRDCmdRun(cmd *cobra.Command, args []string) error {
+	inputs, err := resolveStdinArgs(args)
+	if err != nil {
+		return err
+	}
+
 	archive := extractCRDArgs.outputArchive
 	destDir := extractCRDArgs.Dir
 	if archive != "" {
@@ -83,8 +87,8 @@ func extractCRDCmdRun(cmd *cobra.Command, args []string) error {
 		failures []error
 		written  int
 	)
-	for _, path := range args {
-		data, err := os.ReadFile(path)
+	for _, path := range inputs {
+		data, err := readSource(path)
 		if err != nil {
 			failures = append(failures, fmt.Errorf("%s: %w", path, err))
 			continue

--- a/cmd/flux-schema/extract_crd_test.go
+++ b/cmd/flux-schema/extract_crd_test.go
@@ -224,6 +224,38 @@ spec:
 	g.Expect(string(data)).ToNot(ContainSubstring(`"description"`))
 }
 
+func TestExtractCRDCmd_StdinDash(t *testing.T) {
+	g := NewWithT(t)
+	outDir := t.TempDir()
+	replaceStdin(t, minimalCRDYAML)
+
+	_, err := executeCommand([]string{"extract", "crd", "-", "--output-dir", outDir})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	got, err := os.ReadFile(filepath.Join(outDir, "example.com", "widget_v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(got)).To(Equal(minimalCRDGolden))
+}
+
+func TestExtractCRDCmd_StdinBare(t *testing.T) {
+	g := NewWithT(t)
+	outDir := t.TempDir()
+	replaceStdin(t, minimalCRDYAML)
+
+	_, err := executeCommand([]string{"extract", "crd", "--output-dir", outDir})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, err = os.Stat(filepath.Join(outDir, "example.com", "widget_v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestExtractCRDCmd_NoArgsNoPipe(t *testing.T) {
+	g := NewWithT(t)
+	forceStdinTTY(t)
+	_, err := executeCommand([]string{"extract", "crd", "--output-dir", t.TempDir()})
+	g.Expect(err).To(MatchError(ContainSubstring("no input")))
+}
+
 func writeCRDFixture(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "fixture.yaml")

--- a/cmd/flux-schema/extract_k8s.go
+++ b/cmd/flux-schema/extract_k8s.go
@@ -35,7 +35,7 @@ var extractK8sCmd = &cobra.Command{
   flux-schema extract k8s swagger.json -d ./schemas
 
   # Pipe from stdin
-  kubectl get --raw /openapi/v2 | flux-schema extract k8s /dev/stdin -d ./schemas`,
+  kubectl get --raw /openapi/v2 | flux-schema extract k8s -d ./schemas`,
 	Args: requireFileOrVersion,
 	RunE: extractK8sCmdRun,
 }
@@ -59,8 +59,8 @@ func init() {
 var k8sVersionRe = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
 
 // requireFileOrVersion enforces mutual exclusion between a single positional
-// swagger file and --version. Cobra's MarkFlagsMutuallyExclusive only covers
-// flag pairs.
+// swagger file (or piped stdin) and --version. Cobra's
+// MarkFlagsMutuallyExclusive only covers flag pairs.
 func requireFileOrVersion(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 {
 		return fmt.Errorf("accepts at most 1 positional argument, received %d", len(args))
@@ -69,16 +69,21 @@ func requireFileOrVersion(cmd *cobra.Command, args []string) error {
 	switch {
 	case hasVersion && len(args) == 1:
 		return fmt.Errorf("--version and a swagger file are mutually exclusive")
-	case !hasVersion && len(args) == 0:
-		return fmt.Errorf("either a swagger file or --version is required")
+	case !hasVersion && len(args) == 0 && !stdinIsPiped():
+		return fmt.Errorf("either a swagger file, piped stdin, or --version is required")
 	}
 	return nil
 }
 
 func extractK8sCmdRun(cmd *cobra.Command, args []string) error {
+	// --version mode skips positional input and falls through to fetchK8sSwagger.
 	var arg string
-	if len(args) == 1 {
-		arg = args[0]
+	if extractK8sArgs.k8sVersion == "" {
+		inputs, err := resolveStdinArgs(args)
+		if err != nil {
+			return err
+		}
+		arg = inputs[0]
 	}
 	client := newDefaultK8sHTTPClient()
 	ctx := cmd.Context()
@@ -172,7 +177,7 @@ func resolveK8sInput(ctx context.Context, client *retryablehttp.Client,
 	urlTemplate, arg, version string, timeout time.Duration,
 ) (string, []byte, error) {
 	if arg != "" {
-		data, err := os.ReadFile(arg)
+		data, err := readSource(arg)
 		if err != nil {
 			return "", nil, fmt.Errorf("read %s: %w", arg, err)
 		}

--- a/cmd/flux-schema/extract_k8s_test.go
+++ b/cmd/flux-schema/extract_k8s_test.go
@@ -80,11 +80,35 @@ func TestExtractK8sCmd_StripDescription(t *testing.T) {
 	g.Expect(string(data)).ToNot(ContainSubstring(`"description"`))
 }
 
+func TestExtractK8sCmd_StdinDash(t *testing.T) {
+	g := NewWithT(t)
+	outDir := t.TempDir()
+	replaceStdin(t, minimalSwagger)
+
+	out, err := executeCommand([]string{"extract", "k8s", "-", "--output-dir", outDir})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("reading stdin"))
+	_, err = os.Stat(filepath.Join(outDir, "example.com", "widget_v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestExtractK8sCmd_StdinBare(t *testing.T) {
+	g := NewWithT(t)
+	outDir := t.TempDir()
+	replaceStdin(t, minimalSwagger)
+
+	_, err := executeCommand([]string{"extract", "k8s", "--output-dir", outDir})
+	g.Expect(err).ToNot(HaveOccurred())
+	_, err = os.Stat(filepath.Join(outDir, "example.com", "widget_v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
 func TestExtractK8sCmd_NoInput(t *testing.T) {
 	g := NewWithT(t)
+	forceStdinTTY(t)
 	_, err := executeCommand([]string{"extract", "k8s"})
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("either a swagger file or --version is required"))
+	g.Expect(err.Error()).To(ContainSubstring("either a swagger file, piped stdin, or --version is required"))
 }
 
 func TestExtractK8sCmd_FileAndVersion(t *testing.T) {
@@ -221,9 +245,7 @@ func TestFetchK8sSwagger_NotFound(t *testing.T) {
 }
 
 func TestExtractK8sCmd_VersionFetch(t *testing.T) {
-	// Exercises the full --version path by monkey-patching the URL template.
-	// The httptest server-based fetch is tested directly in TestFetchK8sSwagger_*.
-	// This asserts the CLI wiring: version + output-dir produces a schema file.
+	// Exercises the --version path via a monkey-patched URL template.
 	g := NewWithT(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/flux-schema/main_test.go
+++ b/cmd/flux-schema/main_test.go
@@ -5,7 +5,10 @@ package main
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"os"
+	"syscall"
 	"testing"
 	"time"
 
@@ -42,8 +45,6 @@ func executeCommand(args []string) (string, error) {
 	return buf.String(), err
 }
 
-// resetCmdArgs resets the command arguments
-// to their default values.
 func resetCmdArgs() {
 	rootArgs.timeout = timeout
 
@@ -64,4 +65,44 @@ func resetFlagChanged(cmd *cobra.Command) {
 	for _, sub := range cmd.Commands() {
 		resetFlagChanged(sub)
 	}
+}
+
+// replaceStdin points both os.Stdin and stdinReader at a pipe so the
+// stdinIsPiped fd-mode check and every read site see the same stream.
+// The writer goroutine is joined on cleanup so oversized payloads
+// (bigger than the ~64 KiB kernel pipe buffer) fail instead of hanging.
+func replaceStdin(t *testing.T, data string) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	origStdin := os.Stdin
+	origReader := stdinReader
+	os.Stdin = r
+	stdinReader = r
+	done := make(chan error, 1)
+	go func() {
+		_, werr := w.Write([]byte(data))
+		_ = w.Close()
+		done <- werr
+	}()
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		stdinReader = origReader
+		_ = r.Close()
+		// EPIPE/ErrClosedPipe are expected when a test returns before draining.
+		if err := <-done; err != nil && !errors.Is(err, syscall.EPIPE) && !errors.Is(err, io.ErrClosedPipe) {
+			t.Errorf("stdin writer: %v", err)
+		}
+	})
+}
+
+// forceStdinTTY pins stdinIsPiped() to false so no-pipe assertions pass
+// regardless of how `go test` was invoked.
+func forceStdinTTY(t *testing.T) {
+	t.Helper()
+	orig := stdinIsPiped
+	stdinIsPiped = func() bool { return false }
+	t.Cleanup(func() { stdinIsPiped = orig })
 }

--- a/cmd/flux-schema/stdin.go
+++ b/cmd/flux-schema/stdin.go
@@ -1,0 +1,84 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+
+	"github.com/fluxcd/flux-schema/internal/validator"
+)
+
+const stdinLabel = validator.StdinSource
+
+// stdinReader is the single source of truth for the stdin stream across
+// every subcommand: readSource buffers from it for extract commands, and
+// validate passes it as Options.Stdin so the validator streams from the
+// same reader. A package variable so tests swap one thing rather than
+// swapping os.Stdin and chasing every read site.
+var stdinReader io.Reader = os.Stdin
+
+// isStdinSentinel reports whether arg refers to the process's standard input.
+// "-" is the cross-platform convention; "/dev/stdin" is kept as a Unix
+// back-compat alias so existing scripts don't break.
+func isStdinSentinel(arg string) bool {
+	return arg == "-" || arg == "/dev/stdin"
+}
+
+// stdinIsPiped reports whether os.Stdin has data attached (pipe or redirect)
+// rather than a terminal. Exposed as a package variable so tests can force
+// a deterministic result regardless of how `go test` was invoked.
+var stdinIsPiped = func() bool {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) == 0
+}
+
+// resolveStdinArgs normalizes positional arguments so every caller treats
+// stdin identically. Four cases:
+//
+//   - args is empty AND stdin is piped → [stdinLabel]. Users can run
+//     "cmd | flux-schema validate" without any sentinel.
+//   - args is empty AND stdin is a terminal → error. Without this guard the
+//     command would block on an empty read.
+//   - args contains more than one stdin sentinel → error. Stdin is a
+//     single non-rewindable stream and cannot serve as two sources.
+//   - otherwise → each arg is returned as-is except a single stdin sentinel
+//     ("-", "/dev/stdin") which is replaced with stdinLabel so downstream
+//     code sees a single canonical source name.
+func resolveStdinArgs(args []string) ([]string, error) {
+	if len(args) == 0 {
+		if !stdinIsPiped() {
+			return nil, errors.New("no input: pass a path or pipe data to stdin")
+		}
+		return []string{stdinLabel}, nil
+	}
+	out := make([]string, len(args))
+	stdinCount := 0
+	for i, a := range args {
+		if isStdinSentinel(a) {
+			stdinCount++
+			out[i] = stdinLabel
+		} else {
+			out[i] = a
+		}
+	}
+	if stdinCount > 1 {
+		return nil, errors.New("stdin may only be referenced once per command")
+	}
+	return out, nil
+}
+
+// readSource reads the full contents of path, or the stdinReader if path
+// is the stdin label. Used by commands that buffer input fully (extract
+// crd/k8s) rather than streaming it through the validator.
+func readSource(path string) ([]byte, error) {
+	if path == stdinLabel {
+		return io.ReadAll(stdinReader)
+	}
+	return os.ReadFile(path)
+}

--- a/cmd/flux-schema/validate.go
+++ b/cmd/flux-schema/validate.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"slices"
 	"sort"
 	"strings"
@@ -41,7 +42,10 @@ var validateCmd = &cobra.Command{
   # Skip specific kinds by Kind or apiVersion/Kind
   flux-schema validate ./manifests \
     --skip-kind Secret \
-    --skip-kind source.toolkit.fluxcd.io/v1/GitRepository`,
+    --skip-kind source.toolkit.fluxcd.io/v1/GitRepository
+
+  # Load flag defaults from a checked-in YAML config (CLI flags still override)
+  flux-schema validate ./manifests --config .flux-schema.yaml`,
 	RunE: validateCmdRun,
 }
 
@@ -53,6 +57,7 @@ type validateFlags struct {
 	failFast              bool
 	concurrent            int
 	insecureSkipTLSVerify bool
+	configFile            string
 }
 
 var validateArgs = validateFlags{
@@ -74,10 +79,26 @@ func init() {
 		"number of concurrent workers")
 	validateCmd.Flags().BoolVar(&validateArgs.insecureSkipTLSVerify, "insecure-skip-tls-verify", false,
 		"disable TLS certificate verification when fetching schemas over HTTPS")
+	validateCmd.Flags().StringVar(&validateArgs.configFile, "config", "",
+		"path to a YAML file supplying default values for validate flags "+
+			"(env: "+envConfigFile+")")
+	_ = validateCmd.MarkFlagFilename("config", "yaml", "yml")
 	rootCmd.AddCommand(validateCmd)
 }
 
 func validateCmdRun(cmd *cobra.Command, args []string) error {
+	configPath := validateArgs.configFile
+	if configPath == "" {
+		configPath = os.Getenv(envConfigFile)
+	}
+	if configPath != "" {
+		cfg, err := loadConfigFile(configPath)
+		if err != nil {
+			return err
+		}
+		applyValidateConfig(cmd, cfg.Validate, &validateArgs)
+	}
+
 	inputs, err := resolveStdinArgs(args)
 	if err != nil {
 		return err

--- a/cmd/flux-schema/validate.go
+++ b/cmd/flux-schema/validate.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -32,7 +33,7 @@ var validateCmd = &cobra.Command{
     --schema-location './schemas/{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json'
 
   # Read manifests from a pipe and add remote schema fallback
-  kustomize build . | flux-schema validate /dev/stdin \
+  kustomize build . | flux-schema validate \
     --schema-location default \
     --schema-location ./crd-schemas \
     --schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main
@@ -41,7 +42,6 @@ var validateCmd = &cobra.Command{
   flux-schema validate ./manifests \
     --skip-kind Secret \
     --skip-kind source.toolkit.fluxcd.io/v1/GitRepository`,
-	Args: cobra.MinimumNArgs(1),
 	RunE: validateCmdRun,
 }
 
@@ -58,8 +58,6 @@ type validateFlags struct {
 var validateArgs = validateFlags{
 	concurrent: validator.DefaultWorkers,
 }
-
-const stdinPath = "/dev/stdin"
 
 func init() {
 	validateCmd.Flags().StringArrayVar(&validateArgs.schemaLocations, "schema-location", nil,
@@ -80,13 +78,18 @@ func init() {
 }
 
 func validateCmdRun(cmd *cobra.Command, args []string) error {
+	inputs, err := resolveStdinArgs(args)
+	if err != nil {
+		return err
+	}
+
 	locations := validateArgs.schemaLocations
 	if len(locations) == 0 {
 		locations = []string{validator.DefaultSchemaLocation}
 	} else {
-		expanded, err := expandSchemaLocations(locations)
-		if err != nil {
-			return err
+		expanded, lerr := expandSchemaLocations(locations)
+		if lerr != nil {
+			return lerr
 		}
 		locations = expanded
 	}
@@ -95,14 +98,18 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--concurrent must be >= 1, got %d", validateArgs.concurrent)
 	}
 
-	v, err := validator.New(validator.Options{
+	opts := validator.Options{
 		SchemaLocations:       locations,
 		SkipMissingSchemas:    validateArgs.skipMissingSchemas,
 		SkipKinds:             validateArgs.skipKinds,
 		HTTPTimeout:           rootArgs.timeout,
 		Workers:               validateArgs.concurrent,
 		InsecureSkipTLSVerify: validateArgs.insecureSkipTLSVerify,
-	})
+	}
+	if slices.Contains(inputs, stdinLabel) {
+		opts.Stdin = stdinReader
+	}
+	v, err := validator.New(opts)
 	if err != nil {
 		return err
 	}
@@ -110,7 +117,7 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
-	stdinOnly := len(args) == 1 && args[0] == stdinPath
+	stdinOnly := len(inputs) == 1 && inputs[0] == stdinLabel
 
 	files := make(map[string]struct{})
 	var nValid, nInvalid, nSkipped int
@@ -183,7 +190,7 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	for r := range v.ValidateSources(ctx, args) {
+	for r := range v.ValidateSources(ctx, inputs) {
 		if r.Final {
 			completed[r.Source] = true
 			tryAdvance()
@@ -209,11 +216,8 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 			flushContiguous(r.Source)
 		}
 
-		// --fail-fast: cancel the validator on the first invalid result.
-		// Workers see ctx.Done() and return; ValidateSources closes the
-		// channel after draining the pool, so the loop exits cleanly and
-		// the defensive flush below prints any buffered invalid result
-		// even when an earlier source never reached its Final sentinel.
+		// Fail-fast cancels mid-stream; the defensive flush below still prints
+		// any buffered invalid even when an earlier source lost its Final.
 		if validateArgs.failFast && r.Status == validator.StatusInvalid {
 			cancel()
 		}

--- a/cmd/flux-schema/validate_test.go
+++ b/cmd/flux-schema/validate_test.go
@@ -454,6 +454,226 @@ func TestValidateCmd_SkipKind_Invalid(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("skip kind pattern")))
 }
 
+func TestValidateCmd_Config_AppliesFlagValues(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	cfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "1"
+validate:
+  verbose: true
+  skip-kind:
+    - Widget
+`)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--config", cfg,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("Widget/default/ok-widget is skipped: kind skipped"))
+	g.Expect(out).To(ContainSubstring("Valid: 0, Invalid: 0, Skipped: 1"))
+}
+
+func TestValidateCmd_Config_CLIOverridesBool(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	cfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "1"
+validate:
+  verbose: true
+`)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--config", cfg,
+		"--verbose=false",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).ToNot(ContainSubstring("is valid"))
+	g.Expect(out).To(ContainSubstring("Valid: 1"))
+}
+
+// CLI --skip-kind replaces (does not merge with) the config's skip-kind list.
+func TestValidateCmd_Config_CLIOverridesSlice(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	cfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "1"
+validate:
+  skip-kind:
+    - Widget
+`)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--config", cfg,
+		"--skip-kind", "Secret",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("Valid: 1, Invalid: 0, Skipped: 0"))
+}
+
+// Covers both *int apply paths: absent key preserves the default, explicit
+// value (here 0) is applied and trips the >=1 guard.
+func TestValidateCmd_Config_Concurrent(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	cfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "1"
+validate:
+  verbose: true
+`)
+	_, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--config", cfg,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cfgZero := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "1"
+validate:
+  concurrent: 0
+`)
+	_, err = executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--config", cfgZero,
+	})
+	g.Expect(err).To(MatchError(ContainSubstring("--concurrent must be >= 1")))
+}
+
+func TestValidateCmd_Config_NoValidateSection(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	cfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "1"
+`)
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--config", cfg,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("Valid: 1"))
+}
+
+func TestValidateCmd_Config_VersionMissing(t *testing.T) {
+	g := NewWithT(t)
+	cfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `validate:
+  verbose: true
+`)
+	_, err := executeCommand([]string{"validate", "--config", cfg})
+	g.Expect(err).To(MatchError(ContainSubstring(`unsupported version ""`)))
+}
+
+func TestValidateCmd_Config_VersionUnsupported(t *testing.T) {
+	g := NewWithT(t)
+	cfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "2"
+validate:
+  verbose: true
+`)
+	_, err := executeCommand([]string{"validate", "--config", cfg})
+	g.Expect(err).To(MatchError(ContainSubstring(`unsupported version "2"`)))
+}
+
+func TestValidateCmd_Config_StrictUnknownKey(t *testing.T) {
+	g := NewWithT(t)
+	cfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "1"
+validate:
+  skip_kind:
+    - Secret
+`)
+	_, err := executeCommand([]string{"validate", "--config", cfg})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("skip_kind"))
+}
+
+func TestValidateCmd_Config_StrictUnknownSection(t *testing.T) {
+	g := NewWithT(t)
+	cfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "1"
+extracft:
+  verbose: true
+`)
+	_, err := executeCommand([]string{"validate", "--config", cfg})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("extracft"))
+}
+
+func TestValidateCmd_Config_FileNotFound(t *testing.T) {
+	g := NewWithT(t)
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	_, err := executeCommand([]string{"validate", "--config", missing})
+	g.Expect(err).To(MatchError(ContainSubstring("read " + missing)))
+}
+
+// FLUX_SCHEMA_CONFIG env var is consulted when --config is not passed.
+func TestValidateCmd_Config_EnvVar(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	cfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "1"
+validate:
+  skip-kind:
+    - Widget
+`)
+	t.Setenv("FLUX_SCHEMA_CONFIG", cfg)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("Skipped: 1"))
+}
+
+// --config wins over FLUX_SCHEMA_CONFIG when both are set.
+func TestValidateCmd_Config_FlagBeatsEnvVar(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	// Env var config has unsupported version — must not be read.
+	envCfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "99"`)
+	t.Setenv("FLUX_SCHEMA_CONFIG", envCfg)
+
+	flagCfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "1"
+validate:
+  skip-kind:
+    - Widget
+`)
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--config", flagCfg,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("Skipped: 1"))
+}
+
+func TestValidateCmd_Config_MalformedYAML(t *testing.T) {
+	g := NewWithT(t)
+	cfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml",
+		"version: \"1\"\nvalidate:\n\tverbose: true\n") // tabs are illegal indent
+	_, err := executeCommand([]string{"validate", "--config", cfg})
+	g.Expect(err).To(MatchError(ContainSubstring("parse " + cfg)))
+}
+
 func TestExpandSchemaLocations(t *testing.T) {
 	g := NewWithT(t)
 

--- a/cmd/flux-schema/validate_test.go
+++ b/cmd/flux-schema/validate_test.go
@@ -16,11 +16,8 @@ import (
 	"github.com/fluxcd/flux-schema/internal/validator"
 )
 
-// extractWidgetSchema runs the extract crd command on minimalCRDYAML and returns
-// the schema directory. Dogfoods extract → validate round-trip so tests
-// exercise the real artifact users will point validate at. Pins the flat
-// kubeval-style layout so validate tests keep exercising a single
-// --schema-location template regardless of the extract default.
+// extractWidgetSchema dogfoods the extract → validate round-trip so
+// validate tests run against the real artifact users produce.
 func extractWidgetSchema(t *testing.T) string {
 	t.Helper()
 	g := NewWithT(t)
@@ -76,7 +73,6 @@ func TestValidateCmd_ValidManifest_QuietNoOutput(t *testing.T) {
 		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
 	})
 	g.Expect(err).ToNot(HaveOccurred())
-	// Quiet mode: no per-doc lines, only the summary.
 	g.Expect(out).ToNot(ContainSubstring("is valid"))
 	g.Expect(out).To(ContainSubstring("Summary: 1 resource found in 1 file - Valid: 1, Invalid: 0, Skipped: 0"))
 }
@@ -93,7 +89,6 @@ func TestValidateCmd_InvalidManifest_PrintsViolationAndFails(t *testing.T) {
 	})
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(out).To(ContainSubstring(path + " - Widget/default/bad-widget is invalid: schema validation failed"))
-	// Two-level rendering: one indented line per violation.
 	g.Expect(out).To(MatchRegexp(`(?m)^  - /spec/name: `))
 	g.Expect(out).To(ContainSubstring("Summary: 1 resource found in 1 file - Valid: 0, Invalid: 1, Skipped: 0"))
 }
@@ -199,26 +194,17 @@ func TestValidateCmd_FluxManifestsFixtures(t *testing.T) {
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 
-	// Spot-check one line from each file to prove both sources were walked
-	// and that identifiers render as Kind/Namespace/Name.
 	g.Expect(out).To(ContainSubstring(reconcilersPath + " - HelmRelease/apps/webapp is valid"))
 	g.Expect(out).To(ContainSubstring(sourcesPath + " - Bucket/default/minio-bucket is valid"))
 
-	// The Secret has no schema in testdata; --skip-missing-schemas turns
-	// that into a skipped line.
 	g.Expect(out).To(ContainSubstring(sourcesPath + " - Secret/default/minio-bucket-secret is skipped: schema not found"))
 	g.Expect(out).To(MatchRegexp(`(?m)^  - no schema for kind "Secret" in version "v1"$`))
 
-	// 11 docs in valid-reconcilers.yaml + 8 in valid-sources.yaml = 19; 1 Secret
-	// is skipped, the remaining 18 validate cleanly.
+	// 11 docs in valid-reconcilers.yaml + 8 in valid-sources.yaml = 19; the
+	// Secret is skipped, so the remaining 18 validate cleanly.
 	g.Expect(out).To(ContainSubstring("Summary: 19 resources found in 2 files - Valid: 18, Invalid: 0, Skipped: 1"))
 }
 
-// TestValidateCmd_InvalidFluxManifestsFixtures exercises the full failure
-// surface against a hand-crafted invalid Flux manifest: schema violations
-// (missing required, wrong type, additionalProperties, pattern mismatch) and
-// a GVK with no registered schema. Also pins the summary counts and
-// non-zero exit.
 func TestValidateCmd_InvalidFluxManifestsFixtures(t *testing.T) {
 	g := NewWithT(t)
 
@@ -232,19 +218,14 @@ func TestValidateCmd_InvalidFluxManifestsFixtures(t *testing.T) {
 	})
 	g.Expect(err).To(HaveOccurred())
 
-	// Top-line rendering per failure mode.
 	g.Expect(out).To(ContainSubstring(invalidPath + " - Bucket/default/minio-bucket is invalid: schema validation failed"))
 	g.Expect(out).To(ContainSubstring(invalidPath + " - HelmRepository/default/example is invalid: schema validation failed"))
 	g.Expect(out).To(ContainSubstring(invalidPath + " - GitRepository/default/podinfo is invalid: schema validation failed"))
 	g.Expect(out).To(ContainSubstring(invalidPath + " - OCIRepository/default/podinfo is invalid: schema validation failed"))
 	g.Expect(out).To(ContainSubstring(invalidPath + " - ArtifactGenerator/apps/podinfo-composite is invalid: schema not found"))
 	g.Expect(out).To(MatchRegexp(`(?m)^  - no schema for kind "ArtifactGenerator" in version "source\.extensions\.fluxcd\.io/v1alpha1"$`))
-	// A valid doc in the same file is still reported valid under --verbose.
 	g.Expect(out).To(ContainSubstring(invalidPath + " - HelmChart/default/podinfo is valid"))
 
-	// Representative field-level violations, covering each jsonschema/v6 error
-	// class surfaced by this fixture: missing required, wrong type,
-	// additionalProperties, pattern mismatch.
 	g.Expect(out).To(ContainSubstring("  - /spec: missing property 'bucketName'"))
 	g.Expect(out).To(ContainSubstring("  - /spec/interval: got number, want string"))
 	g.Expect(out).To(ContainSubstring("  - /spec: additional properties 'force' not allowed"))
@@ -254,12 +235,9 @@ func TestValidateCmd_InvalidFluxManifestsFixtures(t *testing.T) {
 	g.Expect(out).To(ContainSubstring("Summary: 6 resources found in 1 file - Valid: 1, Invalid: 5, Skipped: 0"))
 }
 
-// TestValidateCmd_InvalidMetadataFixtures covers three Kubernetes-admission
-// failure modes that short-circuit before JSON Schema validation: strict-YAML
-// duplicate keys (both in metadata.labels and in nested spec.ref), and a
-// document missing metadata.name. Also pins the identity-recovery path: even
-// when strict decode fails, the CLI line must show Kind/Namespace/Name when
-// those fields are present in the document.
+// TestValidateCmd_InvalidMetadataFixtures covers admission short-circuits
+// (duplicate keys, missing metadata.name) and the lenient re-parse that
+// recovers Kind/Namespace/Name when strict decode fails.
 func TestValidateCmd_InvalidMetadataFixtures(t *testing.T) {
 	g := NewWithT(t)
 
@@ -273,18 +251,11 @@ func TestValidateCmd_InvalidMetadataFixtures(t *testing.T) {
 	})
 	g.Expect(err).To(HaveOccurred())
 
-	// Duplicate-key failures render with the short summary on the top line
-	// and each library detail on an indented continuation line, matching the
-	// two-level layout used for JSON Schema violations. Identity fields are
-	// recovered via the lenient re-parse so the line reads as the real
-	// resource, not "/#N".
 	g.Expect(out).To(ContainSubstring(invalidPath + " - OCIRepository/default/duplicate-labels is invalid: YAML parse failed"))
 	g.Expect(out).To(ContainSubstring(invalidPath + " - OCIRepository/default/duplicate-fields is invalid: YAML parse failed"))
 	g.Expect(out).To(MatchRegexp(`(?m)^  - line 8: key "app" already set in map$`))
 	g.Expect(out).To(MatchRegexp(`(?m)^  - line 11: key "tag" already set in map$`))
 
-	// Missing-name admission rule: Kind/Namespace still render; Name falls
-	// back to #{docIndex} because no name is declared.
 	g.Expect(out).To(ContainSubstring(invalidPath + " - OCIRepository/default/#3 is invalid: validation failed"))
 	g.Expect(out).To(MatchRegexp(`(?m)^  - /metadata: missing property 'name' or 'generateName'$`))
 
@@ -306,10 +277,7 @@ func TestValidateCmd_SchemaLocationShorthand(t *testing.T) {
 		"--verbose",
 	})
 	g.Expect(err).ToNot(HaveOccurred())
-	// A representative valid line proves the shorthand resolved to real schemas.
 	g.Expect(out).To(ContainSubstring("Bucket/default/minio-bucket is valid"))
-	// The Secret has no schema under that layout, so --skip-missing-schemas
-	// turns it into a skipped line — confirms the layout is being rendered.
 	g.Expect(out).To(ContainSubstring("Secret/default/minio-bucket-secret is skipped"))
 }
 
@@ -341,19 +309,14 @@ func TestValidateCmd_SkipKind(t *testing.T) {
 	g.Expect(out).To(ContainSubstring(" - HelmRelease/"))
 }
 
-// TestValidateCmd_FailFast pins the short-circuit behavior: a multi-doc file
-// containing many invalid documents must still trigger a non-zero exit, but
-// --fail-fast should stop counting well before every document runs. With
-// --concurrent 1 the pool is near-deterministic — we expect exactly 1 or 2
-// invalid lines (one picked up before the cancel fires, plus at most one
-// already in the worker pipeline) and a matching summary count.
+// TestValidateCmd_FailFast runs 50 invalid docs with --concurrent 1 so the
+// cut-short count is near-deterministic: at most a handful of invalids,
+// never the full 50.
 func TestValidateCmd_FailFast(t *testing.T) {
 	g := NewWithT(t)
 	schemaDir := extractWidgetSchema(t)
 	manifestDir := t.TempDir()
 
-	// 50 invalid docs — the pool with a single worker will cancel long
-	// before all of them are counted.
 	var body []byte
 	for i := range 50 {
 		if i > 0 {
@@ -371,12 +334,9 @@ func TestValidateCmd_FailFast(t *testing.T) {
 	})
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(out).To(ContainSubstring("is invalid: schema validation failed"))
-	// Single-digit invalid count proves fail-fast cut the run short of 50.
 	g.Expect(out).To(MatchRegexp(`Invalid: [1-9],`))
 }
 
-// TestValidateCmd_ConcurrentFlag pins that --concurrent accepts a value and
-// that an invalid (<1) value is rejected with a clear error.
 func TestValidateCmd_ConcurrentFlag(t *testing.T) {
 	g := NewWithT(t)
 	schemaDir := extractWidgetSchema(t)
@@ -399,9 +359,51 @@ func TestValidateCmd_ConcurrentFlag(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("--concurrent must be >= 1")))
 }
 
-// TestValidateCmd_InsecureSkipTLSVerify points --schema-location at a TLS
-// httptest server backed by a self-signed cert. The default run must fail
-// with a TLS verification error; passing the flag must make it succeed.
+func TestValidateCmd_StdinDash(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	replaceStdin(t, validWidget)
+
+	out, err := executeCommand([]string{
+		"validate", "-",
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--verbose",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("stdin - Widget/default/ok-widget is valid"))
+	g.Expect(out).To(ContainSubstring("parsing stdin"))
+}
+
+func TestValidateCmd_StdinBare(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	replaceStdin(t, validWidget)
+
+	out, err := executeCommand([]string{
+		"validate",
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--verbose",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("stdin - Widget/default/ok-widget is valid"))
+}
+
+func TestValidateCmd_NoArgsNoPipe(t *testing.T) {
+	g := NewWithT(t)
+	forceStdinTTY(t)
+	_, err := executeCommand([]string{"validate"})
+	g.Expect(err).To(MatchError(ContainSubstring("no input")))
+}
+
+func TestValidateCmd_MultipleStdinSentinels(t *testing.T) {
+	g := NewWithT(t)
+	_, err := executeCommand([]string{"validate", "-", "-"})
+	g.Expect(err).To(MatchError(ContainSubstring("stdin may only be referenced once")))
+}
+
+// TestValidateCmd_InsecureSkipTLSVerify points --schema-location at an
+// httptest TLS server using a self-signed cert — default run must fail,
+// run with the flag must succeed.
 func TestValidateCmd_InsecureSkipTLSVerify(t *testing.T) {
 	g := NewWithT(t)
 
@@ -424,14 +426,12 @@ func TestValidateCmd_InsecureSkipTLSVerify(t *testing.T) {
 	manifestDir := t.TempDir()
 	writeManifest(t, manifestDir, "ok.yaml", validWidget)
 
-	// Without --insecure-skip-tls-verify the self-signed cert must be rejected.
 	_, err = executeCommand([]string{
 		"validate", manifestDir,
 		"--schema-location", srv.URL + "/{{.Kind}}_{{.Version}}.json",
 	})
 	g.Expect(err).To(HaveOccurred())
 
-	// With the flag, the same run succeeds.
 	out, err := executeCommand([]string{
 		"validate", manifestDir,
 		"--schema-location", srv.URL + "/{{.Kind}}_{{.Version}}.json",
@@ -463,50 +463,39 @@ func TestExpandSchemaLocations(t *testing.T) {
 		return out
 	}
 
-	// "default" alias expands to the hosted catalog URL.
 	g.Expect(expand([]string{"default"})).
 		To(Equal([]string{validator.DefaultSchemaLocation}))
 
 	g.Expect(expand([]string{"DEFAULT", "Default"})).
 		To(Equal([]string{validator.DefaultSchemaLocation, validator.DefaultSchemaLocation}))
 
-	// Values ending in .json are taken verbatim as full templates.
 	g.Expect(expand([]string{"./local/{{.Kind}}.json"})).
 		To(Equal([]string{"./local/{{.Kind}}.json"}))
 
-	// Bare paths get the catalog layout appended.
 	g.Expect(expand([]string{"./my-schemas"})).
 		To(Equal([]string{"./my-schemas/" + validator.DefaultSchemaLayout}))
 
-	// Trailing slashes are collapsed so the result has exactly one separator.
 	g.Expect(expand([]string{"./my-schemas/"})).
 		To(Equal([]string{"./my-schemas/" + validator.DefaultSchemaLayout}))
 	g.Expect(expand([]string{"./my-schemas///"})).
 		To(Equal([]string{"./my-schemas/" + validator.DefaultSchemaLayout}))
 
-	// Backslashes are also trimmed so Windows-style paths ("\", "/") produce
-	// a clean single-separator join. Go accepts forward slashes on Windows.
+	// Go accepts forward slashes on Windows, so backslashes normalize cleanly.
 	g.Expect(expand([]string{`.\my-schemas\`})).
 		To(Equal([]string{`.\my-schemas/` + validator.DefaultSchemaLayout}))
 
-	// Bare URLs get the same tail appended; protocol is untouched.
 	g.Expect(expand([]string{"https://example.com/catalog"})).
 		To(Equal([]string{"https://example.com/catalog/" + validator.DefaultSchemaLayout}))
 
-	// URL query string is preserved on the right of the template tail so the
-	// template lands on the path, not inside the query.
 	g.Expect(expand([]string{"https://example.com/catalog?ref=main"})).
 		To(Equal([]string{"https://example.com/catalog/" + validator.DefaultSchemaLayout + "?ref=main"}))
 
-	// URL fragment is handled the same way as a query string.
 	g.Expect(expand([]string{"https://example.com/catalog#v1"})).
 		To(Equal([]string{"https://example.com/catalog/" + validator.DefaultSchemaLayout + "#v1"}))
 
-	// Trailing slash before the query is also collapsed.
 	g.Expect(expand([]string{"https://example.com/catalog/?ref=main"})).
 		To(Equal([]string{"https://example.com/catalog/" + validator.DefaultSchemaLayout + "?ref=main"}))
 
-	// Mixed inputs preserve order and apply each rule independently.
 	g.Expect(expand([]string{"default", "./local/{{.Kind}}.json"})).
 		To(Equal([]string{validator.DefaultSchemaLocation, "./local/{{.Kind}}.json"}))
 
@@ -522,7 +511,6 @@ func TestExpandSchemaLocations(t *testing.T) {
 	_, err = expandSchemaLocations([]string{"default", ""})
 	g.Expect(err).To(MatchError(ContainSubstring("--schema-location must not be empty")))
 
-	// Whitespace-only values are rejected the same way as empty strings.
 	_, err = expandSchemaLocations([]string{"   "})
 	g.Expect(err).To(MatchError(ContainSubstring("--schema-location must not be empty")))
 }

--- a/internal/extractor/openapi_test.go
+++ b/internal/extractor/openapi_test.go
@@ -85,7 +85,6 @@ func TestExtractOpenAPI_InlinesRef(t *testing.T) {
 
 	props := widget.JSON["properties"].(map[string]any)
 	helper := props["helper"].(map[string]any)
-	// Inlined: has object shape from the helper definition.
 	g.Expect(helper["type"]).To(Equal("object"))
 	g.Expect(helper).To(HaveKey("properties"))
 }
@@ -652,7 +651,6 @@ func TestExtractOpenAPI_StripsVendorExtensions(t *testing.T) {
 	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
-	// Root: no GVK extension anymore.
 	g.Expect(out[0].JSON).ToNot(HaveKey("x-kubernetes-group-version-kind"))
 
 	list := out[0].JSON["properties"].(map[string]any)["list"].(map[string]any)
@@ -689,7 +687,6 @@ func TestExtractOpenAPI_PreservesDescriptions(t *testing.T) {
 	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
-	// Extraction keeps descriptions; stripping is an opt-in post-process.
 	g.Expect(out[0].JSON["description"]).To(Equal("top-level description"))
 	name := out[0].JSON["properties"].(map[string]any)["name"].(map[string]any)
 	g.Expect(name["description"]).To(Equal("property description"))
@@ -741,7 +738,6 @@ func TestExtractOpenAPI_PreservesJSONNumber(t *testing.T) {
 	g.Expect(errs).To(BeEmpty())
 
 	count := out[0].JSON["properties"].(map[string]any)["count"].(map[string]any)
-	// json.Number stringifies as the original literal.
 	g.Expect(count["default"].(json.Number).String()).To(Equal("42"))
 	g.Expect(count["minimum"].(json.Number).String()).To(Equal("1"))
 }

--- a/internal/validator/defaults.go
+++ b/internal/validator/defaults.go
@@ -17,3 +17,8 @@ const DefaultSchemaLayout = "{{.Group}}/{{.Kind}}_{{.Version}}.json"
 // DefaultWorkers is the fallback concurrency level used
 // by ValidateSources when Options.Workers is left at 0.
 const DefaultWorkers = 8
+
+// StdinSource is the canonical source label for documents read from an
+// io.Reader rather than a file path. Options.Stdin must be non-nil when any
+// input path equals this sentinel; callers typically pass os.Stdin.
+const StdinSource = "stdin"

--- a/internal/validator/loader_test.go
+++ b/internal/validator/loader_test.go
@@ -148,7 +148,6 @@ func TestSchemaLoader_Resolve_HTTP500ReturnsError(t *testing.T) {
 func TestSchemaLoader_Resolve_InvalidSchemaBodyReturnsCompileError(t *testing.T) {
 	g := NewWithT(t)
 	dir := t.TempDir()
-	// Not a valid JSON Schema object — the compiler rejects it.
 	bad := []byte(`"not an object"`)
 	g.Expect(os.WriteFile(filepath.Join(dir, "widget-example-v1.json"), bad, 0o644)).To(Succeed())
 	l := newTestLoader(t, filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json"))
@@ -182,7 +181,6 @@ func TestSchemaLoader_Resolve_WithInternalRef(t *testing.T) {
 	s, _, found, err := l.Resolve(context.Background(), widgetVars)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(found).To(BeTrue())
-	// Internal $ref must compile and validate a document end-to-end.
 	g.Expect(s.Validate(map[string]any{"metadata": map[string]any{"name": "r1"}})).To(Succeed())
 }
 

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -93,6 +94,10 @@ func (r Result) Identifier() string {
 // InsecureSkipTLSVerify is only applied when HTTPClient is nil and the
 // validator constructs its own client. Callers who supply HTTPClient are
 // responsible for configuring TLS on that client themselves.
+//
+// Stdin is read when an input path passed to ValidateSources equals
+// StdinSource. It is the caller's responsibility to pass a non-nil reader
+// (typically os.Stdin) when that sentinel is used.
 type Options struct {
 	SchemaLocations       []string
 	SkipMissingSchemas    bool
@@ -101,6 +106,7 @@ type Options struct {
 	HTTPTimeout           time.Duration
 	Workers               int
 	InsecureSkipTLSVerify bool
+	Stdin                 io.Reader
 }
 
 // Validator resolves and applies JSON Schemas to Kubernetes manifests.
@@ -346,6 +352,15 @@ func (v *Validator) ValidateBytes(ctx context.Context, source string, data []byt
 // opened; per-document failures are reported via validateDoc inside the
 // worker pool.
 func (v *Validator) produceFromPath(ctx context.Context, path string, jobs chan<- job, spawnWaiter func(string, *sync.WaitGroup)) error {
+	if path == StdinSource {
+		if v.opts.Stdin == nil {
+			return fmt.Errorf("source %q requires Options.Stdin to be set", StdinSource)
+		}
+		wg := &sync.WaitGroup{}
+		err := v.streamReader(ctx, StdinSource, v.opts.Stdin, jobs, wg)
+		spawnWaiter(StdinSource, wg)
+		return err
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		return err
@@ -383,8 +398,15 @@ func (v *Validator) streamFile(ctx context.Context, path string, jobs chan<- job
 		return err
 	}
 	defer f.Close()
+	return v.streamReader(ctx, path, f, jobs, sourceWG)
+}
 
-	scanner := yamldoc.NewScanner(f)
+// streamReader splits r into YAML documents and pushes them into the job
+// channel under the given source label. Used by streamFile for on-disk
+// inputs and by produceFromPath directly for the StdinSource sentinel so
+// stdin doesn't go through a platform-specific path like "/dev/stdin".
+func (v *Validator) streamReader(ctx context.Context, source string, r io.Reader, jobs chan<- job, sourceWG *sync.WaitGroup) error {
+	scanner := yamldoc.NewScanner(r)
 	idx := 0
 	for scanner.Scan() {
 		raw := bytes.TrimSpace(scanner.Bytes())
@@ -399,11 +421,11 @@ func (v *Validator) streamFile(ctx context.Context, path string, jobs chan<- job
 		case <-ctx.Done():
 			sourceWG.Done()
 			return ctx.Err()
-		case jobs <- job{source: path, docIndex: idx, raw: buf, sourceWG: sourceWG}:
+		case jobs <- job{source: source, docIndex: idx, raw: buf, sourceWG: sourceWG}:
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("scan %s: %w", path, err)
+		return fmt.Errorf("scan %s: %w", source, err)
 	}
 	return nil
 }

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -107,7 +107,6 @@ spec:
 	g.Expect(results[0].Status).To(Equal(StatusInvalid))
 	g.Expect(results[0].Message).To(Equal("schema validation failed"))
 	g.Expect(results[0].Errors).ToNot(BeEmpty())
-	// At least one error must reference /spec/name
 	found := false
 	for _, e := range results[0].Errors {
 		if e.Path == "/spec/name" {
@@ -385,9 +384,6 @@ spec:
 `)
 	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
 	g.Expect(results[0].Status).To(Equal(StatusInvalid))
-	// Two-level rendering: the admission-rule violation lives in Errors as
-	// a JSON Pointer + message pair, matching how JSON Schema violations
-	// surface through flattenErrors.
 	g.Expect(results[0].Message).To(Equal("validation failed"))
 	g.Expect(results[0].Errors).To(ConsistOf(
 		ValidationError{Path: "/metadata", Msg: "missing property 'name' or 'generateName'"},
@@ -411,8 +407,6 @@ spec:
 `)
 	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
 	g.Expect(results[0].Status).To(Equal(StatusInvalid))
-	// Two-level rendering: top-line is the short summary, the library's
-	// per-line details land in Errors so the CLI can indent them.
 	g.Expect(results[0].Message).To(Equal("YAML parse failed"))
 	g.Expect(results[0].Errors).ToNot(BeEmpty())
 	// The last-wins lenient parse must recover identity fields so the CLI
@@ -593,7 +587,6 @@ spec:
 		count++
 	}
 	g.Expect(count).To(Equal(2))
-	// One Final sentinel per discovered file.
 	g.Expect(finals).To(HaveLen(2))
 }
 


### PR DESCRIPTION
Introduce support for passing a YAML file to set defaults for the validation flags and enhance stdin handling for validate and extract commands (allow piping with zero-args or `-`).

### Validation Config File

Flag values can be pre-set in a YAML config file and referenced with `--config` or with the `FLUX_SCHEMA_CONFIG` environment variable. This keeps long invocations out of CI scripts and makes validation reproducible
across developers:

```shell
kustomize build . | flux-schema validate --config .flux-schema.yaml
```

The file has a `version` (required, must be `"1"`) and a `validate` section whose keys mirror the CLI flag names:

```yaml
version: "1"
validate:
  schema-location:
    - default
    - https://raw.githubusercontent.com/datreeio/CRDs-catalog/main
  skip-kind:
    - v1/Secret
    - source.toolkit.fluxcd.io/v1/ExternalArtifact
  skip-missing-schemas: false
  verbose: true
  fail-fast: false
  concurrent: 8
  insecure-skip-tls-verify: false
```

Rules:

- CLI flags override config values. Setting `--verbose=false` wins over `verbose: true` in the file.
- Setting `--config` overrides `FLUX_SCHEMA_CONFIG`. When both are set, the flag wins and the env var is ignored.
- Manifest paths stay positional. The config file configures how to validate; paths are given on the command line.
