### PR TITLE
Add `--skip-file` to validate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Flux CLI plugin for Kubernetes schema extraction and manifests validation.
     - `--skip-missing-schemas`: Skip documents for which no schema can be found
     - `--skip-kind`: Skip documents matching `kind` or `apiVersion/kind` (repeatable)
     - `--skip-json-path`: Strip a JSON Pointer field before validation, optionally scoped: `[apiVersion/kind:]/path` (repeatable)
+    - `--skip-file`: Glob pattern matched against files and dirs; defaults to skipping dotfiles and dot-dirs (repeatable)
     - `--fail-fast`: Exit after the first invalid document
     - `--concurrent`: Number of concurrent workers (default 8)
     - `--insecure-skip-tls-verify`: Disable TLS certificate verification when fetching schemas over HTTPS
@@ -160,6 +161,9 @@ validate:
     - source.toolkit.fluxcd.io/v1/ExternalArtifact
   skip-json-path:
     - Secret:/sops
+  skip-file:
+    - '.*'
+    - kustomization.yaml
   skip-missing-schemas: false
   verbose: true
   fail-fast: false

--- a/cmd/flux-schema/config.go
+++ b/cmd/flux-schema/config.go
@@ -27,6 +27,7 @@ type validateConfig struct {
 	SkipMissingSchemas    bool     `json:"skip-missing-schemas,omitempty"`
 	SkipKinds             []string `json:"skip-kind,omitempty"`
 	SkipJSONPaths         []string `json:"skip-json-path,omitempty"`
+	SkipFiles             []string `json:"skip-file,omitempty"`
 	Verbose               bool     `json:"verbose,omitempty"`
 	FailFast              bool     `json:"fail-fast,omitempty"`
 	Concurrent            *int     `json:"concurrent,omitempty"`
@@ -73,6 +74,9 @@ func applyValidateConfig(cmd *cobra.Command, cfg *validateConfig, args *validate
 	}
 	if cfg.SkipJSONPaths != nil && !flags.Changed("skip-json-path") {
 		args.skipJSONPaths = cfg.SkipJSONPaths
+	}
+	if cfg.SkipFiles != nil && !flags.Changed("skip-file") {
+		args.skipFiles = cfg.SkipFiles
 	}
 	if !flags.Changed("verbose") {
 		args.verbose = cfg.Verbose

--- a/cmd/flux-schema/validate.go
+++ b/cmd/flux-schema/validate.go
@@ -53,6 +53,12 @@ var validateCmd = &cobra.Command{
   flux-schema validate ./manifests \
     --skip-json-path v1/Secret:/sops
 
+  # Skip files and directories by basename glob
+  # default skips dotfiles and dot-directories e.g. '.git'
+  flux-schema validate ./manifests \
+    --skip-file '.*' \
+    --skip-file 'kustomization.yaml'
+
   # Load flag defaults from a checked-in YAML config (CLI flags still override)
   flux-schema validate ./manifests --config .flux-schema.yaml`,
 	RunE: validateCmdRun,
@@ -63,6 +69,7 @@ type validateFlags struct {
 	skipMissingSchemas    bool
 	skipKinds             []string
 	skipJSONPaths         []string
+	skipFiles             []string
 	verbose               bool
 	failFast              bool
 	concurrent            int
@@ -85,6 +92,9 @@ func init() {
 		"skip documents matching kind or apiVersion/kind e.g. 'v1/Secret' (repeatable)")
 	validateCmd.Flags().StringArrayVar(&validateArgs.skipJSONPaths, "skip-json-path", nil,
 		"strip a JSON Pointer field, optionally scoped e.g. 'v1/Secret:/sops' (repeatable)")
+	validateCmd.Flags().StringArrayVar(&validateArgs.skipFiles, "skip-file", nil,
+		"glob pattern matched against files and dirs "+
+			"defaults to skipping dotfiles and dot-dirs (repeatable)")
 	validateCmd.Flags().BoolVarP(&validateArgs.verbose, "verbose", "v", false,
 		"print a line for every document, including valid and skipped")
 	validateCmd.Flags().BoolVar(&validateArgs.failFast, "fail-fast", false,
@@ -431,6 +441,7 @@ func buildValidatorOptions(inputs []string) (validator.Options, error) {
 		SkipMissingSchemas:    validateArgs.skipMissingSchemas,
 		SkipKinds:             validateArgs.skipKinds,
 		SkipJSONPaths:         validateArgs.skipJSONPaths,
+		SkipFiles:             validateArgs.skipFiles,
 		HTTPTimeout:           rootArgs.timeout,
 		Workers:               validateArgs.concurrent,
 		InsecureSkipTLSVerify: validateArgs.insecureSkipTLSVerify,

--- a/cmd/flux-schema/validate_test.go
+++ b/cmd/flux-schema/validate_test.go
@@ -310,6 +310,42 @@ func TestValidateCmd_SkipKind(t *testing.T) {
 	g.Expect(out).To(ContainSubstring(" - HelmRelease/"))
 }
 
+// TestValidateCmd_SkipFile_DefaultHidesDotfiles verifies that without an
+// explicit --skip-file the walker hides dotfiles and dot-directories so a
+// .git/ alongside manifests doesn't trip schema resolution.
+func TestValidateCmd_SkipFile_DefaultHidesDotfiles(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+	writeManifest(t, manifestDir, ".hidden.yaml", invalidWidget)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("Summary: 1 resource found in 1 file - Valid: 1, Invalid: 0, Skipped: 0"))
+}
+
+// TestValidateCmd_SkipFile_CustomPattern verifies an explicit --skip-file
+// replaces the default and matches by basename glob.
+func TestValidateCmd_SkipFile_CustomPattern(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+	writeManifest(t, manifestDir, "kustomization.yaml", invalidWidget)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--skip-file", "kustomization.yaml",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("Summary: 1 resource found in 1 file - Valid: 1, Invalid: 0, Skipped: 0"))
+}
+
 // TestValidateCmd_FailFast runs 50 invalid docs with --concurrent 1 so the
 // cut-short count is near-deterministic: at most a handful of invalids,
 // never the full 50.
@@ -579,6 +615,29 @@ validate:
 		"--skip-json-path", "Secret:/does-not-exist",
 	})
 	g.Expect(err).To(HaveOccurred())
+}
+
+// Config file's skip-file entries replace the built-in default and are
+// picked up when the flag is absent on the CLI.
+func TestValidateCmd_Config_SkipFile(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+	writeManifest(t, manifestDir, "kustomization.yaml", invalidWidget)
+
+	cfg := writeManifest(t, t.TempDir(), ".flux-schema.yaml", `version: "1"
+validate:
+  skip-file:
+    - kustomization.yaml
+`)
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--config", cfg,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("Summary: 1 resource found in 1 file - Valid: 1, Invalid: 0, Skipped: 0"))
 }
 
 // CLI --skip-kind replaces (does not merge with) the config's skip-kind list.

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -103,12 +103,18 @@ type Options struct {
 	SkipMissingSchemas    bool
 	SkipKinds             []string
 	SkipJSONPaths         []string
+	SkipFiles             []string
 	HTTPClient            *retryablehttp.Client
 	HTTPTimeout           time.Duration
 	Workers               int
 	InsecureSkipTLSVerify bool
 	Stdin                 io.Reader
 }
+
+// DefaultSkipFiles is applied when Options.SkipFiles is nil. It hides
+// dotfiles and dot-directories (e.g. .github, .golangci.yml) which are commonly
+// found alongside YAML manifests but never contain Kubernetes resources.
+var DefaultSkipFiles = []string{".*"}
 
 // Validator resolves and applies JSON Schemas to Kubernetes manifests.
 // It is safe for concurrent use by multiple goroutines.
@@ -117,6 +123,7 @@ type Validator struct {
 	loader    *SchemaLoader
 	skipKinds []skipKindMatcher
 	skipPaths []skipPathMatcher
+	skipFiles []string
 }
 
 // skipKindMatcher matches a document by Kind, optionally scoped to an
@@ -297,12 +304,41 @@ func New(opts Options) (*Validator, error) {
 		skipPaths = append(skipPaths, m)
 	}
 
+	skipFiles := opts.SkipFiles
+	if skipFiles == nil {
+		// Clone so DefaultSkipFiles can never be mutated through a
+		// validator's skipFiles slice.
+		skipFiles = slices.Clone(DefaultSkipFiles)
+	}
+	for _, p := range skipFiles {
+		if strings.TrimSpace(p) == "" {
+			return nil, errors.New("skip file pattern must not be empty")
+		}
+		if _, err := filepath.Match(p, "probe"); err != nil {
+			return nil, fmt.Errorf("skip file pattern %q: %w", p, err)
+		}
+	}
+
 	return &Validator{
 		opts:      opts,
 		loader:    NewSchemaLoader(templates, opts.HTTPClient, opts.HTTPTimeout),
 		skipKinds: skipKinds,
 		skipPaths: skipPaths,
+		skipFiles: skipFiles,
 	}, nil
+}
+
+// matchSkipFile reports whether name (a directory or file basename) matches
+// any of the validator's skip-file glob patterns. Matching uses
+// filepath.Match semantics; patterns are validated up-front in New so the
+// match call here cannot return an error.
+func (v *Validator) matchSkipFile(name string) bool {
+	for _, p := range v.skipFiles {
+		if ok, _ := filepath.Match(p, name); ok {
+			return true
+		}
+	}
+	return false
 }
 
 type job struct {
@@ -477,13 +513,16 @@ func (v *Validator) produceFromPath(ctx context.Context, path string, jobs chan<
 				return werr
 			}
 			if d.IsDir() {
-				if p != path && strings.HasPrefix(d.Name(), ".") {
+				if p != path && v.matchSkipFile(d.Name()) {
 					return filepath.SkipDir
 				}
 				return nil
 			}
 			ext := strings.ToLower(filepath.Ext(p))
 			if ext != extYAML && ext != extYML {
+				return nil
+			}
+			if v.matchSkipFile(d.Name()) {
 				return nil
 			}
 			wg := &sync.WaitGroup{}

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -711,6 +711,185 @@ spec:
 	g.Expect(finals).To(HaveLen(2))
 }
 
+// TestValidateSources_SkipFilesDefault verifies the implicit ".*" pattern
+// hides dotfiles and dot-directories during a walk, while still walking the
+// root path itself even when the user explicitly points at a hidden dir.
+func TestValidateSources_SkipFilesDefault(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchema(t, dir)
+
+	manifestsDir := t.TempDir()
+	const widget = `apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w
+spec:
+  name: ok
+`
+	g.Expect(os.WriteFile(filepath.Join(manifestsDir, "a.yaml"), []byte(widget), 0o644)).To(Succeed())
+	g.Expect(os.WriteFile(filepath.Join(manifestsDir, ".hidden.yaml"), []byte(widget), 0o644)).To(Succeed())
+
+	hiddenDir := filepath.Join(manifestsDir, ".git")
+	g.Expect(os.Mkdir(hiddenDir, 0o755)).To(Succeed())
+	g.Expect(os.WriteFile(filepath.Join(hiddenDir, "config.yaml"), []byte(widget), 0o644)).To(Succeed())
+
+	v := newLocalValidator(t, dir, false)
+	ch := v.ValidateSources(context.Background(), []string{manifestsDir})
+	var sources []string
+	for r := range ch {
+		if r.Final {
+			continue
+		}
+		sources = append(sources, r.Source)
+	}
+	g.Expect(sources).To(ConsistOf(filepath.Join(manifestsDir, "a.yaml")))
+}
+
+// TestValidateSources_SkipFilesCustom verifies user-supplied patterns
+// override the default and apply to both files and directories by basename.
+func TestValidateSources_SkipFilesCustom(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchema(t, dir)
+
+	manifestsDir := t.TempDir()
+	const widget = `apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w
+spec:
+  name: ok
+`
+	g.Expect(os.WriteFile(filepath.Join(manifestsDir, "kustomization.yaml"), []byte(widget), 0o644)).To(Succeed())
+	g.Expect(os.WriteFile(filepath.Join(manifestsDir, "app.yaml"), []byte(widget), 0o644)).To(Succeed())
+	skipDir := filepath.Join(manifestsDir, "vendor")
+	g.Expect(os.Mkdir(skipDir, 0o755)).To(Succeed())
+	g.Expect(os.WriteFile(filepath.Join(skipDir, "x.yaml"), []byte(widget), 0o644)).To(Succeed())
+
+	v, err := New(Options{
+		SchemaLocations: []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipFiles:       []string{"kustomization.yaml", "vendor"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	ch := v.ValidateSources(context.Background(), []string{manifestsDir})
+	var sources []string
+	for r := range ch {
+		if r.Final {
+			continue
+		}
+		sources = append(sources, r.Source)
+	}
+	g.Expect(sources).To(ConsistOf(filepath.Join(manifestsDir, "app.yaml")))
+}
+
+// TestValidateSources_SkipFilesRootWalked pins the WalkDir `p != path`
+// guard: when the user explicitly points the validator at a directory whose
+// own basename matches the skip pattern (e.g. `validate .secrets/`), the
+// walk still descends into it — only its descendants are filtered.
+func TestValidateSources_SkipFilesRootWalked(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchema(t, dir)
+
+	// Root directory whose basename matches the default ".*" pattern.
+	parent := t.TempDir()
+	rootDir := filepath.Join(parent, ".secrets")
+	g.Expect(os.Mkdir(rootDir, 0o755)).To(Succeed())
+	const widget = `apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w
+spec:
+  name: ok
+`
+	g.Expect(os.WriteFile(filepath.Join(rootDir, "a.yaml"), []byte(widget), 0o644)).To(Succeed())
+	g.Expect(os.WriteFile(filepath.Join(rootDir, ".hidden.yaml"), []byte(widget), 0o644)).To(Succeed())
+
+	v := newLocalValidator(t, dir, false)
+	ch := v.ValidateSources(context.Background(), []string{rootDir})
+	var sources []string
+	for r := range ch {
+		if r.Final {
+			continue
+		}
+		sources = append(sources, r.Source)
+	}
+	g.Expect(sources).To(ConsistOf(filepath.Join(rootDir, "a.yaml")))
+}
+
+// TestValidateSources_SkipFilesExplicitFile pins that a file passed
+// directly as a CLI argument bypasses the skip-file filter, even when its
+// basename matches the default pattern. produceFromPath only consults the
+// skip patterns inside its WalkDir branch — the file branch streams the
+// caller-named path verbatim.
+func TestValidateSources_SkipFilesExplicitFile(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchema(t, dir)
+
+	manifestsDir := t.TempDir()
+	const widget = `apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w
+spec:
+  name: ok
+`
+	hidden := filepath.Join(manifestsDir, ".hidden.yaml")
+	g.Expect(os.WriteFile(hidden, []byte(widget), 0o644)).To(Succeed())
+
+	v := newLocalValidator(t, dir, false)
+	ch := v.ValidateSources(context.Background(), []string{hidden})
+	var sources []string
+	for r := range ch {
+		if r.Final {
+			continue
+		}
+		sources = append(sources, r.Source)
+	}
+	g.Expect(sources).To(ConsistOf(hidden))
+}
+
+// TestValidateSources_SkipFilesEmpty verifies an explicit empty slice
+// disables the default and walks every YAML, including dotfiles.
+func TestValidateSources_SkipFilesEmpty(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchema(t, dir)
+
+	manifestsDir := t.TempDir()
+	const widget = `apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w
+spec:
+  name: ok
+`
+	g.Expect(os.WriteFile(filepath.Join(manifestsDir, "a.yaml"), []byte(widget), 0o644)).To(Succeed())
+	g.Expect(os.WriteFile(filepath.Join(manifestsDir, ".hidden.yaml"), []byte(widget), 0o644)).To(Succeed())
+
+	v, err := New(Options{
+		SchemaLocations: []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipFiles:       []string{},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	ch := v.ValidateSources(context.Background(), []string{manifestsDir})
+	var sources []string
+	for r := range ch {
+		if r.Final {
+			continue
+		}
+		sources = append(sources, r.Source)
+	}
+	g.Expect(sources).To(ConsistOf(
+		filepath.Join(manifestsDir, "a.yaml"),
+		filepath.Join(manifestsDir, ".hidden.yaml"),
+	))
+}
+
 // TestValidateSources_FinalSentinelOrdering pins the streaming protocol:
 // every real Result for a source arrives strictly before that source's
 // Final sentinel. Consumers rely on this to advance per-source streaming
@@ -1151,6 +1330,24 @@ func TestNew_RejectsBadSkipJSONPath(t *testing.T) {
 		SkipJSONPaths:   []string{"no-leading-slash"},
 	})
 	g.Expect(err).To(HaveOccurred())
+}
+
+func TestNew_RejectsBadSkipFile(t *testing.T) {
+	g := NewWithT(t)
+	cases := map[string]string{
+		"empty":      "",
+		"whitespace": "   ",
+		"bad-glob":   "[invalid",
+	}
+	for name, pattern := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := New(Options{
+				SchemaLocations: []string{"./{{ .Kind }}.json"},
+				SkipFiles:       []string{pattern},
+			})
+			g.Expect(err).To(HaveOccurred())
+		})
+	}
 }
 
 func TestNew_RejectsBadTemplate(t *testing.T) {


### PR DESCRIPTION
Add ` --skip-file` flag to `flux-schema validate` which allows setting glob patterns matched against files and dirs.

By default we skip dotfiles and dot-directories, to avoid scanning `.github`, `.sops.yml`, `.golangci.yml`, etc