### PR TITLE
Add support for structured validation report

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Flux CLI plugin for Kubernetes schema extraction and manifests validation.
     - `--concurrent`: Number of concurrent workers (default 8)
     - `--insecure-skip-tls-verify`: Disable TLS certificate verification when fetching schemas over HTTPS
     - `-v, --verbose`: Print a line for every document, including valid and skipped ones
+    - `-o, --output`: Output format, one of `text|json|yaml` (default: `text`)
     - `--config`: Path to a YAML file supplying default values for validate flags (env: `FLUX_SCHEMA_CONFIG`)
 - `flux-schema extract crd [files...]`: Extract JSON Schema from Kubernetes CRD YAMLs
   - `-d, --output-dir`: Directory to write JSON Schema files to (mutually exclusive with `--output-archive`)
@@ -99,6 +100,20 @@ Summary: 4 resources found in 1 file - Valid: 1, Invalid: 2, Skipped: 1
 
 A non-zero exit code is returned when any document is invalid or errored.
 
+#### Structured output
+
+For CI pipelines and tooling, pass `-o json` (or `-o yaml`) to emit a
+machine-readable report instead of text:
+
+```shell
+flux-schema validate ./manifests -o json | jq '.report.summary'
+```
+
+See the [validation report reference](docs/report/README.md) for the full
+envelope shape, the `reason` enum, and an example covering every result
+type. The report is versioned by a published
+[JSON Schema](docs/report/schema-1.0.0.json).
+
 #### Validation rules
 
 - YAML documents with duplicate keys are rejected matching Flux behavior.
@@ -137,6 +152,7 @@ validate:
   fail-fast: false
   concurrent: 8
   insecure-skip-tls-verify: false
+  output: text
 ```
 
 Rules:

--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ kustomize build . | flux-schema validate \
 Output example with validation errors:
 
 ```
-manifests/sources.yaml - Bucket/apps/s3-data is invalid: schema validation failed
+manifests/sources.yaml - Bucket/apps/s3-data is invalid: schema violation
   - /spec: missing property 'bucketName'
   - /spec/interval: got number, want string
   - /spec/secretRef/name: got object, want string
   - /spec: additional properties 'force' not allowed
-manifests/sources.yaml - OCIRepository/apps/podinfo is invalid: YAML parse failed
+manifests/sources.yaml - OCIRepository/apps/podinfo is invalid: yaml parse error
   - line 18: key "app.kubernetes.io/name" already set in map
 manifests/sources.yaml - HelmChart/apps/redis is valid
 manifests/sources.yaml - Secret/apps/auth-sops is skipped: kind skipped

--- a/cmd/flux-schema/config.go
+++ b/cmd/flux-schema/config.go
@@ -30,6 +30,7 @@ type validateConfig struct {
 	FailFast              bool     `json:"fail-fast,omitempty"`
 	Concurrent            *int     `json:"concurrent,omitempty"`
 	InsecureSkipTLSVerify bool     `json:"insecure-skip-tls-verify,omitempty"`
+	Output                string   `json:"output,omitempty"`
 }
 
 func loadConfigFile(path string) (*configFile, error) {
@@ -50,10 +51,13 @@ func loadConfigFile(path string) (*configFile, error) {
 
 // applyValidateConfig copies cfg values into args for flags not set on the CLI,
 // giving CLI > config > defaults precedence. Nil cfg is a no-op so callers can
-// pass cfg.Validate directly without a nil check.
-func applyValidateConfig(cmd *cobra.Command, cfg *validateConfig, args *validateFlags) {
+// pass cfg.Validate directly without a nil check. Returns an error when a
+// config value fails the same validation the CLI flag would apply (e.g. an
+// invalid output format), so bad config is caught up-front rather than
+// silently ignored.
+func applyValidateConfig(cmd *cobra.Command, cfg *validateConfig, args *validateFlags) error {
 	if cfg == nil {
-		return
+		return nil
 	}
 	flags := cmd.Flags()
 
@@ -78,4 +82,10 @@ func applyValidateConfig(cmd *cobra.Command, cfg *validateConfig, args *validate
 	if !flags.Changed("insecure-skip-tls-verify") {
 		args.insecureSkipTLSVerify = cfg.InsecureSkipTLSVerify
 	}
+	if cfg.Output != "" && !flags.Changed("output") {
+		if err := args.output.Set(cfg.Output); err != nil {
+			return fmt.Errorf("config output: %w", err)
+		}
+	}
+	return nil
 }

--- a/cmd/flux-schema/main_test.go
+++ b/cmd/flux-schema/main_test.go
@@ -51,7 +51,7 @@ func resetCmdArgs() {
 	versionArgs = versionFlags{output: "text"}
 	extractCRDArgs = extractCRDFlags{ExtractOutput: flags.NewExtractOutput()}
 	extractK8sArgs = extractK8sFlags{ExtractOutput: flags.NewExtractOutput()}
-	validateArgs = validateFlags{concurrent: validator.DefaultWorkers}
+	validateArgs = validateFlags{concurrent: validator.DefaultWorkers, output: "text"}
 
 	// pflag.Flag.Changed persists across Execute calls on the shared rootCmd,
 	// which breaks MarkFlagRequired validation in subsequent tests. Clear it

--- a/cmd/flux-schema/validate.go
+++ b/cmd/flux-schema/validate.go
@@ -5,14 +5,18 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 
+	"github.com/fluxcd/flux-schema/internal/flags"
 	"github.com/fluxcd/flux-schema/internal/validator"
 )
 
@@ -58,10 +62,12 @@ type validateFlags struct {
 	concurrent            int
 	insecureSkipTLSVerify bool
 	configFile            string
+	output                flags.Output
 }
 
 var validateArgs = validateFlags{
 	concurrent: validator.DefaultWorkers,
+	output:     "text",
 }
 
 func init() {
@@ -83,20 +89,13 @@ func init() {
 		"path to a YAML file supplying default values for validate flags "+
 			"(env: "+envConfigFile+")")
 	_ = validateCmd.MarkFlagFilename("config", "yaml", "yml")
+	validateCmd.Flags().VarP(&validateArgs.output, "output", "o", validateArgs.output.Description())
 	rootCmd.AddCommand(validateCmd)
 }
 
 func validateCmdRun(cmd *cobra.Command, args []string) error {
-	configPath := validateArgs.configFile
-	if configPath == "" {
-		configPath = os.Getenv(envConfigFile)
-	}
-	if configPath != "" {
-		cfg, err := loadConfigFile(configPath)
-		if err != nil {
-			return err
-		}
-		applyValidateConfig(cmd, cfg.Validate, &validateArgs)
+	if err := loadValidateConfig(cmd); err != nil {
+		return err
 	}
 
 	inputs, err := resolveStdinArgs(args)
@@ -104,31 +103,9 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	locations := validateArgs.schemaLocations
-	if len(locations) == 0 {
-		locations = []string{validator.DefaultSchemaLocation}
-	} else {
-		expanded, lerr := expandSchemaLocations(locations)
-		if lerr != nil {
-			return lerr
-		}
-		locations = expanded
-	}
-
-	if validateArgs.concurrent < 1 {
-		return fmt.Errorf("--concurrent must be >= 1, got %d", validateArgs.concurrent)
-	}
-
-	opts := validator.Options{
-		SchemaLocations:       locations,
-		SkipMissingSchemas:    validateArgs.skipMissingSchemas,
-		SkipKinds:             validateArgs.skipKinds,
-		HTTPTimeout:           rootArgs.timeout,
-		Workers:               validateArgs.concurrent,
-		InsecureSkipTLSVerify: validateArgs.insecureSkipTLSVerify,
-	}
-	if slices.Contains(inputs, stdinLabel) {
-		opts.Stdin = stdinReader
+	opts, err := buildValidatorOptions(inputs)
+	if err != nil {
+		return err
 	}
 	v, err := validator.New(opts)
 	if err != nil {
@@ -139,9 +116,23 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	stdinOnly := len(inputs) == 1 && inputs[0] == stdinLabel
+	mode := validateArgs.output.String()
 
 	files := make(map[string]struct{})
 	var nValid, nInvalid, nSkipped int
+	var collected []validator.Result
+
+	// Text mode streams per-result; structured modes buffer so the envelope
+	// can carry the full summary ahead of results[].
+	emit := func(r validator.Result) {
+		if mode == "text" {
+			if shouldPrint(r.Status, validateArgs.verbose) {
+				writeResult(cmd, r)
+			}
+			return
+		}
+		collected = append(collected, r)
+	}
 
 	// Reorder buffer: workers complete documents out of order, but we want
 	// deterministic (source, docIndex) output. For each source we track the
@@ -169,9 +160,7 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 			if !ok {
 				return
 			}
-			if shouldPrint(r.Status, validateArgs.verbose) {
-				writeResult(cmd, r)
-			}
+			emit(r)
 			delete(buf.pending, buf.nextIdx)
 			buf.nextIdx++
 		}
@@ -191,10 +180,7 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 		}
 		sort.Ints(indices)
 		for _, i := range indices {
-			r := buf.pending[i]
-			if shouldPrint(r.Status, validateArgs.verbose) {
-				writeResult(cmd, r)
-			}
+			emit(buf.pending[i])
 		}
 		buf.pending = nil
 	}
@@ -253,7 +239,20 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 		flushRemaining(src)
 	}
 
-	writeSummary(cmd, len(files), nValid+nInvalid+nSkipped, nValid, nInvalid, nSkipped, stdinOnly)
+	if mode != "text" {
+		summary := validator.ReportSummary{
+			Total:   nValid + nInvalid + nSkipped,
+			Valid:   nValid,
+			Invalid: nInvalid,
+			Skipped: nSkipped,
+		}
+		report := validator.NewReport("flux-schema/"+VERSION, time.Now(), collected, summary)
+		if err := writeReport(cmd, mode, report); err != nil {
+			return err
+		}
+	} else {
+		writeSummary(cmd, len(files), nValid+nInvalid+nSkipped, nValid, nInvalid, nSkipped, stdinOnly)
+	}
 
 	if nInvalid > 0 {
 		// Summary line already communicates the failure; exit non-zero
@@ -261,6 +260,31 @@ func validateCmdRun(cmd *cobra.Command, args []string) error {
 		return errSilent
 	}
 	return nil
+}
+
+// writeReport streams report to cmd's output as JSON or YAML. The `$schema`
+// key is JSON-only: it points at a JSON Schema document and carries no
+// meaning for YAML consumers, so we drop it in YAML mode.
+func writeReport(cmd *cobra.Command, mode string, report validator.Report) error {
+	switch mode {
+	case "json":
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			return fmt.Errorf("marshal report: %w", err)
+		}
+		return nil
+	case "yaml":
+		report.Schema = ""
+		data, err := yaml.Marshal(report)
+		if err != nil {
+			return fmt.Errorf("marshal report: %w", err)
+		}
+		cmd.Print(string(data))
+		return nil
+	default:
+		return fmt.Errorf("unsupported output format %q", mode)
+	}
 }
 
 // expandSchemaLocations normalizes each --schema-location value so callers can
@@ -358,4 +382,52 @@ func pluralize(word string, n int) string {
 		return word
 	}
 	return word + "s"
+}
+
+// loadValidateConfig applies a config file resolved from --config or the
+// FLUX_SCHEMA_CONFIG env var; missing path is a no-op.
+func loadValidateConfig(cmd *cobra.Command) error {
+	configPath := validateArgs.configFile
+	if configPath == "" {
+		configPath = os.Getenv(envConfigFile)
+	}
+	if configPath == "" {
+		return nil
+	}
+	cfg, err := loadConfigFile(configPath)
+	if err != nil {
+		return err
+	}
+	return applyValidateConfig(cmd, cfg.Validate, &validateArgs)
+}
+
+// buildValidatorOptions expands --schema-location values, validates flag
+// invariants, and assembles the validator.Options. Stdin is wired in when
+// inputs references the stdin sentinel.
+func buildValidatorOptions(inputs []string) (validator.Options, error) {
+	locations := validateArgs.schemaLocations
+	if len(locations) == 0 {
+		locations = []string{validator.DefaultSchemaLocation}
+	} else {
+		expanded, err := expandSchemaLocations(locations)
+		if err != nil {
+			return validator.Options{}, err
+		}
+		locations = expanded
+	}
+	if validateArgs.concurrent < 1 {
+		return validator.Options{}, fmt.Errorf("--concurrent must be >= 1, got %d", validateArgs.concurrent)
+	}
+	opts := validator.Options{
+		SchemaLocations:       locations,
+		SkipMissingSchemas:    validateArgs.skipMissingSchemas,
+		SkipKinds:             validateArgs.skipKinds,
+		HTTPTimeout:           rootArgs.timeout,
+		Workers:               validateArgs.concurrent,
+		InsecureSkipTLSVerify: validateArgs.insecureSkipTLSVerify,
+	}
+	if slices.Contains(inputs, stdinLabel) {
+		opts.Stdin = stdinReader
+	}
+	return opts, nil
 }

--- a/cmd/flux-schema/validate.go
+++ b/cmd/flux-schema/validate.go
@@ -327,8 +327,8 @@ func writeResult(cmd *cobra.Command, r validator.Result) {
 	case validator.StatusSkipped:
 		verb = "is skipped"
 	}
-	if r.Message != "" {
-		cmd.Printf("%s - %s %s: %s\n", r.Source, r.Identifier(), verb, r.Message)
+	if r.Reason != validator.ReasonNone {
+		cmd.Printf("%s - %s %s: %s\n", r.Source, r.Identifier(), verb, r.Reason)
 	} else {
 		cmd.Printf("%s - %s %s\n", r.Source, r.Identifier(), verb)
 	}

--- a/cmd/flux-schema/validate_test.go
+++ b/cmd/flux-schema/validate_test.go
@@ -88,7 +88,7 @@ func TestValidateCmd_InvalidManifest_PrintsViolationAndFails(t *testing.T) {
 		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
 	})
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(out).To(ContainSubstring(path + " - Widget/default/bad-widget is invalid: schema validation failed"))
+	g.Expect(out).To(ContainSubstring(path + " - Widget/default/bad-widget is invalid: schema violation"))
 	g.Expect(out).To(MatchRegexp(`(?m)^  - /spec/name: `))
 	g.Expect(out).To(ContainSubstring("Summary: 1 resource found in 1 file - Valid: 0, Invalid: 1, Skipped: 0"))
 }
@@ -155,7 +155,7 @@ spec:
 	// Admission-rule check runs before schema resolution, so the result is
 	// invalid even under --skip-missing-schemas.
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(out).To(ContainSubstring("Widget/default/#1 is invalid: validation failed"))
+	g.Expect(out).To(ContainSubstring("Widget/default/#1 is invalid: schema violation"))
 	g.Expect(out).To(MatchRegexp(`(?m)^  - /metadata: missing property 'name' or 'generateName'$`))
 }
 
@@ -218,10 +218,10 @@ func TestValidateCmd_InvalidFluxManifestsFixtures(t *testing.T) {
 	})
 	g.Expect(err).To(HaveOccurred())
 
-	g.Expect(out).To(ContainSubstring(invalidPath + " - Bucket/default/minio-bucket is invalid: schema validation failed"))
-	g.Expect(out).To(ContainSubstring(invalidPath + " - HelmRepository/default/example is invalid: schema validation failed"))
-	g.Expect(out).To(ContainSubstring(invalidPath + " - GitRepository/default/podinfo is invalid: schema validation failed"))
-	g.Expect(out).To(ContainSubstring(invalidPath + " - OCIRepository/default/podinfo is invalid: schema validation failed"))
+	g.Expect(out).To(ContainSubstring(invalidPath + " - Bucket/default/minio-bucket is invalid: schema violation"))
+	g.Expect(out).To(ContainSubstring(invalidPath + " - HelmRepository/default/example is invalid: schema violation"))
+	g.Expect(out).To(ContainSubstring(invalidPath + " - GitRepository/default/podinfo is invalid: schema violation"))
+	g.Expect(out).To(ContainSubstring(invalidPath + " - OCIRepository/default/podinfo is invalid: schema violation"))
 	g.Expect(out).To(ContainSubstring(invalidPath + " - ArtifactGenerator/apps/podinfo-composite is invalid: schema not found"))
 	g.Expect(out).To(MatchRegexp(`(?m)^  - no schema for kind "ArtifactGenerator" in version "source\.extensions\.fluxcd\.io/v1alpha1"$`))
 	g.Expect(out).To(ContainSubstring(invalidPath + " - HelmChart/default/podinfo is valid"))
@@ -251,12 +251,12 @@ func TestValidateCmd_InvalidMetadataFixtures(t *testing.T) {
 	})
 	g.Expect(err).To(HaveOccurred())
 
-	g.Expect(out).To(ContainSubstring(invalidPath + " - OCIRepository/default/duplicate-labels is invalid: YAML parse failed"))
-	g.Expect(out).To(ContainSubstring(invalidPath + " - OCIRepository/default/duplicate-fields is invalid: YAML parse failed"))
+	g.Expect(out).To(ContainSubstring(invalidPath + " - OCIRepository/default/duplicate-labels is invalid: yaml parse error"))
+	g.Expect(out).To(ContainSubstring(invalidPath + " - OCIRepository/default/duplicate-fields is invalid: yaml parse error"))
 	g.Expect(out).To(MatchRegexp(`(?m)^  - line 8: key "app" already set in map$`))
 	g.Expect(out).To(MatchRegexp(`(?m)^  - line 11: key "tag" already set in map$`))
 
-	g.Expect(out).To(ContainSubstring(invalidPath + " - OCIRepository/default/#3 is invalid: validation failed"))
+	g.Expect(out).To(ContainSubstring(invalidPath + " - OCIRepository/default/#3 is invalid: schema violation"))
 	g.Expect(out).To(MatchRegexp(`(?m)^  - /metadata: missing property 'name' or 'generateName'$`))
 
 	g.Expect(out).To(ContainSubstring("Summary: 3 resources found in 1 file - Valid: 0, Invalid: 3, Skipped: 0"))
@@ -333,7 +333,7 @@ func TestValidateCmd_FailFast(t *testing.T) {
 		"--concurrent", "1",
 	})
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(out).To(ContainSubstring("is invalid: schema validation failed"))
+	g.Expect(out).To(ContainSubstring("is invalid: schema violation"))
 	g.Expect(out).To(MatchRegexp(`Invalid: [1-9],`))
 }
 

--- a/cmd/flux-schema/validate_test.go
+++ b/cmd/flux-schema/validate_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	k8syaml "sigs.k8s.io/yaml"
 
 	"github.com/fluxcd/flux-schema/internal/validator"
 )
@@ -733,4 +734,272 @@ func TestExpandSchemaLocations(t *testing.T) {
 
 	_, err = expandSchemaLocations([]string{"   "})
 	g.Expect(err).To(MatchError(ContainSubstring("--schema-location must not be empty")))
+}
+
+// decodeReport parses the envelope emitted by --output json and returns the
+// inner body for convenient assertions.
+func decodeReport(t *testing.T, raw string) validator.Report {
+	t.Helper()
+	var env validator.Report
+	if err := json.Unmarshal([]byte(raw), &env); err != nil {
+		t.Fatalf("decode report: %v\nraw: %s", err, raw)
+	}
+	return env
+}
+
+func TestValidateCmd_Output_JSON_ValidManifest(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	path := writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"-o", "json",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	env := decodeReport(t, out)
+	g.Expect(env.Version).To(Equal(validator.ReportVersion))
+	g.Expect(env.Schema).To(Equal(validator.ReportSchema))
+	g.Expect(env.Report.Reporter).To(HavePrefix("flux-schema/"))
+	g.Expect(env.Report.Timestamp).ToNot(BeEmpty())
+	g.Expect(env.Report.Summary).To(Equal(validator.ReportSummary{Total: 1, Valid: 1, Invalid: 0, Skipped: 0}))
+	g.Expect(env.Report.Results).To(HaveLen(1))
+
+	res := env.Report.Results[0]
+	g.Expect(res.Source).To(Equal(path))
+	g.Expect(res.Idx).To(Equal(1))
+	g.Expect(res.Status).To(Equal("valid"))
+	g.Expect(res.Reason).To(Equal(validator.ReasonNone))
+	g.Expect(res.Violations).To(BeEmpty())
+	g.Expect(res.Resource).ToNot(BeNil())
+	g.Expect(*res.Resource).To(Equal(validator.ReportResource{
+		APIVersion: "example.com/v1",
+		Kind:       "Widget",
+		Namespace:  "default",
+		Name:       "ok-widget",
+	}))
+
+	// `reason` and `violations` must be omitted from the wire form of a valid
+	// result so consumers can branch on presence.
+	g.Expect(out).ToNot(ContainSubstring(`"reason"`))
+	g.Expect(out).ToNot(ContainSubstring(`"violations"`))
+}
+
+func TestValidateCmd_Output_JSON_SchemaViolation(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "bad.yaml", invalidWidget)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"-o", "json",
+	})
+	g.Expect(err).To(HaveOccurred())
+
+	env := decodeReport(t, out)
+	g.Expect(env.Report.Summary).To(Equal(validator.ReportSummary{Total: 1, Valid: 0, Invalid: 1, Skipped: 0}))
+	g.Expect(env.Report.Results).To(HaveLen(1))
+	res := env.Report.Results[0]
+	g.Expect(res.Status).To(Equal("invalid"))
+	g.Expect(res.Reason).To(Equal(validator.ReasonSchemaViolation))
+	g.Expect(res.Violations).ToNot(BeEmpty())
+	g.Expect(res.Violations[0].Path).To(Equal("/spec/name"))
+	g.Expect(res.Violations[0].Message).ToNot(BeEmpty())
+}
+
+func TestValidateCmd_Output_JSON_MissingAPIVersionKind(t *testing.T) {
+	g := NewWithT(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "noheader.yaml", `metadata:
+  name: orphan
+spec:
+  name: x
+`)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(t.TempDir(), "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"-o", "json",
+	})
+	g.Expect(err).To(HaveOccurred())
+
+	env := decodeReport(t, out)
+	g.Expect(env.Report.Results).To(HaveLen(1))
+	res := env.Report.Results[0]
+	g.Expect(res.Status).To(Equal("invalid"))
+	g.Expect(res.Reason).To(Equal(validator.ReasonSchemaViolation))
+	paths := make([]string, 0, len(res.Violations))
+	for _, v := range res.Violations {
+		paths = append(paths, v.Path)
+	}
+	g.Expect(paths).To(ConsistOf("/apiVersion", "/kind"))
+	for _, v := range res.Violations {
+		g.Expect(v.Message).To(Equal("missing required property"))
+	}
+}
+
+func TestValidateCmd_Output_JSON_KindSkipped(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--skip-kind", "Widget",
+		"-o", "json",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	env := decodeReport(t, out)
+	g.Expect(env.Report.Summary).To(Equal(validator.ReportSummary{Total: 1, Valid: 0, Invalid: 0, Skipped: 1}))
+	g.Expect(env.Report.Results).To(HaveLen(1))
+	res := env.Report.Results[0]
+	g.Expect(res.Status).To(Equal("skipped"))
+	g.Expect(res.Reason).To(Equal(validator.ReasonKindSkipped))
+	g.Expect(res.Violations).To(BeEmpty())
+}
+
+func TestValidateCmd_Output_JSON_SchemaNotFound(t *testing.T) {
+	g := NewWithT(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(t.TempDir(), "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--skip-missing-schemas",
+		"-o", "json",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	env := decodeReport(t, out)
+	g.Expect(env.Report.Summary).To(Equal(validator.ReportSummary{Total: 1, Valid: 0, Invalid: 0, Skipped: 1}))
+	res := env.Report.Results[0]
+	g.Expect(res.Status).To(Equal("skipped"))
+	g.Expect(res.Reason).To(Equal(validator.ReasonSchemaNotFound))
+	g.Expect(res.Violations).To(HaveLen(1))
+	g.Expect(res.Violations[0].Path).To(BeEmpty())
+	g.Expect(res.Violations[0].Message).To(ContainSubstring(`no schema for kind "Widget"`))
+}
+
+func TestValidateCmd_Output_JSON_SourceLoadError(t *testing.T) {
+	g := NewWithT(t)
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+
+	out, err := executeCommand([]string{
+		"validate", missing,
+		"--schema-location", filepath.Join(t.TempDir(), "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"-o", "json",
+	})
+	g.Expect(err).To(HaveOccurred())
+
+	env := decodeReport(t, out)
+	g.Expect(env.Report.Results).To(HaveLen(1))
+	res := env.Report.Results[0]
+	g.Expect(res.Resource).To(BeNil())
+	g.Expect(res.Status).To(Equal("invalid"))
+	g.Expect(res.Reason).To(Equal(validator.ReasonSourceLoadError))
+	g.Expect(res.Violations).To(HaveLen(1))
+	g.Expect(res.Violations[0].Message).To(ContainSubstring("no such file or directory"))
+
+	// `"resource": null` must appear on the wire so consumers can distinguish
+	// "no identity" from an empty object.
+	g.Expect(out).To(ContainSubstring(`"resource": null`))
+}
+
+func TestValidateCmd_Output_YAML_SmokeTest(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"-o", "yaml",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("version: 1.0.0"))
+	g.Expect(out).To(ContainSubstring("reporter: flux-schema/"))
+	g.Expect(out).To(ContainSubstring("status: valid"))
+	// $schema is a JSON-only pointer; dropping it keeps YAML output clean
+	// for consumers like yq that don't care about the envelope schema URL.
+	g.Expect(out).ToNot(ContainSubstring("$schema"))
+
+	var env validator.Report
+	// sigs.k8s.io/yaml re-encodes through JSON; json.Unmarshal is not
+	// appropriate here. Use sigs.k8s.io/yaml.Unmarshal for parity.
+	g.Expect(k8syaml.Unmarshal([]byte(out), &env)).To(Succeed())
+	g.Expect(env.Version).To(Equal(validator.ReportVersion))
+	g.Expect(env.Schema).To(BeEmpty())
+	g.Expect(env.Report.Summary.Valid).To(Equal(1))
+}
+
+// JSON/YAML output always emits every result regardless of --verbose; the
+// structured form is for machines, and filtering belongs downstream.
+func TestValidateCmd_Output_JSON_IgnoresVerbose(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "mixed.yaml", validWidget+"---\n"+invalidWidget)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"-o", "json",
+	})
+	g.Expect(err).To(HaveOccurred())
+
+	env := decodeReport(t, out)
+	g.Expect(env.Report.Summary).To(Equal(validator.ReportSummary{Total: 2, Valid: 1, Invalid: 1, Skipped: 0}))
+	g.Expect(env.Report.Results).To(HaveLen(2))
+
+	statuses := []string{env.Report.Results[0].Status, env.Report.Results[1].Status}
+	g.Expect(statuses).To(ConsistOf("valid", "invalid"))
+}
+
+func TestValidateCmd_Output_JSON_Config(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	cfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "1"
+validate:
+  output: json
+`)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--config", cfg,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	env := decodeReport(t, out)
+	g.Expect(env.Version).To(Equal(validator.ReportVersion))
+	g.Expect(env.Report.Summary.Valid).To(Equal(1))
+}
+
+func TestValidateCmd_Output_Unsupported(t *testing.T) {
+	g := NewWithT(t)
+	_, err := executeCommand([]string{"validate", "--output", "toml"})
+	g.Expect(err).To(MatchError(ContainSubstring("unsupported output format")))
+}
+
+func TestValidateCmd_Config_InvalidOutput(t *testing.T) {
+	g := NewWithT(t)
+	cfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "1"
+validate:
+  output: toml
+`)
+	_, err := executeCommand([]string{"validate", "--config", cfg})
+	g.Expect(err).To(MatchError(ContainSubstring("unsupported output format")))
 }

--- a/docs/report/README.md
+++ b/docs/report/README.md
@@ -1,0 +1,184 @@
+# flux-schema validation report
+
+The `flux-schema validate` command can emit a structured report of the
+validation results by setting `--output` to `json` or `yaml`. The envelope
+shape is versioned and documented by the JSON Schema in
+[`schema-1.0.0.json`](./schema-1.0.0.json).
+
+## Usage
+
+```shell
+flux-schema validate ./manifests -o json
+```
+
+Structured output always emits every result regardless of `--verbose`.
+Filtering belongs downstream (`jq`, `yq`). The process exit code still
+reflects whether any document was invalid.
+
+## Envelope
+
+Every report is wrapped in a top-level envelope:
+
+| Key                | Description                                               |
+|--------------------|-----------------------------------------------------------|
+| `version`          | Wire format version. Currently `"1.0.0"`.                 |
+| `$schema`          | URL of the JSON Schema describing the envelope.           |
+| `report.reporter`  | Identity of the producer, e.g. `flux-schema/0.1.0`.       |
+| `report.timestamp` | RFC 3339 UTC timestamp of the run.                        |
+| `report.summary`   | Aggregate counts: `total`, `valid`, `invalid`, `skipped`. |
+| `report.results[]` | One entry per validated document, in source order.        |
+
+## Result fields
+
+| Key            | Description                                                                                                                                                               |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `resource`     | `{apiVersion, kind, namespace?, name?}` or `null` when no Kubernetes identity could be recovered (e.g. a file that fails to open, or stdin that is not YAML).             |
+| `source`       | File path or `stdin`.                                                                                                                                                     |
+| `idx`          | 1-based position of the document within its source. `0` for source-level failures that have no document.                                                                  |
+| `status`       | `"valid"`, `"invalid"`, or `"skipped"`.                                                                                                                                   |
+| `reason`       | Stable kebab-case code (see below). Omitted when `status` is `"valid"`.                                                                                                   |
+| `violations[]` | Zero or more `{path?, message}` entries. `path` is a JSON Pointer set by schema violations; for every other reason it is absent and `message` carries the raw error text. |
+
+## Reason enum
+
+| Reason              | Triggered by                                                                                           | Status (default / with `--skip-missing-schemas`) |
+|---------------------|--------------------------------------------------------------------------------------------------------|--------------------------------------------------|
+| `source-load-error` | Source-level open/read failure.                                                                        | `invalid` / `invalid`                            |
+| `yaml-parse-error`  | Strict YAML decode fails (duplicate keys, malformed doc).                                              | `invalid` / `invalid`                            |
+| `schema-load-error` | Schema loader failure (HTTP fetch, file read, or JSON Schema compile).                                 | `invalid` / `invalid`                            |
+| `schema-not-found`  | No schema applicable — either no schema file matches the GVK, or the document has no GVK to look up.   | `invalid` / `skipped`                            |
+| `schema-violation`  | Document fails one or more schema constraints. `violations[]` carries a JSON Pointer `path` per entry. | `invalid` / `invalid`                            |
+| `kind-skipped`      | Matched a `--skip-kind` pattern.                                                                       | `skipped` / `skipped`                            |
+
+## Example
+
+```json
+{
+  "version": "1.0.0",
+  "$schema": "https://raw.githubusercontent.com/fluxcd/flux-schema/main/docs/report/schema-1.0.0.json",
+  "report": {
+    "reporter": "flux-schema/v0.1.0",
+    "timestamp": "2026-06-01T12:00:00Z",
+    "summary": {
+      "total": 7,
+      "valid": 1,
+      "invalid": 5,
+      "skipped": 1
+    },
+    "results": [
+      {
+        "resource": {
+          "apiVersion": "apps/v1",
+          "kind": "Deployment",
+          "namespace": "default",
+          "name": "web"
+        },
+        "source": "manifests/app.yaml",
+        "idx": 1,
+        "status": "valid"
+      },
+      {
+        "resource": {
+          "apiVersion": "source.toolkit.fluxcd.io/v1",
+          "kind": "Bucket",
+          "namespace": "apps",
+          "name": "minio"
+        },
+        "source": "manifests/sources.yaml",
+        "idx": 1,
+        "status": "invalid",
+        "reason": "schema-violation",
+        "violations": [
+          {
+            "path": "/spec",
+            "message": "missing property 'bucketName'"
+          },
+          {
+            "path": "/spec/interval",
+            "message": "got number, want string"
+          },
+          {
+            "path": "/spec",
+            "message": "additional properties 'force' not allowed"
+          }
+        ]
+      },
+      {
+        "resource": {
+          "apiVersion": "source.toolkit.fluxcd.io/v1",
+          "kind": "OCIRepository",
+          "namespace": "default",
+          "name": "podinfo"
+        },
+        "source": "manifests/sources.yaml",
+        "idx": 2,
+        "status": "invalid",
+        "reason": "yaml-parse-error",
+        "violations": [
+          {
+            "message": "line 18: key \"app.kubernetes.io/name\" already set in map"
+          }
+        ]
+      },
+      {
+        "resource": null,
+        "source": "manifests/missing.yaml",
+        "idx": 0,
+        "status": "invalid",
+        "reason": "source-load-error",
+        "violations": [
+          {
+            "message": "open manifests/missing.yaml: no such file or directory"
+          }
+        ]
+      },
+      {
+        "resource": {
+          "apiVersion": "example.com/v1",
+          "kind": "Widget",
+          "namespace": "default",
+          "name": "w1"
+        },
+        "source": "manifests/widgets.yaml",
+        "idx": 1,
+        "status": "invalid",
+        "reason": "schema-load-error",
+        "violations": [
+          {
+            "message": "Get \"https://schemas.example.com/Widget_v1.json\": dial tcp: lookup schemas.example.com: no such host"
+          }
+        ]
+      },
+      {
+        "resource": {
+          "apiVersion": "artifact.toolkit.fluxcd.io/v1",
+          "kind": "ArtifactGenerator",
+          "namespace": "apps",
+          "name": "podinfo"
+        },
+        "source": "manifests/artifacts.yaml",
+        "idx": 1,
+        "status": "invalid",
+        "reason": "schema-not-found",
+        "violations": [
+          {
+            "message": "no schema for kind \"ArtifactGenerator\" in version \"artifact.toolkit.fluxcd.io/v1\""
+          }
+        ]
+      },
+      {
+        "resource": {
+          "apiVersion": "v1",
+          "kind": "Secret",
+          "namespace": "apps",
+          "name": "auth-sops"
+        },
+        "source": "manifests/secrets.yaml",
+        "idx": 1,
+        "status": "skipped",
+        "reason": "kind-skipped"
+      }
+    ]
+  }
+}
+```

--- a/docs/report/schema-1.0.0.json
+++ b/docs/report/schema-1.0.0.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/fluxcd/flux-schema/main/docs/report/schema-1.0.0.json",
+  "title": "flux-schema validation report",
+  "description": "Structured report emitted by `flux-schema validate --output json|yaml`.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "report"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "report": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reporter", "timestamp", "summary", "results"],
+      "properties": {
+        "reporter": {
+          "type": "string",
+          "pattern": "^flux-schema/"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["total", "valid", "invalid", "skipped"],
+          "properties": {
+            "total":   { "type": "integer", "minimum": 0 },
+            "valid":   { "type": "integer", "minimum": 0 },
+            "invalid": { "type": "integer", "minimum": 0 },
+            "skipped": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "results": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/result" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["resource", "source", "idx", "status"],
+      "properties": {
+        "resource": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/resource" }
+          ]
+        },
+        "source": { "type": "string" },
+        "idx":    { "type": "integer", "minimum": 0 },
+        "status": {
+          "type": "string",
+          "enum": ["valid", "invalid", "skipped"]
+        },
+        "reason": {
+          "type": "string",
+          "enum": [
+            "source-load-error",
+            "yaml-parse-error",
+            "kind-skipped",
+            "schema-load-error",
+            "schema-not-found",
+            "schema-violation"
+          ]
+        },
+        "violations": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/violation" }
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "status": { "const": "valid" } } },
+          "then": {
+            "not": { "required": ["reason"] }
+          },
+          "else": {
+            "required": ["reason"]
+          }
+        }
+      ]
+    },
+    "resource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["apiVersion", "kind"],
+      "properties": {
+        "apiVersion": { "type": "string" },
+        "kind":       { "type": "string" },
+        "namespace":  { "type": "string" },
+        "name":       { "type": "string" }
+      }
+    },
+    "violation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["message"],
+      "properties": {
+        "path":    { "type": "string" },
+        "message": { "type": "string" }
+      }
+    }
+  }
+}

--- a/internal/validator/reason.go
+++ b/internal/validator/reason.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import "strings"
+
+// Reason is a stable, machine-readable code describing why a Result has
+// its Status. It is treated as API surface: adding a new Reason is
+// backwards-compatible, but renaming or repurposing an existing value is
+// not. The kebab-case wire form doubles as the human-readable form for
+// text output via Reason.String (dashes become spaces), so there is only
+// one string to maintain per case.
+type Reason string
+
+const (
+	// ReasonNone is the zero value, carried by every StatusValid result.
+	ReasonNone Reason = ""
+
+	// ReasonSourceLoadError indicates the input source itself could not be
+	// read (file open/stat failure, stdin read error, etc.). The raw error
+	// text lands in Errors[0].Msg.
+	ReasonSourceLoadError Reason = "source-load-error"
+
+	// ReasonYAMLParseError indicates strict YAML decoding failed — malformed
+	// document, duplicate keys, or other structural issues. Per-violation
+	// detail is in Errors.
+	ReasonYAMLParseError Reason = "yaml-parse-error"
+
+	// ReasonKindSkipped indicates the document was skipped because its
+	// apiVersion/Kind matched a --skip-kind pattern.
+	ReasonKindSkipped Reason = "kind-skipped"
+
+	// ReasonSchemaLoadError indicates the schema loader failed (HTTP fetch,
+	// file read, or JSON Schema compile). Raw error text is in Errors[0].Msg.
+	ReasonSchemaLoadError Reason = "schema-load-error"
+
+	// ReasonSchemaNotFound indicates no schema could be applied to the
+	// document — either no schema file matched the GVK, or the document has
+	// no GVK to look up (under --skip-missing-schemas).
+	ReasonSchemaNotFound Reason = "schema-not-found"
+
+	// ReasonSchemaViolation indicates the document failed one or more schema
+	// constraints. Errors carries one entry per violation with a JSON Pointer
+	// Path to the offending field.
+	ReasonSchemaViolation Reason = "schema-violation"
+)
+
+// String returns the human-readable form used in text output: the kebab-case
+// value with dashes replaced by spaces (e.g. "schema-not-found" → "schema
+// not found"). An empty Reason returns an empty string, which the CLI
+// renderer treats as "no reason suffix."
+func (r Reason) String() string {
+	return strings.ReplaceAll(string(r), "-", " ")
+}

--- a/internal/validator/report.go
+++ b/internal/validator/report.go
@@ -1,0 +1,109 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import "time"
+
+// ReportVersion pins the wire format version emitted by NewReport.
+const ReportVersion = "1.0.0"
+
+// ReportSchema is the canonical URL of the JSON Schema describing the Report shape.
+const ReportSchema = "https://raw.githubusercontent.com/fluxcd/flux-schema/main/docs/report/schema-1.0.0.json"
+
+// Report is the envelope emitted when `flux-schema validate` runs with
+// --output json or --output yaml. The JSON tags are authoritative; the YAML
+// encoder (sigs.k8s.io/yaml) reflects them through JSON.
+type Report struct {
+	Version string     `json:"version"`
+	Schema  string     `json:"$schema,omitempty"`
+	Report  ReportBody `json:"report"`
+}
+
+type ReportBody struct {
+	Reporter  string         `json:"reporter"`
+	Timestamp string         `json:"timestamp"`
+	Summary   ReportSummary  `json:"summary"`
+	Results   []ReportResult `json:"results"`
+}
+
+type ReportSummary struct {
+	Total   int `json:"total"`
+	Valid   int `json:"valid"`
+	Invalid int `json:"invalid"`
+	Skipped int `json:"skipped"`
+}
+
+// ReportResult is the wire form of a single validated document. Resource is
+// a pointer so the zero value renders as `"resource": null` rather than an
+// empty object — consumers must tolerate a null resource when no identity
+// could be recovered (file open failure, unparsable YAML, etc.).
+type ReportResult struct {
+	Resource   *ReportResource   `json:"resource"`
+	Source     string            `json:"source"`
+	Idx        int               `json:"idx"`
+	Status     string            `json:"status"`
+	Reason     Reason            `json:"reason,omitempty"`
+	Violations []ReportViolation `json:"violations,omitempty"`
+}
+
+type ReportResource struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Namespace  string `json:"namespace,omitempty"`
+	Name       string `json:"name,omitempty"`
+}
+
+// ReportViolation carries a JSON Pointer path only for ReasonSchemaViolation;
+// for every other reason Path is empty and Message holds the raw error text.
+type ReportViolation struct {
+	Path    string `json:"path,omitempty"`
+	Message string `json:"message"`
+}
+
+// NewReportResult converts a Result into its wire-format counterpart.
+// Resource is nil when no apiVersion/kind could be recovered (source-load
+// or unparsable-YAML failures); the pointer renders as `"resource": null`.
+func NewReportResult(r Result) ReportResult {
+	out := ReportResult{
+		Source: r.Source,
+		Idx:    r.DocIndex,
+		Status: r.Status.String(),
+		Reason: r.Reason,
+	}
+	if r.APIVersion != "" || r.Kind != "" {
+		out.Resource = &ReportResource{
+			APIVersion: r.APIVersion,
+			Kind:       r.Kind,
+			Namespace:  r.Namespace,
+			Name:       r.Name,
+		}
+	}
+	if len(r.Errors) > 0 {
+		out.Violations = make([]ReportViolation, len(r.Errors))
+		for i, e := range r.Errors {
+			out.Violations[i] = ReportViolation{Path: e.Path, Message: e.Msg}
+		}
+	}
+	return out
+}
+
+// NewReport assembles a Report from the validator outputs. The caller owns
+// the reporter string (typically "flux-schema/"+VERSION) and the timestamp
+// so tests can pin both.
+func NewReport(reporter string, timestamp time.Time, results []Result, summary ReportSummary) Report {
+	body := ReportBody{
+		Reporter:  reporter,
+		Timestamp: timestamp.UTC().Format(time.RFC3339),
+		Summary:   summary,
+		Results:   make([]ReportResult, len(results)),
+	}
+	for i, r := range results {
+		body.Results[i] = NewReportResult(r)
+	}
+	return Report{
+		Version: ReportVersion,
+		Schema:  ReportSchema,
+		Report:  body,
+	}
+}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -69,7 +69,7 @@ type Result struct {
 	Namespace  string
 	Name       string
 	Status     Status
-	Message    string
+	Reason     Reason
 	Errors     []ValidationError
 	Final      bool
 }
@@ -308,7 +308,8 @@ func (v *Validator) runJob(ctx context.Context, j job, results chan<- Result) {
 			Source:   j.source,
 			DocIndex: j.docIndex,
 			Status:   StatusInvalid,
-			Message:  j.loadErr.Error(),
+			Reason:   ReasonSourceLoadError,
+			Errors:   []ValidationError{{Msg: j.loadErr.Error()}},
 		}
 	} else {
 		r, emit = v.validateDoc(ctx, j.source, j.docIndex, j.raw)
@@ -440,14 +441,16 @@ func (v *Validator) streamReader(ctx context.Context, source string, r io.Reader
 // intended to validate — a file starting with `# header\n---\n...` is idiomatic.
 func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw []byte) (Result, bool) {
 	r := Result{Source: source, DocIndex: idx}
-	settle := func(s Status, msg string) (Result, bool) {
+	settle := func(s Status, reason Reason) (Result, bool) {
 		r.Status = s
-		r.Message = msg
+		r.Reason = reason
 		return r, true
 	}
 	// missingSchemaStatus picks between StatusSkipped and StatusInvalid for
-	// "we can't resolve a schema for this document" cases, honoring
-	// Options.SkipMissingSchemas.
+	// the "schema file not found for a resolved GVK" case, honoring
+	// Options.SkipMissingSchemas. The other no-schema case (missing
+	// apiVersion/kind) branches on SkipMissingSchemas directly earlier in
+	// this function, since it maps to different reason codes.
 	missingSchemaStatus := func() Status {
 		if v.opts.SkipMissingSchemas {
 			return StatusSkipped
@@ -468,7 +471,7 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 			r.Name = fmt.Sprintf("#%d", idx)
 		}
 		r.Errors = splitYAMLError(err)
-		return settle(StatusInvalid, "YAML parse failed")
+		return settle(StatusInvalid, ReasonYAMLParseError)
 	}
 	if doc == nil {
 		// Content-free document (comments or whitespace only). Idiomatic
@@ -486,12 +489,34 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 	// that would otherwise fail the name/generateName rule.
 	for _, m := range v.skipKinds {
 		if m.matches(r.APIVersion, r.Kind) {
-			return settle(StatusSkipped, "kind skipped")
+			return settle(StatusSkipped, ReasonKindSkipped)
 		}
 	}
 
 	if r.APIVersion == "" || r.Kind == "" {
-		return settle(missingSchemaStatus(), "document missing apiVersion/kind")
+		// With --skip-missing-schemas we can't do anything useful for a doc
+		// with no GVK to look up; treat it as "schema not found" and let the
+		// user's skip policy decide. Otherwise surface path-based errors so
+		// consumers know exactly which top-level fields the doc is missing.
+		if v.opts.SkipMissingSchemas {
+			r.Errors = []ValidationError{{
+				Msg: "no schema: document is missing apiVersion/kind",
+			}}
+			return settle(StatusSkipped, ReasonSchemaNotFound)
+		}
+		if r.APIVersion == "" {
+			r.Errors = append(r.Errors, ValidationError{
+				Path: "/apiVersion",
+				Msg:  "missing required property",
+			})
+		}
+		if r.Kind == "" {
+			r.Errors = append(r.Errors, ValidationError{
+				Path: "/kind",
+				Msg:  "missing required property",
+			})
+		}
+		return settle(StatusInvalid, ReasonSchemaViolation)
 	}
 
 	if !hasIdentity {
@@ -499,7 +524,7 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 			Path: "/metadata",
 			Msg:  "missing property 'name' or 'generateName'",
 		}}
-		return settle(StatusInvalid, "validation failed")
+		return settle(StatusInvalid, ReasonSchemaViolation)
 	}
 
 	group, version, ok := strings.Cut(r.APIVersion, "/")
@@ -512,18 +537,18 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 	schema, _, found, err := v.loader.Resolve(ctx, vars)
 	if err != nil {
 		r.Errors = []ValidationError{{Msg: err.Error()}}
-		return settle(StatusInvalid, "schema resolution failed")
+		return settle(StatusInvalid, ReasonSchemaLoadError)
 	}
 	if !found {
 		r.Errors = []ValidationError{{
 			Msg: fmt.Sprintf("no schema for kind %q in version %q", r.Kind, r.APIVersion),
 		}}
-		return settle(missingSchemaStatus(), "schema not found")
+		return settle(missingSchemaStatus(), ReasonSchemaNotFound)
 	}
 
 	if err := schema.Validate(doc); err != nil {
 		r.Errors = flattenErrors(err)
-		return settle(StatusInvalid, "schema validation failed")
+		return settle(StatusInvalid, ReasonSchemaViolation)
 	}
 	r.Status = StatusValid
 	return r, true

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -105,7 +105,7 @@ spec:
 	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
 	g.Expect(results).To(HaveLen(1))
 	g.Expect(results[0].Status).To(Equal(StatusInvalid))
-	g.Expect(results[0].Message).To(Equal("schema validation failed"))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaViolation))
 	g.Expect(results[0].Errors).ToNot(BeEmpty())
 	found := false
 	for _, e := range results[0].Errors {
@@ -138,7 +138,7 @@ spec:
 	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
 	g.Expect(results).To(HaveLen(1))
 	g.Expect(results[0].Status).To(Equal(StatusInvalid))
-	g.Expect(results[0].Message).To(Equal("schema validation failed"))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaViolation))
 	// flattenErrors must surface one entry per leaf cause; we don't pin the
 	// exact count (jsonschema/v6 can emit multiple causes per keyword) but
 	// every expected path must appear at least once.
@@ -183,7 +183,7 @@ spec:
 			results := v.ValidateBytes(context.Background(), "test.yaml", doc)
 			g.Expect(results).To(HaveLen(1))
 			g.Expect(results[0].Status).To(Equal(StatusValid),
-				"duration %q should validate; got %s: %s", d, results[0].Status, results[0].Message)
+				"duration %q should validate; got %s: %s", d, results[0].Status, results[0].Reason)
 		})
 	}
 }
@@ -239,7 +239,7 @@ spec:
 `)
 	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
 	g.Expect(results[0].Status).To(Equal(StatusInvalid))
-	g.Expect(results[0].Message).To(Equal("schema not found"))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaNotFound))
 	g.Expect(results[0].Errors).To(ConsistOf(
 		ValidationError{Msg: `no schema for kind "Widget" in version "example.com/v1"`},
 	))
@@ -384,7 +384,7 @@ spec:
 `)
 	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
 	g.Expect(results[0].Status).To(Equal(StatusInvalid))
-	g.Expect(results[0].Message).To(Equal("validation failed"))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaViolation))
 	g.Expect(results[0].Errors).To(ConsistOf(
 		ValidationError{Path: "/metadata", Msg: "missing property 'name' or 'generateName'"},
 	))
@@ -407,7 +407,7 @@ spec:
 `)
 	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
 	g.Expect(results[0].Status).To(Equal(StatusInvalid))
-	g.Expect(results[0].Message).To(Equal("YAML parse failed"))
+	g.Expect(results[0].Reason).To(Equal(ReasonYAMLParseError))
 	g.Expect(results[0].Errors).ToNot(BeEmpty())
 	// The last-wins lenient parse must recover identity fields so the CLI
 	// line reads "Widget/.../w2" rather than "/#1".
@@ -475,7 +475,7 @@ spec:
 	g.Expect(results[0].Identifier()).To(Equal("Widget/default/#1"))
 }
 
-func TestValidateBytes_MissingApiVersion(t *testing.T) {
+func TestValidateBytes_MissingApiVersionAndKind(t *testing.T) {
 	g := NewWithT(t)
 	dir := t.TempDir()
 	v := newLocalValidator(t, dir, false)
@@ -485,7 +485,66 @@ func TestValidateBytes_MissingApiVersion(t *testing.T) {
 `)
 	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
 	g.Expect(results[0].Status).To(Equal(StatusInvalid))
-	g.Expect(results[0].Message).To(ContainSubstring("missing apiVersion/kind"))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaViolation))
+	g.Expect(results[0].Errors).To(ConsistOf(
+		ValidationError{Path: "/apiVersion", Msg: "missing required property"},
+		ValidationError{Path: "/kind", Msg: "missing required property"},
+	))
+}
+
+func TestValidateBytes_MissingApiVersionOnly(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	v := newLocalValidator(t, dir, false)
+
+	doc := []byte(`kind: Widget
+metadata:
+  name: w1
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaViolation))
+	g.Expect(results[0].Errors).To(ConsistOf(
+		ValidationError{Path: "/apiVersion", Msg: "missing required property"},
+	))
+}
+
+func TestValidateBytes_MissingKindOnly(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	v := newLocalValidator(t, dir, false)
+
+	doc := []byte(`apiVersion: example.com/v1
+metadata:
+  name: w1
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaViolation))
+	g.Expect(results[0].Errors).To(ConsistOf(
+		ValidationError{Path: "/kind", Msg: "missing required property"},
+	))
+}
+
+func TestValidateBytes_MissingApiVersionAndKind_Skipped(t *testing.T) {
+	// With --skip-missing-schemas the result is treated the same way as "no
+	// schema file matches the GVK": a single message-only error, no path.
+	// The reason this belongs with schema-not-found (not schema-violation) is
+	// that we can't look up a schema without a GVK, so the user's skip policy
+	// is what decides the outcome — not a content-shape violation.
+	g := NewWithT(t)
+	dir := t.TempDir()
+	v := newLocalValidator(t, dir, true)
+
+	doc := []byte(`metadata:
+  name: w1
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results[0].Status).To(Equal(StatusSkipped))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaNotFound))
+	g.Expect(results[0].Errors).To(ConsistOf(
+		ValidationError{Msg: "no schema: document is missing apiVersion/kind"},
+	))
 }
 
 func TestValidateSources_ConcurrencyCacheDedup(t *testing.T) {
@@ -544,12 +603,74 @@ spec: {}
 		if r.Final {
 			continue
 		}
-		g.Expect(r.Status).To(Equal(StatusValid), "unexpected status for doc %d: %s %s", r.DocIndex, r.Status, r.Message)
+		g.Expect(r.Status).To(Equal(StatusValid), "unexpected status for doc %d: %s %s", r.DocIndex, r.Status, r.Reason)
 		count++
 	}
 	g.Expect(count).To(Equal(50))
 	// Exactly one HTTP fetch thanks to the sync.Map + sync.Once cache.
 	g.Expect(requestCount.Load()).To(Equal(int32(1)))
+}
+
+// TestValidateSources_SourceLoadError exercises the produceFromPath →
+// runJob.loadErr branch: a non-existent input path must surface as a
+// single invalid result with Reason=ReasonSourceLoadError and the raw
+// OS error text attached to Errors[0].Msg (not to the deprecated Message
+// field). Downstream consumers of the structured output contract rely on
+// the raw text living in Errors[0].
+func TestValidateSources_SourceLoadError(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchema(t, dir)
+	v := newLocalValidator(t, dir, false)
+
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	ch := v.ValidateSources(context.Background(), []string{missing})
+
+	var got []Result
+	for r := range ch {
+		if r.Final {
+			continue
+		}
+		got = append(got, r)
+	}
+	g.Expect(got).To(HaveLen(1))
+	g.Expect(got[0].Source).To(Equal(missing))
+	g.Expect(got[0].Status).To(Equal(StatusInvalid))
+	g.Expect(got[0].Reason).To(Equal(ReasonSourceLoadError))
+	g.Expect(got[0].Errors).To(HaveLen(1))
+	g.Expect(got[0].Errors[0].Path).To(BeEmpty())
+	g.Expect(got[0].Errors[0].Msg).To(ContainSubstring("no such file or directory"))
+}
+
+// TestValidateBytes_SchemaLoadError exercises the loader.Resolve error
+// branch: a schema file on disk that is not valid JSON must produce
+// Reason=ReasonSchemaLoadError with the compile error in Errors[0].Msg.
+func TestValidateBytes_SchemaLoadError(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	// Matches the template used by newLocalValidator
+	// ("{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json").
+	g.Expect(os.WriteFile(
+		filepath.Join(dir, "Widget-example-v1.json"),
+		[]byte("{not valid json"),
+		0o644,
+	)).To(Succeed())
+	v := newLocalValidator(t, dir, false)
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec:
+  name: ok
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaLoadError))
+	g.Expect(results[0].Errors).To(HaveLen(1))
+	g.Expect(results[0].Errors[0].Path).To(BeEmpty())
+	g.Expect(results[0].Errors[0].Msg).ToNot(BeEmpty())
 }
 
 func TestValidateSources_WalksDirectory(t *testing.T) {
@@ -766,7 +887,7 @@ stringData:
 	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
 	g.Expect(results).To(HaveLen(1))
 	g.Expect(results[0].Status).To(Equal(StatusSkipped))
-	g.Expect(results[0].Message).To(Equal("kind skipped"))
+	g.Expect(results[0].Reason).To(Equal(ReasonKindSkipped))
 	g.Expect(results[0].Identifier()).To(Equal("Secret/s1"))
 }
 
@@ -801,7 +922,7 @@ spec:
 `)
 	results = v.ValidateBytes(context.Background(), "test.yaml", other)
 	g.Expect(results[0].Status).To(Equal(StatusInvalid))
-	g.Expect(results[0].Message).To(Equal("schema not found"))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaNotFound))
 }
 
 func TestValidateBytes_SkipKind_BypassesAdmissionCheck(t *testing.T) {

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -648,10 +648,10 @@ func TestValidateSources_SourceLoadError(t *testing.T) {
 func TestValidateBytes_SchemaLoadError(t *testing.T) {
 	g := NewWithT(t)
 	dir := t.TempDir()
-	// Matches the template used by newLocalValidator
-	// ("{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json").
+	// Template variables lowercase at render time, so the file must match
+	// the rendered path on case-sensitive filesystems (Linux CI).
 	g.Expect(os.WriteFile(
-		filepath.Join(dir, "Widget-example-v1.json"),
+		filepath.Join(dir, "widget-example-v1.json"),
 		[]byte("{not valid json"),
 		0o644,
 	)).To(Succeed())


### PR DESCRIPTION
The `flux-schema validate` command can now emit a structured report of the validation results by setting `--output` to `json` or `yaml`. The envelope shape is versioned and documented by the JSON Schema.

### Envelope

Every report is wrapped in a top-level envelope:

| Key                | Description                                               |
|--------------------|-----------------------------------------------------------|
| `version`          | Wire format version. Currently `"1.0.0"`.                 |
| `$schema`          | URL of the JSON Schema describing the envelope.           |
| `report.reporter`  | Identity of the producer, e.g. `flux-schema/0.1.0`.       |
| `report.timestamp` | RFC 3339 UTC timestamp of the run.                        |
| `report.summary`   | Aggregate counts: `total`, `valid`, `invalid`, `skipped`. |
| `report.results[]` | One entry per validated document, in source order.        |

### Result fields

| Key            | Description                                                                                                                                                               |
|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `resource`     | `{apiVersion, kind, namespace?, name?}` or `null` when no Kubernetes identity could be recovered (e.g. a file that fails to open, or stdin that is not YAML).             |
| `source`       | File path or `(stdin)`.                                                                                                                                                   |
| `idx`          | 1-based position of the document within its source. `0` for source-level failures that have no document.                                                                  |
| `status`       | `"valid"`, `"invalid"`, or `"skipped"`.                                                                                                                                   |
| `reason`       | Stable kebab-case code (see below). Omitted when `status` is `"valid"`.                                                                                                   |
| `violations[]` | Zero or more `{path?, message}` entries. `path` is a JSON Pointer set by schema violations; for every other reason it is absent and `message` carries the raw error text. |

### Reason enum

| Reason              | Triggered by                                                                                           | Status (default / with `--skip-missing-schemas`) |
|---------------------|--------------------------------------------------------------------------------------------------------|--------------------------------------------------|
| `source-load-error` | Source-level open/read failure.                                                                        | `invalid` / `invalid`                            |
| `yaml-parse-error`  | Strict YAML decode fails (duplicate keys, malformed doc).                                              | `invalid` / `invalid`                            |
| `schema-load-error` | Schema loader failure (HTTP fetch, file read, or JSON Schema compile).                                 | `invalid` / `invalid`                            |
| `schema-not-found`  | No schema applicable — either no schema file matches the GVK, or the document has no GVK to look up.   | `invalid` / `skipped`                            |
| `schema-violation`  | Document fails one or more schema constraints. `violations[]` carries a JSON Pointer `path` per entry. | `invalid` / `invalid`                            |
| `kind-skipped`      | Matched a `--skip-kind` pattern.                                                                       | `skipped` / `skipped`                            |
