### PR TITLE
Add Flagger schemas to the catalog

### DIFF
--- a/.github/workflows/update-catalog.yaml
+++ b/.github/workflows/update-catalog.yaml
@@ -31,6 +31,8 @@ jobs:
         run: ./scripts/gen-crd-schemas.sh -r kubernetes-sigs/gateway-api -d ./catalog/latest
       - name: Update Flux schemas
         run: ./scripts/gen-flux-schemas.sh -d ./catalog/latest
+      - name: Update Flagger schemas
+        run: ./scripts/gen-crd-schemas.sh -r fluxcd/flagger -p kustomize/kubernetes -d ./catalog/latest
       - name: Update Flux Operator schemas
         run: ./scripts/gen-crd-schemas.sh -r controlplaneio-fluxcd/flux-operator -d ./catalog/latest
       - name: Update README versions
@@ -51,6 +53,7 @@ jobs:
             - Kubernetes: ${{ env.K8S_VERSION }}
             - Gateway API: ${{ env.GATEWAY_API_VERSION }}
             - Flux: ${{ env.FLUX_VERSION }}
+            - Flagger: ${{ env.FLAGGER_VERSION }}
             - Flux Operator: ${{ env.FLUX_OPERATOR_VERSION }}
           labels: |
             area/catalog

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ and validates each document against a JSON Schema resolved from its `apiVersion`
 
 When no `--schema-location` is given, validate uses the [flux-schema catalog](catalog/README.md),
 which covers the latest Kubernetes APIs, the stable channel of Gateway API,
-and the Flux CRDs (controllers and operator):
+and the Flux ecosystem CRDs:
 
 ```shell
 flux-schema validate ./manifests

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -9,12 +9,13 @@ used by the `flux schema validation` tool.
 | [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) | v1.35.4 |
 | [kubernetes-sigs/gateway-api](https://github.com/kubernetes-sigs/gateway-api) | v1.5.1 |
 | [fluxcd/flux2](https://github.com/fluxcd/flux2) | v2.8.6 |
+| [fluxcd/flagger](https://github.com/fluxcd/flagger) | v1.43.0 |
 | [controlplaneio-fluxcd/flux-operator](https://github.com/controlplaneio-fluxcd/flux-operator) | v0.48.0 |
 <!-- versions:end -->
 
 ## Flux APIs
 
-Extracted from the CRDs shipped by the latest stable Flux distribution and Flux Operator.
+Extracted from the CRDs shipped by the latest stable Flux distribution, Flagger and Flux Operator.
 
 - `helm.toolkit.fluxcd.io` — `HelmRelease`
 - `image.toolkit.fluxcd.io` — `ImagePolicy`, `ImageRepository`, `ImageUpdateAutomation`
@@ -22,6 +23,7 @@ Extracted from the CRDs shipped by the latest stable Flux distribution and Flux 
 - `notification.toolkit.fluxcd.io` — `Alert`, `Provider`, `Receiver`
 - `source.toolkit.fluxcd.io` — `Bucket`, `ExternalArtifact`, `GitRepository`, `HelmChart`, `HelmRepository`, `OCIRepository`
 - `source.extensions.fluxcd.io` — `ArtifactGenerator`
+- `flagger.app` — `Canary`, `MetricTemplate`, `AlertProvider`
 - `fluxcd.controlplane.io` — `FluxInstance`, `FluxReport`, `ResourceSet`, `ResourceSetInputProvider`
 
 ## Kubernetes APIs

--- a/catalog/latest/flagger.app/alertprovider_v1beta1.json
+++ b/catalog/latest/flagger.app/alertprovider_v1beta1.json
@@ -1,0 +1,68 @@
+{
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "required": [
+            "type",
+            "address"
+          ]
+        },
+        {
+          "required": [
+            "type",
+            "secretRef"
+          ]
+        }
+      ],
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "proxy": {
+          "type": "string"
+        },
+        "secretRef": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        },
+        "type": {
+          "enum": [
+            "slack",
+            "msteams",
+            "discord",
+            "rocket",
+            "gchat"
+          ],
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/catalog/latest/flagger.app/canary_v1beta1.json
+++ b/catalog/latest/flagger.app/canary_v1beta1.json
@@ -1,0 +1,1788 @@
+{
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "additionalProperties": false,
+      "properties": {
+        "analysis": {
+          "additionalProperties": false,
+          "oneOf": [
+            {
+              "required": [
+                "interval",
+                "threshold",
+                "iterations"
+              ]
+            },
+            {
+              "required": [
+                "interval",
+                "threshold",
+                "stepWeight"
+              ]
+            },
+            {
+              "required": [
+                "interval",
+                "threshold",
+                "stepWeights"
+              ]
+            }
+          ],
+          "properties": {
+            "alerts": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "providerRef": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object"
+                  },
+                  "severity": {
+                    "enum": [
+                      "",
+                      "info",
+                      "warn",
+                      "error"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "providerRef",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "canaryReadyThreshold": {
+              "type": "number"
+            },
+            "interval": {
+              "pattern": "^[0-9]+(m|s)",
+              "type": "string"
+            },
+            "iterations": {
+              "type": "number"
+            },
+            "match": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "headers": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "oneOf": [
+                        {
+                          "required": [
+                            "exact"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "prefix"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "suffix"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "regex"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "exact": {
+                          "format": "string",
+                          "type": "string"
+                        },
+                        "prefix": {
+                          "format": "string",
+                          "type": "string"
+                        },
+                        "regex": {
+                          "format": "string",
+                          "type": "string"
+                        },
+                        "suffix": {
+                          "format": "string",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "queryParams": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "oneOf": [
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "exact"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "prefix"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "regex"
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "required": [
+                            "exact"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "prefix"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "regex"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "exact": {
+                          "type": "string"
+                        },
+                        "prefix": {
+                          "type": "string"
+                        },
+                        "regex": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "sourceLabels": {
+                    "additionalProperties": {
+                      "format": "string",
+                      "type": "string"
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "maxWeight": {
+              "type": "number"
+            },
+            "metrics": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "interval": {
+                    "pattern": "^[0-9]+(m|s)",
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "query": {
+                    "type": "string"
+                  },
+                  "templateRef": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object"
+                  },
+                  "templateVariables": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "threshold": {
+                    "type": "number"
+                  },
+                  "thresholdRange": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "max": {
+                        "type": "number"
+                      },
+                      "min": {
+                        "type": "number"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "mirror": {
+              "type": "boolean"
+            },
+            "mirrorWeight": {
+              "type": "number"
+            },
+            "primaryReadyThreshold": {
+              "type": "number"
+            },
+            "sessionAffinity": {
+              "additionalProperties": false,
+              "properties": {
+                "cookieName": {
+                  "type": "string"
+                },
+                "domain": {
+                  "type": "string"
+                },
+                "httpOnly": {
+                  "type": "boolean"
+                },
+                "maxAge": {
+                  "default": 86400,
+                  "type": "number"
+                },
+                "partitioned": {
+                  "type": "boolean"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "primaryCookieName": {
+                  "type": "string"
+                },
+                "sameSite": {
+                  "enum": [
+                    "Strict",
+                    "Lax",
+                    "None"
+                  ],
+                  "type": "string"
+                },
+                "secure": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "cookieName"
+              ],
+              "type": "object"
+            },
+            "stepWeight": {
+              "type": "number"
+            },
+            "stepWeightPromotion": {
+              "type": "number"
+            },
+            "stepWeights": {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "threshold": {
+              "type": "number"
+            },
+            "webhooks": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "disableTLS": {
+                    "type": "boolean"
+                  },
+                  "metadata": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "muteAlert": {
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "retries": {
+                    "type": "number"
+                  },
+                  "timeout": {
+                    "pattern": "^[0-9]+(m|s)",
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "",
+                      "confirm-rollout",
+                      "pre-rollout",
+                      "rollout",
+                      "confirm-promotion",
+                      "post-rollout",
+                      "event",
+                      "rollback",
+                      "confirm-traffic-increase"
+                    ],
+                    "type": "string"
+                  },
+                  "url": {
+                    "format": "url",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "url"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "autoscalerRef": {
+          "additionalProperties": false,
+          "properties": {
+            "apiVersion": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "HorizontalPodAutoscaler",
+                "ScaledObject"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "primaryScalerQueries": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "primaryScalerReplicas": {
+              "additionalProperties": false,
+              "properties": {
+                "maxReplicas": {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "minReplicas": {
+                  "minimum": 1,
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "apiVersion",
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        "ingressRef": {
+          "additionalProperties": false,
+          "properties": {
+            "apiVersion": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "Ingress"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiVersion",
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        "metricsServer": {
+          "type": "string"
+        },
+        "progressDeadlineSeconds": {
+          "type": "number"
+        },
+        "provider": {
+          "enum": [
+            "apisix",
+            "appmesh",
+            "appmesh:v1beta2",
+            "contour",
+            "gatewayapi:v1",
+            "gatewayapi:v1beta1",
+            "gloo",
+            "istio",
+            "knative",
+            "kubernetes",
+            "kuma",
+            "linkerd",
+            "nginx",
+            "osm",
+            "skipper",
+            "smi:v1alpha1",
+            "smi:v1alpha2",
+            "smi:v1alpha3",
+            "traefik"
+          ],
+          "type": "string"
+        },
+        "revertOnDeletion": {
+          "type": "boolean"
+        },
+        "routeRef": {
+          "additionalProperties": false,
+          "properties": {
+            "apiVersion": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "ApisixRoute"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiVersion",
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        "service": {
+          "additionalProperties": false,
+          "properties": {
+            "apex": {
+              "additionalProperties": false,
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "appProtocol": {
+              "type": "string"
+            },
+            "backends": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "canary": {
+              "additionalProperties": false,
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "corsPolicy": {
+              "additionalProperties": false,
+              "properties": {
+                "allowCredentials": {
+                  "type": "boolean"
+                },
+                "allowHeaders": {
+                  "items": {
+                    "format": "string",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "allowMethods": {
+                  "items": {
+                    "format": "string",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "allowOrigin": {
+                  "items": {
+                    "format": "string",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "allowOrigins": {
+                  "items": {
+                    "additionalProperties": false,
+                    "oneOf": [
+                      {
+                        "required": [
+                          "exact"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "prefix"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "regex"
+                        ]
+                      }
+                    ],
+                    "properties": {
+                      "exact": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "prefix": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "regex": {
+                        "format": "string",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "exposeHeaders": {
+                  "items": {
+                    "format": "string",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "maxAge": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "delegation": {
+              "type": "boolean"
+            },
+            "gatewayRefs": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "group": {
+                    "default": "gateway.networking.k8s.io",
+                    "maxLength": 253,
+                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "default": "Gateway",
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                    "type": "string"
+                  },
+                  "name": {
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "type": "string"
+                  },
+                  "port": {
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "sectionName": {
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "maxItems": 32,
+              "type": "array"
+            },
+            "gateways": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "headers": {
+              "additionalProperties": false,
+              "properties": {
+                "request": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "add": {
+                      "additionalProperties": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "remove": {
+                      "items": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "set": {
+                      "additionalProperties": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "response": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "add": {
+                      "additionalProperties": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "remove": {
+                      "items": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "set": {
+                      "additionalProperties": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "headless": {
+              "type": "boolean"
+            },
+            "hosts": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "match": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "authority": {
+                    "additionalProperties": false,
+                    "oneOf": [
+                      {
+                        "not": {
+                          "anyOf": [
+                            {
+                              "required": [
+                                "exact"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "prefix"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "regex"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "required": [
+                          "exact"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "prefix"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "regex"
+                        ]
+                      }
+                    ],
+                    "properties": {
+                      "exact": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "prefix": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "regex": {
+                        "format": "string",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "gateways": {
+                    "items": {
+                      "format": "string",
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "headers": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "oneOf": [
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "exact"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "prefix"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "regex"
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "required": [
+                            "exact"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "prefix"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "regex"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "exact": {
+                          "format": "string",
+                          "type": "string"
+                        },
+                        "prefix": {
+                          "format": "string",
+                          "type": "string"
+                        },
+                        "regex": {
+                          "format": "string",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "ignoreUriCase": {
+                    "type": "boolean"
+                  },
+                  "method": {
+                    "additionalProperties": false,
+                    "oneOf": [
+                      {
+                        "not": {
+                          "anyOf": [
+                            {
+                              "required": [
+                                "exact"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "prefix"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "regex"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "required": [
+                          "exact"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "prefix"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "regex"
+                        ]
+                      }
+                    ],
+                    "properties": {
+                      "exact": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "prefix": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "regex": {
+                        "format": "string",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "name": {
+                    "format": "string",
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  },
+                  "queryParams": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "oneOf": [
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "exact"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "prefix"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "regex"
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "required": [
+                            "exact"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "prefix"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "regex"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "exact": {
+                          "format": "string",
+                          "type": "string"
+                        },
+                        "prefix": {
+                          "format": "string",
+                          "type": "string"
+                        },
+                        "regex": {
+                          "format": "string",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "scheme": {
+                    "additionalProperties": false,
+                    "oneOf": [
+                      {
+                        "not": {
+                          "anyOf": [
+                            {
+                              "required": [
+                                "exact"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "prefix"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "regex"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "required": [
+                          "exact"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "prefix"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "regex"
+                        ]
+                      }
+                    ],
+                    "properties": {
+                      "exact": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "prefix": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "regex": {
+                        "format": "string",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "sourceLabels": {
+                    "additionalProperties": {
+                      "format": "string",
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "sourceNamespace": {
+                    "format": "string",
+                    "type": "string"
+                  },
+                  "uri": {
+                    "additionalProperties": false,
+                    "oneOf": [
+                      {
+                        "not": {
+                          "anyOf": [
+                            {
+                              "required": [
+                                "exact"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "prefix"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "regex"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "required": [
+                          "exact"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "prefix"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "regex"
+                        ]
+                      }
+                    ],
+                    "properties": {
+                      "exact": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "prefix": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "regex": {
+                        "format": "string",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "withoutHeaders": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "oneOf": [
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "exact"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "prefix"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "regex"
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "required": [
+                            "exact"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "prefix"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "regex"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "exact": {
+                          "format": "string",
+                          "type": "string"
+                        },
+                        "prefix": {
+                          "format": "string",
+                          "type": "string"
+                        },
+                        "regex": {
+                          "format": "string",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "meshName": {
+              "type": "string"
+            },
+            "mirror": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "backendRef": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "group": {
+                        "default": "",
+                        "maxLength": 253,
+                        "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "default": "Service",
+                        "maxLength": 63,
+                        "minLength": 1,
+                        "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                        "type": "string"
+                      },
+                      "name": {
+                        "maxLength": 253,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "maxLength": 63,
+                        "minLength": 1,
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                        "type": "string"
+                      },
+                      "port": {
+                        "format": "int32",
+                        "maximum": 65535,
+                        "minimum": 1,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "Must have port for Service reference",
+                        "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                      }
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "required": [
+                "backendRef"
+              ],
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "port": {
+              "type": "number"
+            },
+            "portDiscovery": {
+              "type": "boolean"
+            },
+            "portName": {
+              "type": "string"
+            },
+            "primary": {
+              "additionalProperties": false,
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "retries": {
+              "additionalProperties": false,
+              "properties": {
+                "attempts": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "perTryTimeout": {
+                  "type": "string"
+                },
+                "retryOn": {
+                  "format": "string",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "rewrite": {
+              "additionalProperties": false,
+              "properties": {
+                "authority": {
+                  "format": "string",
+                  "type": "string"
+                },
+                "type": {
+                  "format": "string",
+                  "type": "string"
+                },
+                "uri": {
+                  "format": "string",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "targetPort": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "timeout": {
+              "type": "string"
+            },
+            "trafficDistribution": {
+              "enum": [
+                "PreferClose",
+                "PreferSameZone",
+                "PreferSameNode"
+              ],
+              "type": "string"
+            },
+            "trafficPolicy": {
+              "additionalProperties": false,
+              "properties": {
+                "connectionPool": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "http": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "h2UpgradePolicy": {
+                          "enum": [
+                            "DEFAULT",
+                            "DO_NOT_UPGRADE",
+                            "UPGRADE"
+                          ],
+                          "type": "string"
+                        },
+                        "http1MaxPendingRequests": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "http2MaxRequests": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "idleTimeout": {
+                          "type": "string"
+                        },
+                        "maxRequestsPerConnection": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "maxRetries": {
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "loadBalancer": {
+                  "additionalProperties": false,
+                  "oneOf": [
+                    {
+                      "required": [
+                        "simple"
+                      ]
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "consistentHash": {
+                          "oneOf": [
+                            {
+                              "required": [
+                                "httpHeaderName"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "httpCookie"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "useSourceIp"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "httpQueryParameterName"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "consistentHash"
+                      ]
+                    }
+                  ],
+                  "properties": {
+                    "consistentHash": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "httpCookie": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "name": {
+                              "format": "string",
+                              "type": "string"
+                            },
+                            "path": {
+                              "format": "string",
+                              "type": "string"
+                            },
+                            "ttl": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "httpHeaderName": {
+                          "format": "string",
+                          "type": "string"
+                        },
+                        "httpQueryParameterName": {
+                          "format": "string",
+                          "type": "string"
+                        },
+                        "minimumRingSize": {
+                          "type": "integer"
+                        },
+                        "useSourceIp": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "localityLbSetting": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "distribute": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "from": {
+                                "format": "string",
+                                "type": "string"
+                              },
+                              "to": {
+                                "additionalProperties": {
+                                  "type": "integer"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "failover": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "from": {
+                                "format": "string",
+                                "type": "string"
+                              },
+                              "to": {
+                                "format": "string",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "simple": {
+                      "enum": [
+                        "ROUND_ROBIN",
+                        "LEAST_CONN",
+                        "RANDOM",
+                        "PASSTHROUGH",
+                        "LEAST_REQUEST"
+                      ],
+                      "type": "string"
+                    },
+                    "warmupDurationSecs": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "outlierDetection": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "baseEjectionTime": {
+                      "type": "string"
+                    },
+                    "consecutive5xxErrors": {
+                      "type": "integer"
+                    },
+                    "consecutiveErrors": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "consecutiveGatewayErrors": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "interval": {
+                      "type": "string"
+                    },
+                    "maxEjectionPercent": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "minHealthPercent": {
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "tls": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "caCertificates": {
+                      "format": "string",
+                      "type": "string"
+                    },
+                    "clientCertificate": {
+                      "format": "string",
+                      "type": "string"
+                    },
+                    "mode": {
+                      "enum": [
+                        "DISABLE",
+                        "SIMPLE",
+                        "MUTUAL",
+                        "ISTIO_MUTUAL"
+                      ],
+                      "type": "string"
+                    },
+                    "privateKey": {
+                      "format": "string",
+                      "type": "string"
+                    },
+                    "sni": {
+                      "format": "string",
+                      "type": "string"
+                    },
+                    "subjectAltNames": {
+                      "items": {
+                        "format": "string",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "unmanagedMetadata": {
+              "additionalProperties": false,
+              "properties": {
+                "annotations": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "labels": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "port"
+          ],
+          "type": "object"
+        },
+        "skipAnalysis": {
+          "type": "boolean"
+        },
+        "suspend": {
+          "type": "boolean"
+        },
+        "targetRef": {
+          "additionalProperties": false,
+          "properties": {
+            "apiVersion": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "DaemonSet",
+                "Deployment",
+                "Service"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiVersion",
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        "upstreamRef": {
+          "additionalProperties": false,
+          "properties": {
+            "apiVersion": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "Upstream"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiVersion",
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "targetRef",
+        "analysis"
+      ],
+      "type": "object"
+    },
+    "status": {
+      "additionalProperties": false,
+      "properties": {
+        "canaryWeight": {
+          "type": "number"
+        },
+        "conditions": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "lastTransitionTime": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "status",
+              "reason"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "failedChecks": {
+          "type": "number"
+        },
+        "iterations": {
+          "type": "number"
+        },
+        "lastAppliedSpec": {
+          "type": "string"
+        },
+        "lastPromotedSpec": {
+          "type": "string"
+        },
+        "lastTransitionTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "phase": {
+          "enum": [
+            "",
+            "Initializing",
+            "Initialized",
+            "Waiting",
+            "Progressing",
+            "WaitingPromotion",
+            "Promoting",
+            "Finalising",
+            "Succeeded",
+            "Failed",
+            "Terminating",
+            "Terminated"
+          ],
+          "type": "string"
+        },
+        "previousSessionAffinityCookie": {
+          "type": "string"
+        },
+        "primarySessionAffinityCookie": {
+          "type": "string"
+        },
+        "sessionAffinityCookie": {
+          "type": "string"
+        },
+        "trackedConfigs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/catalog/latest/flagger.app/metrictemplate_v1beta1.json
+++ b/catalog/latest/flagger.app/metrictemplate_v1beta1.json
@@ -1,0 +1,82 @@
+{
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "additionalProperties": false,
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "headers": {
+              "additionalProperties": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": "object"
+            },
+            "insecureSkipVerify": {
+              "type": "boolean"
+            },
+            "region": {
+              "type": "string"
+            },
+            "secretRef": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            },
+            "type": {
+              "enum": [
+                "prometheus",
+                "influxdb",
+                "datadog",
+                "externalmetrics",
+                "stackdriver",
+                "cloudwatch",
+                "newrelic",
+                "graphite",
+                "dynatrace",
+                "keptn",
+                "splunk"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        "query": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "query"
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/scripts/gen-crd-schemas.sh
+++ b/scripts/gen-crd-schemas.sh
@@ -7,14 +7,15 @@ set -o errexit
 set -o pipefail
 
 usage() {
-  echo "Usage: $(basename "$0") -r <owner/repo> -d <directory> [-v <version>]"
+  echo "Usage: $(basename "$0") -r <owner/repo> -d <directory> [-v <version>] [-p <overlay-path>]"
   echo ""
-  echo "Extracts JSON schemas from CRDs under <repo>/config/crd at the given version."
+  echo "Extracts JSON schemas from CRDs under <repo>/<overlay-path> at the given version."
   echo ""
   echo "Options:"
   echo "  -r  GitHub repository in 'owner/name' form"
   echo "  -d  Directory to write the generated JSON schemas to"
   echo "  -v  Repository release tag; defaults to the latest release"
+  echo "  -p  Kustomize overlay path within the repository; defaults to 'config/crd'"
   echo "  -h  Show this help message"
   exit 1
 }
@@ -22,12 +23,14 @@ usage() {
 repo=""
 dir=""
 version=""
+overlay_path="config/crd"
 
-while getopts "r:d:v:h" opt; do
+while getopts "r:d:v:p:h" opt; do
   case $opt in
     r) repo="$OPTARG" ;;
     d) dir="$OPTARG" ;;
     v) version="$OPTARG" ;;
+    p) overlay_path="$OPTARG" ;;
     h) usage ;;
     *) usage ;;
   esac
@@ -77,9 +80,9 @@ if [[ "$version" != v* ]]; then
   version="v${version}"
 fi
 
-echo "Extracting schemas for ${repo}@${version} into ${dir}"
+echo "Extracting schemas for ${repo}@${version} (overlay: ${overlay_path}) into ${dir}"
 mkdir -p "$dir"
-kubectl kustomize "https://github.com/${repo}/config/crd?ref=${version}" | \
+kubectl kustomize "https://github.com/${repo}/${overlay_path}?ref=${version}" | \
   flux-schema extract crd /dev/stdin \
     -f '{{ .Group }}/{{ .Kind }}_{{ .Version }}.json' \
     --strip-description \

--- a/scripts/update-catalog-readme.sh
+++ b/scripts/update-catalog-readme.sh
@@ -11,8 +11,9 @@ usage() {
   echo ""
   echo "Rewrites the versions table between '<!-- versions:start -->' and"
   echo "'<!-- versions:end -->' markers using the K8S_REPO/K8S_VERSION,"
-  echo "GATEWAY_API_REPO/GATEWAY_API_VERSION, FLUX_REPO/FLUX_VERSION and"
-  echo "FLUX_OPERATOR_REPO/FLUX_OPERATOR_VERSION env vars."
+  echo "GATEWAY_API_REPO/GATEWAY_API_VERSION, FLUX_REPO/FLUX_VERSION,"
+  echo "FLUX_OPERATOR_REPO/FLUX_OPERATOR_VERSION and"
+  echo "FLAGGER_REPO/FLAGGER_VERSION env vars."
   echo ""
   echo "Options:"
   echo "  -f  Path to the README file to update"
@@ -40,7 +41,7 @@ if [[ ! -f "$readme" ]]; then
   exit 1
 fi
 
-for v in K8S_REPO K8S_VERSION GATEWAY_API_REPO GATEWAY_API_VERSION FLUX_REPO FLUX_VERSION FLUX_OPERATOR_REPO FLUX_OPERATOR_VERSION; do
+for v in K8S_REPO K8S_VERSION GATEWAY_API_REPO GATEWAY_API_VERSION FLUX_REPO FLUX_VERSION FLUX_OPERATOR_REPO FLUX_OPERATOR_VERSION FLAGGER_REPO FLAGGER_VERSION; do
   if [[ -z "${!v:-}" ]]; then
     echo "Error: ${v} is not set"
     exit 1
@@ -54,7 +55,8 @@ awk \
   -v k8s_repo="$K8S_REPO" -v k8s_ver="$K8S_VERSION" \
   -v gw_repo="$GATEWAY_API_REPO" -v gw_ver="$GATEWAY_API_VERSION" \
   -v flux_repo="$FLUX_REPO" -v flux_ver="$FLUX_VERSION" \
-  -v fop_repo="$FLUX_OPERATOR_REPO" -v fop_ver="$FLUX_OPERATOR_VERSION" '
+  -v fop_repo="$FLUX_OPERATOR_REPO" -v fop_ver="$FLUX_OPERATOR_VERSION" \
+  -v flagger_repo="$FLAGGER_REPO" -v flagger_ver="$FLAGGER_VERSION" '
   /<!-- versions:start -->/ {
     print
     print "| Source | Version |"
@@ -62,6 +64,7 @@ awk \
     printf("| [%s](https://github.com/%s) | %s |\n", k8s_repo, k8s_repo, k8s_ver)
     printf("| [%s](https://github.com/%s) | %s |\n", gw_repo, gw_repo, gw_ver)
     printf("| [%s](https://github.com/%s) | %s |\n", flux_repo, flux_repo, flux_ver)
+    printf("| [%s](https://github.com/%s) | %s |\n", flagger_repo, flagger_repo, flagger_ver)
     printf("| [%s](https://github.com/%s) | %s |\n", fop_repo, fop_repo, fop_ver)
     skip = 1
     next


### PR DESCRIPTION
Add Flagger's `Canary`, `MetricTemplate`, `AlertProvider` schemas to the default catalog.