### PR TITLE
Add `--skip-json-path` to validate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Flux CLI plugin for Kubernetes schema extraction and manifests validation.
 - `flux-schema validate [paths...]`: Validate Kubernetes manifests against JSON Schemas
     - `--schema-location`: URL or file path for schemas (repeatable, tried in order); `default` points at the built-in catalog
     - `--skip-missing-schemas`: Skip documents for which no schema can be found
-    - `--skip-kind`: Skip documents matching `Kind` or `apiVersion/Kind` (repeatable)
+    - `--skip-kind`: Skip documents matching `kind` or `apiVersion/kind` (repeatable)
+    - `--skip-json-path`: Strip a JSON Pointer field before validation, optionally scoped: `[apiVersion/kind:]/path` (repeatable)
     - `--fail-fast`: Exit after the first invalid document
     - `--concurrent`: Number of concurrent workers (default 8)
     - `--insecure-skip-tls-verify`: Disable TLS certificate verification when fetching schemas over HTTPS
@@ -79,8 +80,18 @@ Manifests can also be piped in and certain documents skipped with `--skip-kind`:
 
 ```shell
 kustomize build . | flux-schema validate \
-  --skip-kind 'v1/Secret' \
+  --skip-kind 'v1/Service' \
   --skip-kind 'source.toolkit.fluxcd.io/v1/ExternalArtifact'
+```
+
+Some manifests carry tooling-injected fields that are stripped at apply time by Flux
+(e.g. SOPS-encrypted Secrets). Use `--skip-json-path` to remove those fields from
+validation so the rest of the document is still checked.
+
+```shell
+flux-schema validate ./manifests \
+  --skip-json-path 'v1/Secret:/sops' \
+  --skip-json-path 'Deployment:/sops'
 ```
 
 Output example with validation errors:
@@ -145,8 +156,10 @@ validate:
     - default
     - https://raw.githubusercontent.com/datreeio/CRDs-catalog/main
   skip-kind:
-    - v1/Secret
+    - v1/ServiceAccont
     - source.toolkit.fluxcd.io/v1/ExternalArtifact
+  skip-json-path:
+    - Secret:/sops
   skip-missing-schemas: false
   verbose: true
   fail-fast: false

--- a/cmd/flux-schema/config.go
+++ b/cmd/flux-schema/config.go
@@ -26,6 +26,7 @@ type validateConfig struct {
 	SchemaLocations       []string `json:"schema-location,omitempty"`
 	SkipMissingSchemas    bool     `json:"skip-missing-schemas,omitempty"`
 	SkipKinds             []string `json:"skip-kind,omitempty"`
+	SkipJSONPaths         []string `json:"skip-json-path,omitempty"`
 	Verbose               bool     `json:"verbose,omitempty"`
 	FailFast              bool     `json:"fail-fast,omitempty"`
 	Concurrent            *int     `json:"concurrent,omitempty"`
@@ -69,6 +70,9 @@ func applyValidateConfig(cmd *cobra.Command, cfg *validateConfig, args *validate
 	}
 	if cfg.SkipKinds != nil && !flags.Changed("skip-kind") {
 		args.skipKinds = cfg.SkipKinds
+	}
+	if cfg.SkipJSONPaths != nil && !flags.Changed("skip-json-path") {
+		args.skipJSONPaths = cfg.SkipJSONPaths
 	}
 	if !flags.Changed("verbose") {
 		args.verbose = cfg.Verbose

--- a/cmd/flux-schema/testdata/validate/manifests/valid-secrets.yaml
+++ b/cmd/flux-schema/testdata/validate/manifests/valid-secrets.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3-secret
+  namespace: default
+type: Opaque
+immutable: true
+stringData:
+  accesskey: "access-key"
+  secretkey: "secret-key"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sops-secret
+  namespace: default
+type: Opaque
+stringData:
+  key: ENC[AES256_GCM,data:5d9WYyV8eyrOhF/m,iv:wuxE+q4pB+2cXBLcOy4/eZFSteLXJJDEI001UFAPd3A=,tag:EyM2zosBOv5/DnZMUqyNJg==,type:str]
+sops:
+  age:
+    - recipient: age1henwn645drkd3fa34t27t2w2x0nsgw3w4h62gmg5x5xflyjpy38s5cncph
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhSEJIVUQrZXpkZmJ6ek1U
+        enNmL2cycGJVTUp0bGJBQmhzUms5eENWd1MwCjZtUjMvT28zWU8wVHArNDdyNG1x
+        RjJCK29jNEJ5bDc5M2pNVG0rcHhFQ2cKLS0tIDkzRk5zdTZ5ek4rNzNvT2l5VDJ1
+        Sk01a05sV094UjFVbkhsVUhaOFhWa3MKwVILC0MO4CPlK0kniPTxOgMxej+E1NJ3
+        d1vA+h/DFoHDV6fU63n/v0BLmi7q0x10pYj95u1Ef1cP24JC/G+M4g==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-04-25T17:19:51Z"
+  mac: ENC[AES256_GCM,data:5vkroTHj/9sLCEb+LHZEWwbrq9amLfU9QsDE6ZmpSDa/r7T2RGzX9cAhe73s2L7E5EZblsWOGLPdQCRXP/Llp19QzEU6dYs+n0IyFprjtYpL8VEB3S2aCPzdhOrN0o/pcHGmfvp4S9gXvwki1EIYhRL7ozBHNppxQGLOdVDigjg=,iv:dCzK0olxFn4QwknnYvO4LNo7SjuX04zF6saVRFQv7wY=,tag:GwL7WDw2IBxNUdGUBpBXEQ==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  version: 3.10.2

--- a/cmd/flux-schema/testdata/validate/manifests/valid-sources.yaml
+++ b/cmd/flux-schema/testdata/validate/manifests/valid-sources.yaml
@@ -14,15 +14,15 @@ spec:
     name: minio-bucket-secret
   bucketName: example
 ---
-apiVersion: v1
-kind: Secret
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
 metadata:
   name: minio-bucket-secret
   namespace: default
 type: Opaque
-stringData:
-  accesskey: "access-key"
-  secretkey: "secret-key"
+encryptedData:
+  accesskey: "ewogICJjcmVk..."
+  secretkey: "42010aac003e..."
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository

--- a/cmd/flux-schema/testdata/validate/schemas/core/secret_v1.json
+++ b/cmd/flux-schema/testdata/validate/schemas/core/secret_v1.json
@@ -1,0 +1,244 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "data": {
+      "additionalProperties": {
+        "format": "byte",
+        "type": "string"
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "immutable": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "creationTimestamp": {
+          "format": "date-time",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "deletionGracePeriodSeconds": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "deletionTimestamp": {
+          "format": "date-time",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "finalizers": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "generateName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "generation": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "managedFields": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "apiVersion": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "fieldsType": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "fieldsV1": {
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "manager": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "operation": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "subresource": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "time": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "type": "object"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "namespace": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ownerReferences": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "apiVersion": {
+                "type": "string"
+              },
+              "blockOwnerDeletion": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "controller": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "kind": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "uid": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "apiVersion",
+              "kind",
+              "name",
+              "uid"
+            ],
+            "type": "object"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "resourceVersion": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "selfLink": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uid": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "stringData": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "type": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "apiVersion",
+    "kind"
+  ],
+  "type": "object"
+}

--- a/cmd/flux-schema/testdata/validate/schemas/core/secretlist_v1.json
+++ b/cmd/flux-schema/testdata/validate/schemas/core/secretlist_v1.json
@@ -1,0 +1,300 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "items": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "apiVersion": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "data": {
+            "additionalProperties": {
+              "format": "byte",
+              "type": "string"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "immutable": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "kind": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "metadata": {
+            "additionalProperties": false,
+            "properties": {
+              "annotations": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "creationTimestamp": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "deletionGracePeriodSeconds": {
+                "format": "int64",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "deletionTimestamp": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "finalizers": {
+                "items": {
+                  "type": "string"
+                },
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "generateName": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "generation": {
+                "format": "int64",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "labels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "managedFields": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "apiVersion": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "fieldsType": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "fieldsV1": {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "manager": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "operation": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "subresource": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "time": {
+                      "format": "date-time",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "namespace": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ownerReferences": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "apiVersion": {
+                      "type": "string"
+                    },
+                    "blockOwnerDeletion": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "controller": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "apiVersion",
+                    "kind",
+                    "name",
+                    "uid"
+                  ],
+                  "type": "object"
+                },
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "resourceVersion": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "selfLink": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uid": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "stringData": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "additionalProperties": false,
+      "properties": {
+        "continue": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "remainingItemCount": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "resourceVersion": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "selfLink": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "items",
+    "apiVersion",
+    "kind"
+  ],
+  "type": "object"
+}

--- a/cmd/flux-schema/validate.go
+++ b/cmd/flux-schema/validate.go
@@ -45,8 +45,13 @@ var validateCmd = &cobra.Command{
 
   # Skip specific kinds by Kind or apiVersion/Kind
   flux-schema validate ./manifests \
-    --skip-kind Secret \
+    --skip-kind Service \
     --skip-kind source.toolkit.fluxcd.io/v1/GitRepository
+
+  # Strip non-conformant fields before validation
+  # e.g. SOPS metadata that Flux removes at apply time
+  flux-schema validate ./manifests \
+    --skip-json-path v1/Secret:/sops
 
   # Load flag defaults from a checked-in YAML config (CLI flags still override)
   flux-schema validate ./manifests --config .flux-schema.yaml`,
@@ -57,6 +62,7 @@ type validateFlags struct {
 	schemaLocations       []string
 	skipMissingSchemas    bool
 	skipKinds             []string
+	skipJSONPaths         []string
 	verbose               bool
 	failFast              bool
 	concurrent            int
@@ -76,7 +82,9 @@ func init() {
 	validateCmd.Flags().BoolVar(&validateArgs.skipMissingSchemas, "skip-missing-schemas", false,
 		"skip documents for which no schema can be found instead of failing")
 	validateCmd.Flags().StringArrayVar(&validateArgs.skipKinds, "skip-kind", nil,
-		"skip documents matching Kind or apiVersion/Kind (repeatable)")
+		"skip documents matching kind or apiVersion/kind e.g. 'v1/Secret' (repeatable)")
+	validateCmd.Flags().StringArrayVar(&validateArgs.skipJSONPaths, "skip-json-path", nil,
+		"strip a JSON Pointer field, optionally scoped e.g. 'v1/Secret:/sops' (repeatable)")
 	validateCmd.Flags().BoolVarP(&validateArgs.verbose, "verbose", "v", false,
 		"print a line for every document, including valid and skipped")
 	validateCmd.Flags().BoolVar(&validateArgs.failFast, "fail-fast", false,
@@ -422,6 +430,7 @@ func buildValidatorOptions(inputs []string) (validator.Options, error) {
 		SchemaLocations:       locations,
 		SkipMissingSchemas:    validateArgs.skipMissingSchemas,
 		SkipKinds:             validateArgs.skipKinds,
+		SkipJSONPaths:         validateArgs.skipJSONPaths,
 		HTTPTimeout:           rootArgs.timeout,
 		Workers:               validateArgs.concurrent,
 		InsecureSkipTLSVerify: validateArgs.insecureSkipTLSVerify,

--- a/cmd/flux-schema/validate_test.go
+++ b/cmd/flux-schema/validate_test.go
@@ -198,8 +198,8 @@ func TestValidateCmd_FluxManifestsFixtures(t *testing.T) {
 	g.Expect(out).To(ContainSubstring(reconcilersPath + " - HelmRelease/apps/webapp is valid"))
 	g.Expect(out).To(ContainSubstring(sourcesPath + " - Bucket/default/minio-bucket is valid"))
 
-	g.Expect(out).To(ContainSubstring(sourcesPath + " - Secret/default/minio-bucket-secret is skipped: schema not found"))
-	g.Expect(out).To(MatchRegexp(`(?m)^  - no schema for kind "Secret" in version "v1"$`))
+	g.Expect(out).To(ContainSubstring(sourcesPath + " - SealedSecret/default/minio-bucket-secret is skipped: schema not found"))
+	g.Expect(out).To(MatchRegexp(`(?m)^  - no schema for kind "SealedSecret" in version "bitnami.com/v1alpha1"$`))
 
 	// 11 docs in valid-reconcilers.yaml + 8 in valid-sources.yaml = 19; the
 	// Secret is skipped, so the remaining 18 validate cleanly.
@@ -279,7 +279,7 @@ func TestValidateCmd_SchemaLocationShorthand(t *testing.T) {
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(out).To(ContainSubstring("Bucket/default/minio-bucket is valid"))
-	g.Expect(out).To(ContainSubstring("Secret/default/minio-bucket-secret is skipped"))
+	g.Expect(out).To(ContainSubstring("SealedSecret/default/minio-bucket-secret is skipped"))
 }
 
 // TestValidateCmd_SkipKind exercises all three accepted pattern shapes against
@@ -297,14 +297,14 @@ func TestValidateCmd_SkipKind(t *testing.T) {
 		reconcilersPath,
 		sourcesPath,
 		"--schema-location", "./testdata/validate/schemas/{{ .Group }}/{{ .Kind }}_{{ .Version }}.json",
-		"--skip-kind", "Secret",
+		"--skip-kind", "SealedSecret",
 		"--skip-kind", "source.toolkit.fluxcd.io/v1/GitRepository",
 		"--skip-kind", "helm.toolkit.fluxcd.io/v2/HelmRelease",
 		"--verbose",
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 
-	g.Expect(out).To(ContainSubstring(sourcesPath + " - Secret/default/minio-bucket-secret is skipped: kind skipped"))
+	g.Expect(out).To(ContainSubstring(sourcesPath + " - SealedSecret/default/minio-bucket-secret is skipped: kind skipped"))
 	g.Expect(out).To(ContainSubstring(" - GitRepository/"))
 	g.Expect(out).To(ContainSubstring("is skipped: kind skipped"))
 	g.Expect(out).To(ContainSubstring(" - HelmRelease/"))
@@ -442,6 +442,48 @@ func TestValidateCmd_InsecureSkipTLSVerify(t *testing.T) {
 	g.Expect(out).To(ContainSubstring("Valid: 1"))
 }
 
+// TestValidateCmd_SkipJSONPath strips the SOPS metadata block from the
+// encrypted Secret in the fixture so the strict v1.Secret schema accepts it.
+// The unencrypted Secret in the same file is unaffected.
+func TestValidateCmd_SkipJSONPath(t *testing.T) {
+	g := NewWithT(t)
+
+	secretsPath := "./testdata/validate/manifests/valid-secrets.yaml"
+
+	// Without the strip, the SOPS Secret fails on additionalProperties.
+	out, err := executeCommand([]string{
+		"validate",
+		secretsPath,
+		"--schema-location", "./testdata/validate/schemas/{{ .Group }}/{{ .Kind }}_{{ .Version }}.json",
+	})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("Secret/default/sops-secret is invalid: schema violation"))
+	g.Expect(out).To(ContainSubstring("additional properties 'sops' not allowed"))
+
+	// With the kind-scoped strip both Secrets validate.
+	out, err = executeCommand([]string{
+		"validate",
+		secretsPath,
+		"--schema-location", "./testdata/validate/schemas/{{ .Group }}/{{ .Kind }}_{{ .Version }}.json",
+		"--skip-json-path", "Secret:/sops",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("Summary: 2 resources found in 1 file - Valid: 2, Invalid: 0, Skipped: 0"))
+}
+
+func TestValidateCmd_SkipJSONPath_Invalid(t *testing.T) {
+	g := NewWithT(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	_, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(t.TempDir(), "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--skip-json-path", "no-leading-slash",
+	})
+	g.Expect(err).To(MatchError(ContainSubstring("skip JSON path pattern")))
+}
+
 func TestValidateCmd_SkipKind_Invalid(t *testing.T) {
 	g := NewWithT(t)
 	manifestDir := t.TempDir()
@@ -498,6 +540,45 @@ validate:
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(out).ToNot(ContainSubstring("is valid"))
 	g.Expect(out).To(ContainSubstring("Valid: 1"))
+}
+
+// Config file's skip-json-path entries are picked up when the flag is absent.
+func TestValidateCmd_Config_SkipJSONPath(t *testing.T) {
+	g := NewWithT(t)
+
+	cfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "1"
+validate:
+  skip-json-path:
+    - Secret:/sops
+`)
+	out, err := executeCommand([]string{
+		"validate", "./testdata/validate/manifests/valid-secrets.yaml",
+		"--schema-location", "./testdata/validate/schemas/{{ .Group }}/{{ .Kind }}_{{ .Version }}.json",
+		"--config", cfg,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("Valid: 2, Invalid: 0, Skipped: 0"))
+}
+
+// CLI --skip-json-path replaces (does not merge with) the config's list.
+// Mirrors TestValidateCmd_Config_CLIOverridesSlice for skip-kind.
+func TestValidateCmd_Config_CLIOverridesSkipJSONPath(t *testing.T) {
+	g := NewWithT(t)
+
+	// Config strips /sops; CLI replaces the list with a different pointer
+	// that doesn't match anything in the doc, so SOPS validation fails.
+	cfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "1"
+validate:
+  skip-json-path:
+    - Secret:/sops
+`)
+	_, err := executeCommand([]string{
+		"validate", "./testdata/validate/manifests/valid-secrets.yaml",
+		"--schema-location", "./testdata/validate/schemas/{{ .Group }}/{{ .Kind }}_{{ .Version }}.json",
+		"--config", cfg,
+		"--skip-json-path", "Secret:/does-not-exist",
+	})
+	g.Expect(err).To(HaveOccurred())
 }
 
 // CLI --skip-kind replaces (does not merge with) the config's skip-kind list.

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -102,6 +102,7 @@ type Options struct {
 	SchemaLocations       []string
 	SkipMissingSchemas    bool
 	SkipKinds             []string
+	SkipJSONPaths         []string
 	HTTPClient            *retryablehttp.Client
 	HTTPTimeout           time.Duration
 	Workers               int
@@ -115,6 +116,7 @@ type Validator struct {
 	opts      Options
 	loader    *SchemaLoader
 	skipKinds []skipKindMatcher
+	skipPaths []skipPathMatcher
 }
 
 // skipKindMatcher matches a document by Kind, optionally scoped to an
@@ -150,6 +152,99 @@ func (m skipKindMatcher) matches(apiVersion, kind string) bool {
 		return false
 	}
 	return m.apiVersion == "" || m.apiVersion == apiVersion
+}
+
+// skipPathMatcher targets a JSON Pointer for deletion before schema.Validate
+// runs, optionally scoped to a Kind / apiVersion-Kind via the same selector
+// rules as skipKindMatcher. An empty kind matches any Kind.
+type skipPathMatcher struct {
+	apiVersion string
+	kind       string
+	segments   []string
+}
+
+// parseSkipJSONPath parses a SkipJSONPaths pattern. Accepted shapes:
+//
+//	/foo/bar                          strip on every doc
+//	Kind:/foo/bar                     scope by Kind
+//	apiVersion/Kind:/foo/bar          scope by apiVersion+Kind
+//	group/version/Kind:/foo/bar       scope by full GVK
+//
+// A leading '/' marks the input as a pure pointer with no selector, so
+// pointer keys may freely contain ':' (e.g. '/metadata/annotations/foo:bar').
+// Otherwise the first ':' separates the selector half (parsed by parseSkipKind)
+// from the pointer half, which follows RFC 6901; '~1' decodes to '/' and '~0'
+// to '~'. Pointer descent through arrays is a silent no-op (map keys only).
+func parseSkipJSONPath(s string) (skipPathMatcher, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return skipPathMatcher{}, errors.New("skip JSON path pattern must not be empty")
+	}
+	var selector, pointer string
+	switch {
+	case strings.HasPrefix(s, "/"):
+		// Pure pointer; preserves any ':' inside keys.
+		pointer = s
+	default:
+		left, right, hasSelector := strings.Cut(s, ":")
+		if !hasSelector {
+			return skipPathMatcher{}, fmt.Errorf("skip JSON path pattern %q: pointer must start with '/'", s)
+		}
+		selector, pointer = left, right
+	}
+	if !strings.HasPrefix(pointer, "/") {
+		return skipPathMatcher{}, fmt.Errorf("skip JSON path pattern %q: pointer must start with '/'", s)
+	}
+	if pointer == "/" {
+		return skipPathMatcher{}, fmt.Errorf("skip JSON path pattern %q: pointer must target a property", s)
+	}
+	var apiVersion, kind string
+	if selector != "" {
+		m, err := parseSkipKind(selector)
+		if err != nil {
+			return skipPathMatcher{}, fmt.Errorf("skip JSON path pattern %q: %w", s, err)
+		}
+		apiVersion, kind = m.apiVersion, m.kind
+	}
+	rawSegments := strings.Split(strings.TrimPrefix(pointer, "/"), "/")
+	segments := make([]string, len(rawSegments))
+	for i, seg := range rawSegments {
+		if seg == "" {
+			return skipPathMatcher{}, fmt.Errorf("skip JSON path pattern %q: empty segment in pointer", s)
+		}
+		// RFC 6901: decode '~1' before '~0' so '~01' decodes to literal '~1'
+		// rather than collapsing into '/'.
+		seg = strings.ReplaceAll(seg, "~1", "/")
+		seg = strings.ReplaceAll(seg, "~0", "~")
+		segments[i] = seg
+	}
+	return skipPathMatcher{apiVersion: apiVersion, kind: kind, segments: segments}, nil
+}
+
+func (m skipPathMatcher) matches(apiVersion, kind string) bool {
+	if m.kind != "" && m.kind != kind {
+		return false
+	}
+	return m.apiVersion == "" || m.apiVersion == apiVersion
+}
+
+// stripPath deletes the field referenced by m.segments from doc when present.
+// Missing keys and non-object containers along the path are silent no-ops, so
+// a single unscoped pattern (e.g. '/sops') can be left on across a mixed tree
+// without falsely modifying unrelated kinds.
+func (m skipPathMatcher) stripPath(doc map[string]any) {
+	parent := doc
+	for i, seg := range m.segments {
+		if i == len(m.segments)-1 {
+			delete(parent, seg)
+			return
+		}
+		next, ok := parent[seg].(map[string]any)
+		if !ok {
+			return
+		}
+		parent = next
+	}
 }
 
 // New returns a Validator configured from opts. Each location template is
@@ -193,10 +288,20 @@ func New(opts Options) (*Validator, error) {
 		skipKinds = append(skipKinds, m)
 	}
 
+	skipPaths := make([]skipPathMatcher, 0, len(opts.SkipJSONPaths))
+	for _, s := range opts.SkipJSONPaths {
+		m, err := parseSkipJSONPath(s)
+		if err != nil {
+			return nil, err
+		}
+		skipPaths = append(skipPaths, m)
+	}
+
 	return &Validator{
 		opts:      opts,
 		loader:    NewSchemaLoader(templates, opts.HTTPClient, opts.HTTPTimeout),
 		skipKinds: skipKinds,
+		skipPaths: skipPaths,
 	}, nil
 }
 
@@ -544,6 +649,12 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 			Msg: fmt.Sprintf("no schema for kind %q in version %q", r.Kind, r.APIVersion),
 		}}
 		return settle(missingSchemaStatus(), ReasonSchemaNotFound)
+	}
+
+	for _, m := range v.skipPaths {
+		if m.matches(r.APIVersion, r.Kind) {
+			m.stripPath(doc)
+		}
 	}
 
 	if err := schema.Validate(doc); err != nil {

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -956,6 +956,203 @@ func TestNew_RejectsBadSkipKind(t *testing.T) {
 	g.Expect(err).To(HaveOccurred())
 }
 
+func TestParseSkipJSONPath(t *testing.T) {
+	cases := map[string]struct {
+		in           string
+		wantAPIVer   string
+		wantKind     string
+		wantSegments []string
+		wantErr      bool
+	}{
+		"unscoped":             {in: "/sops", wantSegments: []string{"sops"}},
+		"kind-scoped":          {in: "Secret:/sops", wantKind: "Secret", wantSegments: []string{"sops"}},
+		"core gvk-scoped":      {in: "v1/Secret:/sops", wantAPIVer: "v1", wantKind: "Secret", wantSegments: []string{"sops"}},
+		"group gvk-scoped":     {in: "apps/v1/Deployment:/spec/foo", wantAPIVer: "apps/v1", wantKind: "Deployment", wantSegments: []string{"spec", "foo"}},
+		"nested pointer":       {in: "/metadata/annotations/foo.bar~1baz", wantSegments: []string{"metadata", "annotations", "foo.bar/baz"}},
+		"escape literal tilde": {in: "/~0sops", wantSegments: []string{"~sops"}},
+		"escape order":         {in: "/~01", wantSegments: []string{"~1"}},
+		"whitespace trimmed":   {in: "  /sops  ", wantSegments: []string{"sops"}},
+		// Pointer keys may contain ':' — the leading '/' marks the whole input
+		// as a pure pointer, so no selector split happens.
+		"colon in pointer key":           {in: "/metadata/annotations/prometheus.io:port", wantSegments: []string{"metadata", "annotations", "prometheus.io:port"}},
+		"colon in scoped pointer key":    {in: "Secret:/metadata/annotations/prometheus.io:port", wantKind: "Secret", wantSegments: []string{"metadata", "annotations", "prometheus.io:port"}},
+		"empty selector equals no scope": {in: ":/sops", wantSegments: []string{"sops"}},
+		"empty":                          {in: "", wantErr: true},
+		"whitespace only":                {in: "   ", wantErr: true},
+		"missing pointer prefix":         {in: "sops", wantErr: true},
+		"selector without path":          {in: "Secret:", wantErr: true},
+		"root pointer only":              {in: "/", wantErr: true},
+		"empty segment":                  {in: "/foo//bar", wantErr: true},
+		"bad selector":                   {in: "v1/:/foo", wantErr: true},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+			m, err := parseSkipJSONPath(tc.in)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(m.apiVersion).To(Equal(tc.wantAPIVer))
+			g.Expect(m.kind).To(Equal(tc.wantKind))
+			g.Expect(m.segments).To(Equal(tc.wantSegments))
+		})
+	}
+}
+
+func TestSkipPathMatcher_Matches(t *testing.T) {
+	g := NewWithT(t)
+	unscoped, err := parseSkipJSONPath("/sops")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(unscoped.matches("v1", "Secret")).To(BeTrue())
+	g.Expect(unscoped.matches("apps/v1", "Deployment")).To(BeTrue())
+
+	kindOnly, err := parseSkipJSONPath("Secret:/sops")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(kindOnly.matches("v1", "Secret")).To(BeTrue())
+	g.Expect(kindOnly.matches("custom.io/v1", "Secret")).To(BeTrue())
+	g.Expect(kindOnly.matches("v1", "ConfigMap")).To(BeFalse())
+
+	gvk, err := parseSkipJSONPath("v1/Secret:/sops")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(gvk.matches("v1", "Secret")).To(BeTrue())
+	g.Expect(gvk.matches("custom.io/v1", "Secret")).To(BeFalse())
+}
+
+func TestSkipPathMatcher_StripPath(t *testing.T) {
+	g := NewWithT(t)
+
+	doc := map[string]any{
+		"sops": map[string]any{"version": "3.10"},
+		"spec": map[string]any{"foo": "bar", "baz": "qux"},
+	}
+	mustParse := func(s string) skipPathMatcher {
+		m, err := parseSkipJSONPath(s)
+		g.Expect(err).ToNot(HaveOccurred())
+		return m
+	}
+
+	// Top-level strip removes the entire subtree.
+	mustParse("/sops").stripPath(doc)
+	g.Expect(doc).ToNot(HaveKey("sops"))
+	g.Expect(doc).To(HaveKey("spec"))
+
+	// Nested strip removes only the named property.
+	mustParse("/spec/foo").stripPath(doc)
+	g.Expect(doc["spec"]).To(Equal(map[string]any{"baz": "qux"}))
+
+	// Missing intermediate is a silent no-op.
+	mustParse("/missing/child").stripPath(doc)
+	mustParse("/spec/missing").stripPath(doc)
+	g.Expect(doc["spec"]).To(Equal(map[string]any{"baz": "qux"}))
+
+	// Non-object container along the path is a silent no-op
+	// (e.g. trying to descend through a scalar).
+	doc["scalar"] = "hello"
+	mustParse("/scalar/child").stripPath(doc)
+	g.Expect(doc["scalar"]).To(Equal("hello"))
+
+	// Array containers are also a silent no-op — descent is map-only by design.
+	// Pinning this prevents a future map-only → array-aware change from
+	// silently breaking patterns like '/spec/containers/0/image'.
+	doc["containers"] = []any{
+		map[string]any{"image": "nginx"},
+	}
+	mustParse("/containers/0/image").stripPath(doc)
+	g.Expect(doc["containers"]).To(Equal([]any{
+		map[string]any{"image": "nginx"},
+	}))
+}
+
+func TestValidateBytes_SkipJSONPath_StripsBeforeValidation(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchema(t, dir)
+	v, err := New(Options{
+		SchemaLocations: []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipJSONPaths:   []string{"Widget:/spec/extra"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// /spec/extra would trip additionalProperties: false on widget.spec; the
+	// strip removes it before schema.Validate runs.
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec:
+  name: hello
+  extra: injected-by-tooling
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusValid))
+	g.Expect(results[0].Errors).To(BeEmpty())
+}
+
+func TestValidateBytes_SkipJSONPath_KindScopeBlocksUnrelatedDocs(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchema(t, dir)
+	v, err := New(Options{
+		SchemaLocations: []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		// Pattern targets a different Kind — must not strip on Widget.
+		SkipJSONPaths: []string{"Secret:/spec/extra"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec:
+  name: hello
+  extra: tooling-injected
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+}
+
+func TestValidateBytes_SkipJSONPath_MultiplePatterns(t *testing.T) {
+	// Two patterns target different fields on the same doc; both must apply
+	// in order, regardless of declaration order.
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchema(t, dir)
+	v, err := New(Options{
+		SchemaLocations: []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipJSONPaths: []string{
+			"Widget:/spec/extraOne",
+			"Widget:/spec/extraTwo",
+		},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec:
+  name: hello
+  extraOne: a
+  extraTwo: b
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusValid))
+}
+
+func TestNew_RejectsBadSkipJSONPath(t *testing.T) {
+	g := NewWithT(t)
+	_, err := New(Options{
+		SchemaLocations: []string{"./{{ .Kind }}.json"},
+		SkipJSONPaths:   []string{"no-leading-slash"},
+	})
+	g.Expect(err).To(HaveOccurred())
+}
+
 func TestNew_RejectsBadTemplate(t *testing.T) {
 	g := NewWithT(t)
 	_, err := New(Options{SchemaLocations: []string{"{{ .Unknown }}"}})


### PR DESCRIPTION
Some manifests carry tooling-injected fields that are stripped at apply time by Flux (e.g. SOPS-encrypted Secrets). Use `--skip-json-path` to remove those fields from validation so the rest of the document is still checked.

Example:

```shell
flux-schema validate ./manifests \
  --skip-json-path 'v1/Secret:/sops' \
  --skip-json-path 'Deployment:/sops'
```
