### PR TITLE
Add `extract openshift` command

### DIFF
--- a/.github/workflows/update-catalog.yaml
+++ b/.github/workflows/update-catalog.yaml
@@ -35,6 +35,8 @@ jobs:
         run: ./scripts/gen-crd-schemas.sh -r fluxcd/flagger -p kustomize/kubernetes -d ./catalog/latest
       - name: Update Flux Operator schemas
         run: ./scripts/gen-crd-schemas.sh -r controlplaneio-fluxcd/flux-operator -d ./catalog/latest
+      - name: Update OpenShift schemas
+        run: ./scripts/gen-openshift-schemas.sh -d ./catalog/latest
       - name: Update README versions
         run: ./scripts/update-catalog-readme.sh -f ./catalog/README.md
       - name: Create Pull Request
@@ -55,6 +57,7 @@ jobs:
             - Flux: ${{ env.FLUX_VERSION }}
             - Flagger: ${{ env.FLAGGER_VERSION }}
             - Flux Operator: ${{ env.FLUX_OPERATOR_VERSION }}
+            - OpenShift: ${{ env.OPENSHIFT_REF }}
           labels: |
             area/catalog
           add-paths: |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Flux CLI plugin for Kubernetes schema extraction and manifests validation agains
 - `flux-schema extract k8s [swagger-file]`: Extract JSON Schema from a Kubernetes OpenAPI v2 swagger document
   - `--version X.Y.Z`: Fetch the swagger from `kubernetes/kubernetes` for the given release tag (mutually exclusive with a swagger file)
   - `-d, --output-dir`, `-f, --output-format`, `--strip-description`: same as `extract crd`
+- `flux-schema extract openshift [swagger-file]`: Extract JSON Schema from an `openshift/api` OpenAPI v2 swagger document
+  - `--ref REF`: Fetch the swagger from `openshift/api` at the given git ref (e.g. `release-4.20`); mutually exclusive with a swagger file
+  - `-d, --output-dir`, `-f, --output-format`, `--strip-description`: same as `extract k8s`
 
 ### Kubernetes Manifests Validation
 
@@ -43,7 +46,7 @@ The validate command reads Kubernetes YAML manifests from one or more files or d
 and validates each document against a JSON Schema resolved from its `apiVersion` and `kind`.
 
 When no `--schema-location` is given, validate uses the [flux-schema catalog](catalog/README.md),
-which covers the latest Kubernetes APIs, the stable channel of Gateway API,
+which covers the latest Kubernetes and OpenShift APIs, the stable channel of Gateway API,
 and the Flux ecosystem CRDs:
 
 ```shell
@@ -284,3 +287,27 @@ The emitted schemas are the standalone-strict variant:
 - Optional fields are marked nullable (`type: [<t>, "null"]`), matching the
   Kubernetes API server's behavior of accepting `null` for unset optional values.
 - `apiVersion` and `kind` are injected into every kind's properties and required list.
+
+### OpenShift OpenAPI Extraction
+
+The `extract openshift` command reads the `openshift/api` OpenAPI v2 swagger document
+and writes one JSON Schema file per OpenShift resource. Only definitions in the
+`openshift` namespace are emitted; the upstream Kubernetes types
+embedded in the same document (e.g. `Pod`) are inlined.
+
+Fetch the swagger from `openshift/api` at a release branch:
+
+```shell
+flux-schema extract openshift --ref release-4.20 -d ./schemas
+```
+
+Supply the swagger file:
+
+```shell
+curl -sL https://raw.githubusercontent.com/openshift/api/release-4.20/openapi/openapi.json \
+  flux-schema extract openshift -d ./schemas
+```
+
+The same `-f, --output-format` template used by `extract k8s` works here, so the
+generated files remain resolvable by `validate` with a single `--schema-location`
+for both Kubernetes and OpenShift resources. 

--- a/cmd/flux-schema/extract_k8s.go
+++ b/cmd/flux-schema/extract_k8s.go
@@ -25,8 +25,9 @@ import (
 const defaultK8sSwaggerURL = "https://raw.githubusercontent.com/kubernetes/kubernetes/%s/api/openapi-spec/swagger.json"
 
 var extractK8sCmd = &cobra.Command{
-	Use:   "k8s [swagger-file]",
-	Short: "Extract JSON Schemas from a Kubernetes OpenAPI v2 swagger document",
+	Use:     "k8s [swagger-file]",
+	Aliases: []string{"kubernetes"},
+	Short:   "Extract JSON Schemas from a Kubernetes OpenAPI v2 swagger document",
 	Example: `  # Fetch upstream swagger for a release version
   flux-schema extract k8s --version 1.35.0 -d ./schemas
 
@@ -103,7 +104,7 @@ func extractK8sCmdRun(cmd *cobra.Command, args []string) error {
 
 	cmd.Printf("reading %s\n", source)
 
-	schemas, errs := extractor.ExtractOpenAPI(data)
+	schemas, errs := extractor.ExtractKubernetes(data)
 
 	if extractK8sArgs.StripDescription {
 		for _, s := range schemas {
@@ -118,7 +119,7 @@ func extractK8sCmdRun(cmd *cobra.Command, args []string) error {
 
 	written := 0
 	for _, schema := range schemas {
-		relPath, err := writeK8sSchema(schema, destDir)
+		relPath, err := writeSwaggerSchema(schema, destDir, extractK8sArgs.Format)
 		if err != nil {
 			failures = append(failures, err)
 			continue
@@ -138,8 +139,12 @@ func extractK8sCmdRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func writeK8sSchema(schema extractor.Schema, destDir string) (string, error) {
-	rendered, err := tmpl.Render(extractK8sArgs.Format, tmpl.SchemaVars{
+// writeSwaggerSchema renders the output template, writes the schema as
+// pretty-printed JSON under destDir, and returns the path relative to
+// destDir. Shared by `extract k8s` and `extract openshift` since their
+// per-schema write loops are otherwise identical.
+func writeSwaggerSchema(schema extractor.Schema, destDir, format string) (string, error) {
+	rendered, err := tmpl.Render(format, tmpl.SchemaVars{
 		Group:   schema.Group,
 		Kind:    schema.Kind,
 		Version: schema.Version,
@@ -198,10 +203,19 @@ func fetchK8sSwagger(ctx context.Context, client *retryablehttp.Client,
 		return "", nil, err
 	}
 	url := fmt.Sprintf(urlTemplate, normalized)
+	body, err := fetchURL(ctx, client, url, timeout)
+	return url, body, err
+}
 
+// fetchURL performs a GET against url and returns the response body. Non-2xx
+// responses are hard errors; callers that want to interpret a 404 as a soft
+// miss should use a different code path.
+func fetchURL(ctx context.Context, client *retryablehttp.Client,
+	url string, timeout time.Duration,
+) ([]byte, error) {
 	req, err := retryablehttp.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return url, nil, err
+		return nil, err
 	}
 	if timeout > 0 {
 		reqCtx, cancel := context.WithTimeout(ctx, timeout)
@@ -210,18 +224,18 @@ func fetchK8sSwagger(ctx context.Context, client *retryablehttp.Client,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return url, nil, fmt.Errorf("fetch %s: %w", url, err)
+		return nil, fmt.Errorf("fetch %s: %w", url, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return url, nil, fmt.Errorf("fetch %s: %s", url, resp.Status)
+		return nil, fmt.Errorf("fetch %s: %s", url, resp.Status)
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return url, nil, fmt.Errorf("read %s: %w", url, err)
+		return nil, fmt.Errorf("read %s: %w", url, err)
 	}
-	return url, body, nil
+	return body, nil
 }
 
 func normalizeK8sVersion(version string) (string, error) {

--- a/cmd/flux-schema/extract_openshift.go
+++ b/cmd/flux-schema/extract_openshift.go
@@ -1,0 +1,162 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/spf13/cobra"
+
+	"github.com/fluxcd/flux-schema/internal/extractor"
+	"github.com/fluxcd/flux-schema/internal/flags"
+)
+
+const defaultOpenShiftSwaggerURL = "https://raw.githubusercontent.com/openshift/api/%s/openapi/openapi.json"
+
+var extractOpenShiftCmd = &cobra.Command{
+	Use:   "openshift [swagger-file]",
+	Short: "Extract JSON Schemas from an openshift/api OpenAPI v2 swagger document",
+	Example: `  # Fetch the swagger from openshift/api at a git ref
+  flux-schema extract openshift --ref release-4.20 -d ./schemas
+
+  # Pipe from stdin
+  curl -sL https://raw.githubusercontent.com/openshift/api/release-4.20/openapi/openapi.json \
+    | flux-schema extract openshift -d ./schemas`,
+	Args: requireFileOrRef,
+	RunE: extractOpenShiftCmdRun,
+}
+
+type extractOpenShiftFlags struct {
+	flags.ExtractOutput
+	ref string
+}
+
+var extractOpenShiftArgs = extractOpenShiftFlags{
+	ExtractOutput: flags.NewExtractOutput(),
+}
+
+func init() {
+	extractOpenShiftArgs.Register(extractOpenShiftCmd)
+	extractOpenShiftCmd.Flags().StringVar(&extractOpenShiftArgs.ref, "ref", "",
+		"openshift/api git ref (e.g. release-4.20) to fetch the upstream swagger from")
+	extractCmd.AddCommand(extractOpenShiftCmd)
+}
+
+// requireFileOrRef enforces mutual exclusion between a single positional
+// swagger file (or piped stdin) and --ref. An explicit empty --ref="" is
+// rejected here so it never reaches the URL formatter — Cobra would
+// otherwise treat it the same as the flag being absent.
+func requireFileOrRef(cmd *cobra.Command, args []string) error {
+	if len(args) > 1 {
+		return fmt.Errorf("accepts at most 1 positional argument, received %d", len(args))
+	}
+	if cmd.Flags().Changed("ref") && extractOpenShiftArgs.ref == "" {
+		return fmt.Errorf("--ref must not be empty")
+	}
+	hasRef := extractOpenShiftArgs.ref != ""
+	switch {
+	case hasRef && len(args) == 1:
+		return fmt.Errorf("--ref and a swagger file are mutually exclusive")
+	case !hasRef && len(args) == 0 && !stdinIsPiped():
+		return fmt.Errorf("either a swagger file, piped stdin, or --ref is required")
+	}
+	return nil
+}
+
+func extractOpenShiftCmdRun(cmd *cobra.Command, args []string) error {
+	var arg string
+	if extractOpenShiftArgs.ref == "" {
+		inputs, err := resolveStdinArgs(args)
+		if err != nil {
+			return err
+		}
+		arg = inputs[0]
+	}
+	client := newDefaultK8sHTTPClient()
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	source, data, err := resolveOpenShiftInput(ctx, client, defaultOpenShiftSwaggerURL, arg, extractOpenShiftArgs.ref, rootArgs.timeout)
+	if err != nil {
+		return err
+	}
+
+	destDir := extractOpenShiftArgs.Dir
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+
+	cmd.Printf("reading %s\n", source)
+
+	schemas, errs := extractor.ExtractOpenShift(data)
+
+	if extractOpenShiftArgs.StripDescription {
+		for _, s := range schemas {
+			extractor.StripDescriptions(s.JSON)
+		}
+	}
+
+	var failures []error
+	for _, e := range errs {
+		failures = append(failures, fmt.Errorf("%s: %w", source, e))
+	}
+
+	written := 0
+	for _, schema := range schemas {
+		relPath, err := writeSwaggerSchema(schema, destDir, extractOpenShiftArgs.Format)
+		if err != nil {
+			failures = append(failures, err)
+			continue
+		}
+		cmd.Printf("OK   %s\n", relPath)
+		written++
+	}
+
+	cmd.Printf("Summary: %d schemas extracted\n", written)
+
+	if len(failures) > 0 {
+		for _, e := range failures {
+			cmd.PrintErrf("FAIL %v\n", e)
+		}
+		return fmt.Errorf("%d error(s) during extraction", len(failures))
+	}
+	return nil
+}
+
+// resolveOpenShiftInput returns (source, data). source is the file path or
+// URL used as the log header. Exactly one of arg / ref is populated by the
+// time this runs (requireFileOrRef has already enforced that).
+func resolveOpenShiftInput(ctx context.Context, client *retryablehttp.Client,
+	urlTemplate, arg, ref string, timeout time.Duration,
+) (string, []byte, error) {
+	if arg != "" {
+		data, err := readSource(arg)
+		if err != nil {
+			return "", nil, fmt.Errorf("read %s: %w", arg, err)
+		}
+		return arg, data, nil
+	}
+	return fetchOpenShiftSwagger(ctx, client, urlTemplate, ref, timeout)
+}
+
+// fetchOpenShiftSwagger downloads the openshift/api OpenAPI v2 swagger
+// document at the given git ref. The empty-ref guard in requireFileOrRef
+// must run before this — an empty ref produces a doubled '/' in the URL
+// that raw.githubusercontent.com handles inconsistently.
+func fetchOpenShiftSwagger(ctx context.Context, client *retryablehttp.Client,
+	urlTemplate, ref string, timeout time.Duration,
+) (string, []byte, error) {
+	if ref == "" {
+		return "", nil, fmt.Errorf("--ref must not be empty")
+	}
+	url := fmt.Sprintf(urlTemplate, ref)
+	body, err := fetchURL(ctx, client, url, timeout)
+	return url, body, err
+}

--- a/cmd/flux-schema/extract_openshift_test.go
+++ b/cmd/flux-schema/extract_openshift_test.go
@@ -1,0 +1,244 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-retryablehttp"
+	. "github.com/onsi/gomega"
+)
+
+const minimalOpenShiftSwagger = `{
+  "swagger": "2.0",
+  "definitions": {
+    "com.github.openshift.api.route.v1.Route": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {"type": "string"},
+        "kind":       {"type": "string"},
+        "metadata":   {"type": "object"},
+        "spec": {
+          "type": "object",
+          "properties": {"host": {"type": "string"}}
+        }
+      }
+    },
+    "com.github.openshift.api.cloudnetwork.v1.CloudPrivateIPConfig": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {"type": "string"},
+        "kind":       {"type": "string"},
+        "metadata":   {"type": "object"}
+      }
+    }
+  }
+}`
+
+func writeOpenShiftSwaggerFixture(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "openapi.json")
+	if err := os.WriteFile(path, []byte(minimalOpenShiftSwagger), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func TestExtractOpenShiftCmd_File(t *testing.T) {
+	g := NewWithT(t)
+
+	outDir := t.TempDir()
+	input := writeOpenShiftSwaggerFixture(t)
+
+	out, err := executeCommand([]string{"extract", "openshift", input, "--output-dir", outDir})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("reading " + input))
+	g.Expect(out).To(ContainSubstring("OK   " + filepath.Join("route.openshift.io", "route_v1.json")))
+	g.Expect(out).To(ContainSubstring("OK   " + filepath.Join("cloud.network.openshift.io", "cloudprivateipconfig_v1.json")))
+	g.Expect(out).To(ContainSubstring("Summary: 2 schemas extracted"))
+
+	data, err := os.ReadFile(filepath.Join(outDir, "route.openshift.io", "route_v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(data)).To(ContainSubstring(`"apiVersion"`))
+	g.Expect(string(data)).To(ContainSubstring(`"kind"`))
+	g.Expect(string(data)).ToNot(ContainSubstring(`"$schema"`))
+}
+
+func TestExtractOpenShiftCmd_OutputPathsAreOpenShiftOnly(t *testing.T) {
+	// Walk every output file and assert each lives under <group>.openshift.io/.
+	// The catalog-safety invariant: extract openshift must never write
+	// outside the .openshift.io namespace, so a misconfigured generator
+	// cannot overwrite a Kubernetes catalog entry.
+	g := NewWithT(t)
+	outDir := t.TempDir()
+	input := writeOpenShiftSwaggerFixture(t)
+
+	_, err := executeCommand([]string{"extract", "openshift", input, "--output-dir", outDir})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	pathRe := regexp.MustCompile(`^[a-z][a-z0-9.]*\.openshift\.io/`)
+	var written []string
+	g.Expect(filepath.Walk(outDir, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		rel, _ := filepath.Rel(outDir, p)
+		written = append(written, filepath.ToSlash(rel))
+		return nil
+	})).To(Succeed())
+
+	g.Expect(written).ToNot(BeEmpty())
+	for _, p := range written {
+		g.Expect(pathRe.MatchString(p)).To(BeTrue(), "path %q must start with <group>.openshift.io/", p)
+	}
+}
+
+func TestExtractOpenShiftCmd_StdinDash(t *testing.T) {
+	g := NewWithT(t)
+	outDir := t.TempDir()
+	replaceStdin(t, minimalOpenShiftSwagger)
+
+	out, err := executeCommand([]string{"extract", "openshift", "-", "--output-dir", outDir})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("reading stdin"))
+	_, err = os.Stat(filepath.Join(outDir, "route.openshift.io", "route_v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestExtractOpenShiftCmd_NoInput(t *testing.T) {
+	g := NewWithT(t)
+	forceStdinTTY(t)
+	_, err := executeCommand([]string{"extract", "openshift"})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("either a swagger file, piped stdin, or --ref is required"))
+}
+
+func TestExtractOpenShiftCmd_FileAndRef(t *testing.T) {
+	g := NewWithT(t)
+	input := writeOpenShiftSwaggerFixture(t)
+	_, err := executeCommand([]string{"extract", "openshift", input, "--ref", "release-4.20"})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("mutually exclusive"))
+}
+
+func TestExtractOpenShiftCmd_EmptyRef(t *testing.T) {
+	g := NewWithT(t)
+	forceStdinTTY(t)
+	_, err := executeCommand([]string{"extract", "openshift", "--ref", ""})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("--ref must not be empty"))
+}
+
+func TestExtractOpenShiftCmd_TwoFiles(t *testing.T) {
+	g := NewWithT(t)
+	input := writeOpenShiftSwaggerFixture(t)
+	_, err := executeCommand([]string{"extract", "openshift", input, input})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("at most 1 positional argument"))
+}
+
+func TestFetchOpenShiftSwagger_Success(t *testing.T) {
+	g := NewWithT(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g.Expect(r.URL.Path).To(Equal("/release-4.20/openapi.json"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(minimalOpenShiftSwagger))
+	}))
+	defer srv.Close()
+
+	client := retryablehttp.NewClient()
+	client.Logger = nil
+
+	tmpl := srv.URL + "/%s/openapi.json"
+	url, body, err := fetchOpenShiftSwagger(context.Background(), client, tmpl, "release-4.20", 0)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(url).To(Equal(srv.URL + "/release-4.20/openapi.json"))
+	g.Expect(body).To(ContainSubstring("Route"))
+}
+
+func TestFetchOpenShiftSwagger_NotFound(t *testing.T) {
+	g := NewWithT(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "ref not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	client := retryablehttp.NewClient()
+	client.Logger = nil
+
+	url, _, err := fetchOpenShiftSwagger(context.Background(), client, srv.URL+"/%s/openapi.json", "release-9.99", 0)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("fetch "))
+	g.Expect(err.Error()).To(ContainSubstring("404"))
+	g.Expect(url).To(ContainSubstring("release-9.99"))
+}
+
+func TestFetchOpenShiftSwagger_RejectsEmptyRef(t *testing.T) {
+	g := NewWithT(t)
+
+	client := retryablehttp.NewClient()
+	client.Logger = nil
+
+	_, _, err := fetchOpenShiftSwagger(context.Background(), client, "http://127.0.0.1/%s/openapi.json", "", 0)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("--ref"))
+}
+
+func TestExtractOpenShiftCmd_RefFetch(t *testing.T) {
+	g := NewWithT(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g.Expect(r.URL.Path).To(Equal("/release-4.20/openapi.json"))
+		_, _ = w.Write([]byte(minimalOpenShiftSwagger))
+	}))
+	defer srv.Close()
+
+	client := newDefaultK8sHTTPClient()
+	source, data, err := resolveOpenShiftInput(context.Background(), client, srv.URL+"/%s/openapi.json", "", "release-4.20", 0)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(source).To(Equal(srv.URL + "/release-4.20/openapi.json"))
+	g.Expect(data).To(ContainSubstring("Route"))
+}
+
+func TestExtractOpenShiftCmd_AutoCreatesOutputDir(t *testing.T) {
+	g := NewWithT(t)
+
+	parent := t.TempDir()
+	outDir := filepath.Join(parent, "nested", "out")
+	input := writeOpenShiftSwaggerFixture(t)
+
+	_, err := executeCommand([]string{"extract", "openshift", input, "--output-dir", outDir})
+	g.Expect(err).ToNot(HaveOccurred())
+	_, err = os.Stat(filepath.Join(outDir, "route.openshift.io", "route_v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestExtractOpenShiftCmd_StripDescription(t *testing.T) {
+	g := NewWithT(t)
+	outDir := t.TempDir()
+	input := writeOpenShiftSwaggerFixture(t)
+
+	_, err := executeCommand([]string{"extract", "openshift", input, "--output-dir", outDir, "--strip-description"})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	data, err := os.ReadFile(filepath.Join(outDir, "route.openshift.io", "route_v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(data)).ToNot(ContainSubstring(`"description"`))
+}
+
+func TestExtractOpenShiftCmd_NonexistentFile(t *testing.T) {
+	g := NewWithT(t)
+	outDir := t.TempDir()
+	_, err := executeCommand([]string{"extract", "openshift", filepath.Join(outDir, "missing.json"), "--output-dir", outDir})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("read "))
+}

--- a/cmd/flux-schema/main_test.go
+++ b/cmd/flux-schema/main_test.go
@@ -51,6 +51,7 @@ func resetCmdArgs() {
 	versionArgs = versionFlags{output: "text"}
 	extractCRDArgs = extractCRDFlags{ExtractOutput: flags.NewExtractOutput()}
 	extractK8sArgs = extractK8sFlags{ExtractOutput: flags.NewExtractOutput()}
+	extractOpenShiftArgs = extractOpenShiftFlags{ExtractOutput: flags.NewExtractOutput()}
 	validateArgs = validateFlags{concurrent: validator.DefaultWorkers, output: "text"}
 
 	// pflag.Flag.Changed persists across Execute calls on the shared rootCmd,

--- a/internal/extractor/doc.go
+++ b/internal/extractor/doc.go
@@ -4,18 +4,28 @@
 // Package extractor converts Kubernetes API definitions into standalone-strict
 // JSON Schema documents suitable for offline validators and editor tooling.
 //
-// Two entry points are provided:
+// Three entry points are provided:
 //
 //   - ExtractCRDs reads a YAML payload containing CustomResourceDefinitions
 //     (bare, List-wrapped, or multi-document — e.g. `kubectl get crds -o yaml`)
 //     and returns one Schema per CRD version, taken from
 //     spec.versions[].schema.openAPIV3Schema.
 //
-//   - ExtractOpenAPI reads a Kubernetes OpenAPI v2 swagger document (e.g.
+//   - ExtractKubernetes reads a Kubernetes OpenAPI v2 swagger document (e.g.
 //     `kubectl get --raw /openapi/v2`) and returns one Schema per
 //     x-kubernetes-group-version-kind entry, with all $refs inlined.
 //
-// Both entry points return []Schema, where each Schema carries the GVK
+//   - ExtractOpenShift reads an openshift/api OpenAPI v2 swagger document
+//     and returns one Schema per top-level OpenShift resource. The OpenShift
+//     swagger carries no x-kubernetes-group-version-kind annotations, so
+//     the GVK is derived from the definition key
+//     (com.github.openshift.api.<dir>.<version>.<Kind>) and the dir is
+//     mapped to its canonical group via a hand-curated table. Only
+//     definitions in the com.github.openshift.api.* namespace are emitted;
+//     the upstream Kubernetes types embedded in the same document are
+//     inlined when referenced but never written as standalone Schemas.
+//
+// All three entry points return []Schema, where each Schema carries the GVK
 // coordinates and the transformed JSON document. The Schema's JSON map is
 // owned by the instance: transforms mutate it in place, so callers should
 // treat each Schema as single-use.

--- a/internal/extractor/kubernetes.go
+++ b/internal/extractor/kubernetes.go
@@ -10,42 +10,19 @@ import (
 	"sort"
 )
 
-// ExtractOpenAPI walks a Kubernetes OpenAPI v2 swagger document and returns
+// ExtractKubernetes walks a Kubernetes OpenAPI v2 swagger document and returns
 // one Schema per x-kubernetes-group-version-kind entry with all $refs inlined
 // and the standalone-strict transforms applied. The returned slice is sorted
 // by (Group, Version, Kind) so golden tests and archive listings are stable
 // across runs. Errors are aggregated: a malformed definition does not stop
 // extraction of the rest.
-func ExtractOpenAPI(data []byte) ([]Schema, []error) {
-	dec := json.NewDecoder(bytes.NewReader(data))
-	dec.UseNumber()
-
-	var doc any
-	if err := dec.Decode(&doc); err != nil {
-		return nil, []error{fmt.Errorf("decode swagger: %w", err)}
+func ExtractKubernetes(data []byte) ([]Schema, []error) {
+	definitions, names, errs := parseSwaggerDefinitions(data)
+	if errs != nil {
+		return nil, errs
 	}
 
-	root, ok := doc.(map[string]any)
-	if !ok {
-		return nil, []error{fmt.Errorf("swagger document is not a JSON object")}
-	}
-
-	definitions, ok := root["definitions"].(map[string]any)
-	if !ok {
-		return nil, []error{fmt.Errorf("swagger document has no 'definitions'")}
-	}
-
-	// Visit definitions in name order so log/error ordering is stable.
-	names := make([]string, 0, len(definitions))
-	for name := range definitions {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	var (
-		out  []Schema
-		errs []error
-	)
+	var out []Schema
 	for _, name := range names {
 		def, ok := definitions[name].(map[string]any)
 		if !ok {
@@ -70,6 +47,44 @@ func ExtractOpenAPI(data []byte) ([]Schema, []error) {
 		}
 	}
 
+	sortSchemasByGVK(out)
+	return out, errs
+}
+
+// parseSwaggerDefinitions decodes a swagger document and returns its
+// definitions map together with the definition names sorted alphabetically.
+// Number-preserving decode (UseNumber) lets integer literals round-trip
+// through downstream transforms unchanged.
+func parseSwaggerDefinitions(data []byte) (map[string]any, []string, []error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+
+	var doc any
+	if err := dec.Decode(&doc); err != nil {
+		return nil, nil, []error{fmt.Errorf("decode swagger: %w", err)}
+	}
+
+	root, ok := doc.(map[string]any)
+	if !ok {
+		return nil, nil, []error{fmt.Errorf("swagger document is not a JSON object")}
+	}
+
+	definitions, ok := root["definitions"].(map[string]any)
+	if !ok {
+		return nil, nil, []error{fmt.Errorf("swagger document has no 'definitions'")}
+	}
+
+	names := make([]string, 0, len(definitions))
+	for name := range definitions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return definitions, names, nil
+}
+
+// sortSchemasByGVK orders schemas by (Group, Version, Kind) so output is
+// deterministic across runs.
+func sortSchemasByGVK(out []Schema) {
 	sort.SliceStable(out, func(i, j int) bool {
 		if out[i].Group != out[j].Group {
 			return out[i].Group < out[j].Group
@@ -79,8 +94,6 @@ func ExtractOpenAPI(data []byte) ([]Schema, []error) {
 		}
 		return out[i].Kind < out[j].Kind
 	})
-
-	return out, errs
 }
 
 func readGVKs(def map[string]any) []GVK {

--- a/internal/extractor/kubernetes_test.go
+++ b/internal/extractor/kubernetes_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// mustMarshal serialises v as JSON for ExtractOpenAPI test inputs.
+// mustMarshal serialises v as JSON for ExtractKubernetes test inputs.
 func mustMarshal(t *testing.T, v any) []byte {
 	t.Helper()
 	b, err := json.Marshal(v)
@@ -20,40 +20,40 @@ func mustMarshal(t *testing.T, v any) []byte {
 	return b
 }
 
-func TestExtractOpenAPI_NoDefinitions(t *testing.T) {
+func TestExtractKubernetes_NoDefinitions(t *testing.T) {
 	g := NewWithT(t)
-	_, errs := ExtractOpenAPI([]byte(`{}`))
+	_, errs := ExtractKubernetes([]byte(`{}`))
 	g.Expect(errs).To(HaveLen(1))
 	g.Expect(errs[0].Error()).To(ContainSubstring("no 'definitions'"))
 }
 
-func TestExtractOpenAPI_InvalidJSON(t *testing.T) {
+func TestExtractKubernetes_InvalidJSON(t *testing.T) {
 	g := NewWithT(t)
-	_, errs := ExtractOpenAPI([]byte(`not json`))
+	_, errs := ExtractKubernetes([]byte(`not json`))
 	g.Expect(errs).To(HaveLen(1))
 	g.Expect(errs[0].Error()).To(ContainSubstring("decode swagger"))
 }
 
-func TestExtractOpenAPI_NonObjectRoot(t *testing.T) {
+func TestExtractKubernetes_NonObjectRoot(t *testing.T) {
 	g := NewWithT(t)
-	_, errs := ExtractOpenAPI([]byte(`[]`))
+	_, errs := ExtractKubernetes([]byte(`[]`))
 	g.Expect(errs).To(HaveLen(1))
 	g.Expect(errs[0].Error()).To(ContainSubstring("not a JSON object"))
 }
 
-func TestExtractOpenAPI_SkipsDefinitionsWithoutGVK(t *testing.T) {
+func TestExtractKubernetes_SkipsDefinitionsWithoutGVK(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
 			"helper": map[string]any{"type": "object"},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 	g.Expect(out).To(BeEmpty())
 }
 
-func TestExtractOpenAPI_InlinesRef(t *testing.T) {
+func TestExtractKubernetes_InlinesRef(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -75,7 +75,7 @@ func TestExtractOpenAPI_InlinesRef(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 	g.Expect(out).To(HaveLen(1))
 	widget := out[0]
@@ -89,7 +89,7 @@ func TestExtractOpenAPI_InlinesRef(t *testing.T) {
 	g.Expect(helper).To(HaveKey("properties"))
 }
 
-func TestExtractOpenAPI_CoreGroupKept(t *testing.T) {
+func TestExtractKubernetes_CoreGroupKept(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -101,7 +101,7 @@ func TestExtractOpenAPI_CoreGroupKept(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 	g.Expect(out).To(HaveLen(1))
 	// Group left empty here; tmpl.Execute normalizes to "core".
@@ -109,7 +109,7 @@ func TestExtractOpenAPI_CoreGroupKept(t *testing.T) {
 	g.Expect(out[0].Kind).To(Equal("Pod"))
 }
 
-func TestExtractOpenAPI_IntOrString(t *testing.T) {
+func TestExtractKubernetes_IntOrString(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -130,7 +130,7 @@ func TestExtractOpenAPI_IntOrString(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 	g.Expect(out).To(HaveLen(1))
 
@@ -143,7 +143,7 @@ func TestExtractOpenAPI_IntOrString(t *testing.T) {
 	g.Expect(port).ToNot(HaveKey("x-kubernetes-int-or-string"))
 }
 
-func TestExtractOpenAPI_PreserveUnknownFields(t *testing.T) {
+func TestExtractKubernetes_PreserveUnknownFields(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -165,7 +165,7 @@ func TestExtractOpenAPI_PreserveUnknownFields(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 	g.Expect(out).To(HaveLen(1))
 
@@ -177,7 +177,7 @@ func TestExtractOpenAPI_PreserveUnknownFields(t *testing.T) {
 	g.Expect(hasAP).To(BeFalse(), "preserve-unknown subtree stays open")
 }
 
-func TestExtractOpenAPI_PreserveUnknownFieldsSkipsNullable(t *testing.T) {
+func TestExtractKubernetes_PreserveUnknownFieldsSkipsNullable(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -199,7 +199,7 @@ func TestExtractOpenAPI_PreserveUnknownFieldsSkipsNullable(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
 	values := out[0].JSON["properties"].(map[string]any)["values"].(map[string]any)
@@ -208,7 +208,7 @@ func TestExtractOpenAPI_PreserveUnknownFieldsSkipsNullable(t *testing.T) {
 		"properties inside a preserve-unknown subtree must not be nulled")
 }
 
-func TestExtractOpenAPI_NestedNullableOptional(t *testing.T) {
+func TestExtractKubernetes_NestedNullableOptional(t *testing.T) {
 	g := NewWithT(t)
 	// Each nested object has its own required array; nulling must not
 	// propagate downward.
@@ -233,7 +233,7 @@ func TestExtractOpenAPI_NestedNullableOptional(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
 	spec := out[0].JSON["properties"].(map[string]any)["spec"].(map[string]any)
@@ -244,7 +244,7 @@ func TestExtractOpenAPI_NestedNullableOptional(t *testing.T) {
 	g.Expect(optional["type"]).To(ConsistOf("integer", "null"), "optional nested field is nulled")
 }
 
-func TestExtractOpenAPI_IndirectCycle(t *testing.T) {
+func TestExtractKubernetes_IndirectCycle(t *testing.T) {
 	g := NewWithT(t)
 	// A refs B, B refs A. This is the real-world shape of JSONSchemaProps /
 	// JSONSchemaPropsOrArray.
@@ -267,7 +267,7 @@ func TestExtractOpenAPI_IndirectCycle(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 	g.Expect(out).To(HaveLen(1))
 
@@ -278,7 +278,7 @@ func TestExtractOpenAPI_IndirectCycle(t *testing.T) {
 	g.Expect(a["x-kubernetes-preserve-unknown-fields"]).To(BeTrue())
 }
 
-func TestExtractOpenAPI_NullableOptional(t *testing.T) {
+func TestExtractKubernetes_NullableOptional(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -295,7 +295,7 @@ func TestExtractOpenAPI_NullableOptional(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
 	props := out[0].JSON["properties"].(map[string]any)
@@ -306,7 +306,7 @@ func TestExtractOpenAPI_NullableOptional(t *testing.T) {
 	g.Expect(optional["type"]).To(ConsistOf("integer", "null"))
 }
 
-func TestExtractOpenAPI_NullableIdempotent(t *testing.T) {
+func TestExtractKubernetes_NullableIdempotent(t *testing.T) {
 	g := NewWithT(t)
 	// Optional field already typed as a list containing null — should not double-add.
 	doc := map[string]any{
@@ -322,7 +322,7 @@ func TestExtractOpenAPI_NullableIdempotent(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
 	props := out[0].JSON["properties"].(map[string]any)
@@ -330,7 +330,7 @@ func TestExtractOpenAPI_NullableIdempotent(t *testing.T) {
 	g.Expect(already["type"]).To(ConsistOf("string", "null"))
 }
 
-func TestExtractOpenAPI_OneOfGetsNullBranch(t *testing.T) {
+func TestExtractKubernetes_OneOfGetsNullBranch(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -350,7 +350,7 @@ func TestExtractOpenAPI_OneOfGetsNullBranch(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
 	props := out[0].JSON["properties"].(map[string]any)
@@ -360,7 +360,7 @@ func TestExtractOpenAPI_OneOfGetsNullBranch(t *testing.T) {
 	g.Expect(oneOf[2]).To(Equal(map[string]any{"type": "null"}))
 }
 
-func TestExtractOpenAPI_OneOfWithExistingNullBranch(t *testing.T) {
+func TestExtractKubernetes_OneOfWithExistingNullBranch(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -380,7 +380,7 @@ func TestExtractOpenAPI_OneOfWithExistingNullBranch(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
 	props := out[0].JSON["properties"].(map[string]any)
@@ -389,7 +389,7 @@ func TestExtractOpenAPI_OneOfWithExistingNullBranch(t *testing.T) {
 	g.Expect(oneOf).To(HaveLen(2), "existing null branch prevents a duplicate")
 }
 
-func TestExtractOpenAPI_ObjectWithEmptyRequired(t *testing.T) {
+func TestExtractKubernetes_ObjectWithEmptyRequired(t *testing.T) {
 	g := NewWithT(t)
 	// required: [] means every property is optional.
 	doc := map[string]any{
@@ -406,7 +406,7 @@ func TestExtractOpenAPI_ObjectWithEmptyRequired(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
 	props := out[0].JSON["properties"].(map[string]any)
@@ -414,7 +414,7 @@ func TestExtractOpenAPI_ObjectWithEmptyRequired(t *testing.T) {
 	g.Expect(a["type"]).To(ConsistOf("string", "null"))
 }
 
-func TestExtractOpenAPI_GVKInjection(t *testing.T) {
+func TestExtractKubernetes_GVKInjection(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -426,7 +426,7 @@ func TestExtractOpenAPI_GVKInjection(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
 	schema := out[0].JSON
@@ -442,7 +442,7 @@ func TestExtractOpenAPI_GVKInjection(t *testing.T) {
 	g.Expect(required).To(ContainElement("kind"))
 }
 
-func TestExtractOpenAPI_GVKInjectionIdempotent(t *testing.T) {
+func TestExtractKubernetes_GVKInjectionIdempotent(t *testing.T) {
 	g := NewWithT(t)
 	// Existing apiVersion / kind properties are left untouched.
 	doc := map[string]any{
@@ -459,7 +459,7 @@ func TestExtractOpenAPI_GVKInjectionIdempotent(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
 	props := out[0].JSON["properties"].(map[string]any)
@@ -469,7 +469,7 @@ func TestExtractOpenAPI_GVKInjectionIdempotent(t *testing.T) {
 	g.Expect(kind["default"]).To(Equal("Widget"))
 }
 
-func TestExtractOpenAPI_NoMetadataForBinding(t *testing.T) {
+func TestExtractKubernetes_NoMetadataForBinding(t *testing.T) {
 	g := NewWithT(t)
 	// A kind without metadata (e.g. Binding-shaped) must not gain a metadata
 	// property and must not require metadata.
@@ -483,7 +483,7 @@ func TestExtractOpenAPI_NoMetadataForBinding(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
 	props := out[0].JSON["properties"].(map[string]any)
@@ -492,7 +492,7 @@ func TestExtractOpenAPI_NoMetadataForBinding(t *testing.T) {
 	g.Expect(required).ToNot(ContainElement("metadata"))
 }
 
-func TestExtractOpenAPI_RefSiblingMetadataWins(t *testing.T) {
+func TestExtractKubernetes_RefSiblingMetadataWins(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -515,14 +515,14 @@ func TestExtractOpenAPI_RefSiblingMetadataWins(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
 	helper := out[0].JSON["properties"].(map[string]any)["helper"].(map[string]any)
 	g.Expect(helper["default"]).To(Equal("contextual"))
 }
 
-func TestExtractOpenAPI_RefSiblingTypeLoses(t *testing.T) {
+func TestExtractKubernetes_RefSiblingTypeLoses(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -547,14 +547,14 @@ func TestExtractOpenAPI_RefSiblingTypeLoses(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
 	helper := out[0].JSON["properties"].(map[string]any)["helper"].(map[string]any)
 	g.Expect(helper["type"]).To(Equal("object"), "structural type from the inlined definition wins")
 }
 
-func TestExtractOpenAPI_RefCycleBailsOut(t *testing.T) {
+func TestExtractKubernetes_RefCycleBailsOut(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -569,14 +569,14 @@ func TestExtractOpenAPI_RefCycleBailsOut(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
 	self := out[0].JSON["properties"].(map[string]any)["self"].(map[string]any)
 	g.Expect(self["x-kubernetes-preserve-unknown-fields"]).To(BeTrue())
 }
 
-func TestExtractOpenAPI_MultipleGVK(t *testing.T) {
+func TestExtractKubernetes_MultipleGVK(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -589,12 +589,12 @@ func TestExtractOpenAPI_MultipleGVK(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 	g.Expect(out).To(HaveLen(2))
 }
 
-func TestExtractOpenAPI_MissingRefIsError(t *testing.T) {
+func TestExtractKubernetes_MissingRefIsError(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -610,7 +610,7 @@ func TestExtractOpenAPI_MissingRefIsError(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	// Processing continues; a placeholder is emitted.
 	g.Expect(errs).To(BeEmpty())
 	g.Expect(out).To(HaveLen(1))
@@ -620,7 +620,7 @@ func TestExtractOpenAPI_MissingRefIsError(t *testing.T) {
 	g.Expect(broken["description"]).To(ContainSubstring("unresolved $ref"))
 }
 
-func TestExtractOpenAPI_StripsVendorExtensions(t *testing.T) {
+func TestExtractKubernetes_StripsVendorExtensions(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -648,7 +648,7 @@ func TestExtractOpenAPI_StripsVendorExtensions(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
 	g.Expect(out[0].JSON).ToNot(HaveKey("x-kubernetes-group-version-kind"))
@@ -665,7 +665,7 @@ func TestExtractOpenAPI_StripsVendorExtensions(t *testing.T) {
 	g.Expect(count).To(HaveKey("x-kubernetes-validations"))
 }
 
-func TestExtractOpenAPI_PreservesDescriptions(t *testing.T) {
+func TestExtractKubernetes_PreservesDescriptions(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -684,7 +684,7 @@ func TestExtractOpenAPI_PreservesDescriptions(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
 	g.Expect(out[0].JSON["description"]).To(Equal("top-level description"))
@@ -692,7 +692,7 @@ func TestExtractOpenAPI_PreservesDescriptions(t *testing.T) {
 	g.Expect(name["description"]).To(Equal("property description"))
 }
 
-func TestExtractOpenAPI_SortedOutput(t *testing.T) {
+func TestExtractKubernetes_SortedOutput(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -710,14 +710,14 @@ func TestExtractOpenAPI_SortedOutput(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 	g.Expect(out).To(HaveLen(2))
 	g.Expect(out[0].Group).To(Equal("a.example.com"))
 	g.Expect(out[1].Group).To(Equal("b.example.com"))
 }
 
-func TestExtractOpenAPI_PreservesJSONNumber(t *testing.T) {
+func TestExtractKubernetes_PreservesJSONNumber(t *testing.T) {
 	g := NewWithT(t)
 	// Use raw JSON so the integer literal stays exact through UseNumber.
 	raw := []byte(`{
@@ -734,7 +734,7 @@ func TestExtractOpenAPI_PreservesJSONNumber(t *testing.T) {
     }
   }
 }`)
-	out, errs := ExtractOpenAPI(raw)
+	out, errs := ExtractKubernetes(raw)
 	g.Expect(errs).To(BeEmpty())
 
 	count := out[0].JSON["properties"].(map[string]any)["count"].(map[string]any)
@@ -742,7 +742,7 @@ func TestExtractOpenAPI_PreservesJSONNumber(t *testing.T) {
 	g.Expect(count["minimum"].(json.Number).String()).To(Equal("1"))
 }
 
-func TestExtractOpenAPI_RootIsClosed(t *testing.T) {
+func TestExtractKubernetes_RootIsClosed(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -757,13 +757,13 @@ func TestExtractOpenAPI_RootIsClosed(t *testing.T) {
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 	g.Expect(out[0].JSON["additionalProperties"]).To(BeFalse(),
 		"root must reject undocumented top-level keys")
 }
 
-func TestExtractOpenAPI_DoesNotOverwriteExistingAdditionalProperties(t *testing.T) {
+func TestExtractKubernetes_DoesNotOverwriteExistingAdditionalProperties(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -782,7 +782,7 @@ func TestExtractOpenAPI_DoesNotOverwriteExistingAdditionalProperties(t *testing.
 			},
 		},
 	}
-	out, errs := ExtractOpenAPI(mustMarshal(t, doc))
+	out, errs := ExtractKubernetes(mustMarshal(t, doc))
 	g.Expect(errs).To(BeEmpty())
 
 	labels := out[0].JSON["properties"].(map[string]any)["labels"].(map[string]any)

--- a/internal/extractor/openshift.go
+++ b/internal/extractor/openshift.go
@@ -1,0 +1,189 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package extractor
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// openShiftDefinitionPrefix is the prefix every openshift/api swagger
+// definition key shares. Keys outside this namespace (the upstream
+// Kubernetes types embedded in the same document) are inlined when
+// referenced but never emitted as standalone Schemas.
+const openShiftDefinitionPrefix = "com.github.openshift.api."
+
+// openShiftDirToGroup maps the swagger directory segment (the token after
+// com.github.openshift.api.) to the canonical Kubernetes API group declared
+// in openshift/api's <dir>/v*/register.go GroupName constants. Verified at
+// release-4.20 against every dir present in the swagger.
+//
+// legacyconfig is intentionally absent: its LegacyGroupName is "" (config-
+// file format, not an API group) and every legacyconfig definition fails
+// the GitOps-scope filter regardless.
+var openShiftDirToGroup = map[string]string{
+	"apiserver":             "apiserver.openshift.io",
+	"apps":                  "apps.openshift.io",
+	"authorization":         "authorization.openshift.io",
+	"build":                 "build.openshift.io",
+	"cloudnetwork":          "cloud.network.openshift.io",
+	"config":                "config.openshift.io",
+	"console":               "console.openshift.io",
+	"example":               "example.openshift.io",
+	"helm":                  "helm.openshift.io",
+	"image":                 "image.openshift.io",
+	"insights":              "insights.openshift.io",
+	"kubecontrolplane":      "kubecontrolplane.config.openshift.io",
+	"machine":               "machine.openshift.io",
+	"machineconfiguration":  "machineconfiguration.openshift.io",
+	"monitoring":            "monitoring.openshift.io",
+	"network":               "network.openshift.io",
+	"networkoperator":       "network.operator.openshift.io",
+	"oauth":                 "oauth.openshift.io",
+	"openshiftcontrolplane": "openshiftcontrolplane.config.openshift.io",
+	"operator":              "operator.openshift.io",
+	"operatorcontrolplane":  "controlplane.operator.openshift.io",
+	"operatoringress":       "ingress.operator.openshift.io",
+	"osin":                  "osin.config.openshift.io",
+	"project":               "project.openshift.io",
+	"quota":                 "quota.openshift.io",
+	"route":                 "route.openshift.io",
+	"samples":               "samples.operator.openshift.io",
+	"security":              "security.openshift.io",
+	"securityinternal":      "security.internal.openshift.io",
+	"servicecertsigner":     "servicecertsigner.config.openshift.io",
+	"sharedresource":        "sharedresource.openshift.io",
+	"template":              "template.openshift.io",
+	"user":                  "user.openshift.io",
+}
+
+var (
+	// openShiftVersionRe accepts the K8s version forms used by openshift/api:
+	// stable (vN), alpha (vNalphaN), beta (vNbetaN).
+	openShiftVersionRe = regexp.MustCompile(`^v\d+(alpha\d+|beta\d+)?$`)
+
+	// openShiftSkipKindRe matches kind names that are never persisted to Git:
+	// list wrappers (server response shape), review/option payloads (POST
+	// bodies on auth and subresource endpoints), and provider configs
+	// (embedded as RawExtension under MachineSet, never validated standalone).
+	// The pattern is anchored so unrelated kinds whose names happen to
+	// contain a suffix substring (e.g. "Console", "Configurations") are
+	// preserved.
+	openShiftSkipKindRe = regexp.MustCompile(`^[A-Za-z]+(List|ReviewResponse|Review|ProviderConfig|ProviderSpec|ProviderStatus|Options)$`)
+)
+
+// ExtractOpenShift walks an openshift/api OpenAPI v2 swagger document and
+// returns one Schema per top-level OpenShift resource, with all $refs
+// inlined (including refs to upstream Kubernetes types embedded in the same
+// document) and the standalone-strict transforms applied. Definitions
+// outside the com.github.openshift.api.* namespace are inlined when
+// referenced but never emitted as their own Schema, so the catalog can
+// never accidentally overwrite a Kubernetes schema with an OpenShift copy.
+//
+// The returned slice is sorted by (Group, Version, Kind). Errors are
+// aggregated: a malformed definition does not stop extraction of the rest.
+func ExtractOpenShift(data []byte) ([]Schema, []error) {
+	definitions, names, errs := parseSwaggerDefinitions(data)
+	if errs != nil {
+		return nil, errs
+	}
+
+	var out []Schema
+	for _, name := range names {
+		def, ok := definitions[name].(map[string]any)
+		if !ok {
+			continue
+		}
+		// Namespace filter: only OpenShift definitions are candidates.
+		if !strings.HasPrefix(name, openShiftDefinitionPrefix) {
+			continue
+		}
+		// GitOps-scope filter: the kind must look like a persistable resource.
+		if !hasGitOpsShape(def) {
+			continue
+		}
+		// GVK derivation must precede the suffix filter so the regex applies
+		// to just the <Kind> segment, not the dotted definition key.
+		gvk, err := deriveOpenShiftGVK(name)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		// Suffix filter: drop list/review/options/provider* shapes that are
+		// never persisted, even though they pass the structural filter.
+		if openShiftSkipKindRe.MatchString(gvk.Kind) {
+			continue
+		}
+		// Catalog-safety guard: a bug in the dir map or the namespace filter
+		// must never produce a non-OpenShift group.
+		if !strings.HasSuffix(gvk.Group, ".openshift.io") {
+			errs = append(errs, fmt.Errorf("internal: derived group %q for %q is not under .openshift.io", gvk.Group, name))
+			continue
+		}
+		schema, err := buildSchema(name, def, definitions)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", name, err))
+			continue
+		}
+		out = append(out, Schema{
+			Group:   gvk.Group,
+			Version: gvk.Version,
+			Kind:    gvk.Kind,
+			JSON:    schema,
+		})
+	}
+
+	sortSchemasByGVK(out)
+	return out, errs
+}
+
+// hasGitOpsShape reports whether def carries the apiVersion, kind, and
+// metadata properties that distinguish a GitOps-applicable resource from
+// a helper or subresource type. Subresource request payloads
+// (BuildLog, DeploymentRequest, …) lack metadata and are filtered here.
+func hasGitOpsShape(def map[string]any) bool {
+	props, ok := def["properties"].(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, key := range []string{"apiVersion", "kind", "metadata"} {
+		if _, has := props[key]; !has {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveOpenShiftGVK parses an OpenShift definition key into a GVK. Keys
+// are shaped com.github.openshift.api.<dir>.<version>.<Kind>. The dir is
+// looked up in openShiftDirToGroup; an unknown dir is a hard error so a
+// future openshift/api directory addition surfaces as a generator failure
+// instead of silently producing a wrong group.
+func deriveOpenShiftGVK(name string) (GVK, error) {
+	suffix := strings.TrimPrefix(name, openShiftDefinitionPrefix)
+	parts := strings.SplitN(suffix, ".", 3)
+	if len(parts) != 3 {
+		return GVK{}, fmt.Errorf("openshift definition %q is malformed (expected <dir>.<version>.<Kind>)", name)
+	}
+	dir, version, kind := parts[0], parts[1], parts[2]
+	if !openShiftVersionRe.MatchString(version) {
+		return GVK{}, fmt.Errorf("openshift definition %q has unsupported version %q", name, version)
+	}
+	if kind == "" {
+		return GVK{}, fmt.Errorf("openshift definition %q has empty kind segment", name)
+	}
+	// SplitN consumes only the first two dots, so a synthetic key like
+	// com.github.openshift.api.<dir>.v1.Foo.Bar would yield kind="Foo.Bar"
+	// and produce a file path with an embedded dot. No such kind exists
+	// today, but we reject it here to keep the parse strict.
+	if strings.Contains(kind, ".") {
+		return GVK{}, fmt.Errorf("openshift definition %q has dotted kind segment %q", name, kind)
+	}
+	group, ok := openShiftDirToGroup[dir]
+	if !ok {
+		return GVK{}, fmt.Errorf("openshift definition %q uses unknown dir %q (add it to openShiftDirToGroup)", name, dir)
+	}
+	return GVK{Group: group, Version: version, Kind: kind}, nil
+}

--- a/internal/extractor/openshift_test.go
+++ b/internal/extractor/openshift_test.go
@@ -1,0 +1,357 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package extractor
+
+import (
+	"maps"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+// gitopsKindDef returns a definition that passes the GitOps-scope filter:
+// it carries apiVersion, kind, and metadata properties. Callers can
+// override or extend properties via the with map.
+func gitopsKindDef(with map[string]any) map[string]any {
+	props := map[string]any{
+		"apiVersion": map[string]any{"type": "string"},
+		"kind":       map[string]any{"type": "string"},
+		"metadata":   map[string]any{"type": "object"},
+		"spec":       map[string]any{"type": "object"},
+	}
+	maps.Copy(props, with)
+	return map[string]any{
+		"type":       "object",
+		"properties": props,
+	}
+}
+
+func swaggerWith(t *testing.T, defs map[string]any) []byte {
+	t.Helper()
+	return mustMarshal(t, map[string]any{
+		"swagger":     "2.0",
+		"definitions": defs,
+	})
+}
+
+func TestExtractOpenShift_NoDefinitions(t *testing.T) {
+	g := NewWithT(t)
+	_, errs := ExtractOpenShift([]byte(`{}`))
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0].Error()).To(ContainSubstring("no 'definitions'"))
+}
+
+func TestExtractOpenShift_InvalidJSON(t *testing.T) {
+	g := NewWithT(t)
+	_, errs := ExtractOpenShift([]byte(`not json`))
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0].Error()).To(ContainSubstring("decode swagger"))
+}
+
+func TestExtractOpenShift_RouteHappyPath(t *testing.T) {
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.route.v1.Route": gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(schemas).To(HaveLen(1))
+	g.Expect(schemas[0].Group).To(Equal("route.openshift.io"))
+	g.Expect(schemas[0].Version).To(Equal("v1"))
+	g.Expect(schemas[0].Kind).To(Equal("Route"))
+	required := schemas[0].JSON["required"].([]any)
+	g.Expect(required).To(ContainElement("apiVersion"))
+	g.Expect(required).To(ContainElement("kind"))
+	g.Expect(schemas[0].JSON["additionalProperties"]).To(BeFalse())
+	// $schema is intentionally not injected — the catalog's K8s schemas
+	// also omit it, and a stray injection here would diverge.
+	_, hasSchema := schemas[0].JSON["$schema"]
+	g.Expect(hasSchema).To(BeFalse())
+}
+
+func TestExtractOpenShift_AlphaVersion(t *testing.T) {
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.config.v1alpha1.Foo": gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(schemas).To(HaveLen(1))
+	g.Expect(schemas[0].Version).To(Equal("v1alpha1"))
+	g.Expect(schemas[0].Kind).To(Equal("Foo"))
+}
+
+func TestExtractOpenShift_CompoundGroup(t *testing.T) {
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.cloudnetwork.v1.CloudPrivateIPConfig": gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(schemas).To(HaveLen(1))
+	g.Expect(schemas[0].Group).To(Equal("cloud.network.openshift.io"))
+}
+
+func TestExtractOpenShift_OperatorIngressGroup(t *testing.T) {
+	// operatoringress is one of the compound-group cases where the dir
+	// segment is *not* the prefix of the group — guards against a naive
+	// `<dir>.openshift.io` fallback.
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.operatoringress.v1.DNSRecord": gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(schemas).To(HaveLen(1))
+	g.Expect(schemas[0].Group).To(Equal("ingress.operator.openshift.io"))
+}
+
+func TestExtractOpenShift_HelperTypeNotEmitted(t *testing.T) {
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.route.v1.RouteSpec": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"host": map[string]any{"type": "string"},
+			},
+		},
+		"com.github.openshift.api.route.v1.Route": gitopsKindDef(map[string]any{
+			"spec": map[string]any{"$ref": "#/definitions/com.github.openshift.api.route.v1.RouteSpec"},
+		}),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(schemas).To(HaveLen(1))
+	g.Expect(schemas[0].Kind).To(Equal("Route"))
+	// The RouteSpec ref was inlined into Route.spec.
+	spec := schemas[0].JSON["properties"].(map[string]any)["spec"].(map[string]any)
+	specProps := spec["properties"].(map[string]any)
+	g.Expect(specProps).To(HaveKey("host"))
+}
+
+func TestExtractOpenShift_K8sDefinitionsNotEmitted(t *testing.T) {
+	// Catalog-safety invariant: K8s types embedded in the OpenShift
+	// swagger must not be emitted, otherwise this run would overwrite
+	// entries produced by gen-k8s-schemas.sh.
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"io.k8s.api.core.v1.Pod":                  gitopsKindDef(nil),
+		"com.github.openshift.api.route.v1.Route": gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(schemas).To(HaveLen(1))
+	g.Expect(schemas[0].Kind).To(Equal("Route"))
+}
+
+func TestExtractOpenShift_RefToK8sTypeInlined(t *testing.T) {
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{"type": "string"},
+			},
+		},
+		"com.github.openshift.api.route.v1.Route": gitopsKindDef(map[string]any{
+			"metadata": map[string]any{"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},
+		}),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(schemas).To(HaveLen(1))
+	meta := schemas[0].JSON["properties"].(map[string]any)["metadata"].(map[string]any)
+	metaProps := meta["properties"].(map[string]any)
+	g.Expect(metaProps).To(HaveKey("name"))
+}
+
+func TestExtractOpenShift_SuffixListSkipped(t *testing.T) {
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.route.v1.Route":     gitopsKindDef(nil),
+		"com.github.openshift.api.route.v1.RouteList": gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(schemas).To(HaveLen(1))
+	g.Expect(schemas[0].Kind).To(Equal("Route"))
+}
+
+func TestExtractOpenShift_SuffixReviewSkipped(t *testing.T) {
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.authorization.v1.SubjectAccessReview":         gitopsKindDef(nil),
+		"com.github.openshift.api.authorization.v1.SubjectAccessReviewResponse": gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(schemas).To(BeEmpty())
+}
+
+func TestExtractOpenShift_SuffixProviderConfigSkipped(t *testing.T) {
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.machine.v1beta1.AWSMachineProviderConfig": gitopsKindDef(nil),
+		"com.github.openshift.api.machine.v1beta1.AWSMachineProviderSpec":   gitopsKindDef(nil),
+		"com.github.openshift.api.machine.v1beta1.AWSMachineProviderStatus": gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(schemas).To(BeEmpty())
+}
+
+func TestExtractOpenShift_SuffixOptionsSkipped(t *testing.T) {
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.build.v1.BinaryBuildRequestOptions": gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(schemas).To(BeEmpty())
+}
+
+func TestExtractOpenShift_SuffixRegexDoesNotOverMatch(t *testing.T) {
+	// Console / Routelistener / Configuration share substrings with the
+	// excluded suffixes but must stay in the output — guards against the
+	// regex losing its anchor or its case-sensitivity.
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.console.v1.Console":      gitopsKindDef(nil),
+		"com.github.openshift.api.route.v1.Routelistener":  gitopsKindDef(nil),
+		"com.github.openshift.api.config.v1.Configuration": gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(schemas).To(HaveLen(3))
+	kinds := []string{schemas[0].Kind, schemas[1].Kind, schemas[2].Kind}
+	g.Expect(kinds).To(ConsistOf("Console", "Configuration", "Routelistener"))
+}
+
+func TestExtractOpenShift_SubresourceWithoutMetadataSkipped(t *testing.T) {
+	// BuildLog and DeploymentRequest carry apiVersion+kind but no
+	// metadata — they are POST/GET payloads on subresource endpoints
+	// (/log, /instantiate) and are never written to Git. The structural
+	// filter excludes them silently.
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.build.v1.BuildLog": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"apiVersion": map[string]any{"type": "string"},
+				"kind":       map[string]any{"type": "string"},
+			},
+		},
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(schemas).To(BeEmpty())
+}
+
+func TestExtractOpenShift_LegacyConfigSkipped(t *testing.T) {
+	// legacyconfig is intentionally absent from openShiftDirToGroup
+	// (LegacyGroupName = "" upstream). The structural filter already drops
+	// every legacyconfig definition at release-4.20; this test pins the
+	// belt-and-suspenders behavior for a hypothetical future definition
+	// that grew apiVersion+kind+metadata properties.
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.legacyconfig.v1.MasterConfig": gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(schemas).To(BeEmpty())
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0].Error()).To(ContainSubstring("legacyconfig"))
+}
+
+func TestExtractOpenShift_UnknownDirError(t *testing.T) {
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.brandnewthing.v1.Foo": gitopsKindDef(nil),
+		"com.github.openshift.api.route.v1.Route":       gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(schemas).To(HaveLen(1))
+	g.Expect(schemas[0].Kind).To(Equal("Route"))
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0].Error()).To(ContainSubstring("brandnewthing"))
+}
+
+func TestExtractOpenShift_MalformedKey(t *testing.T) {
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.notakind":       gitopsKindDef(nil),
+		"com.github.openshift.api.route.v1.Route": gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(schemas).To(HaveLen(1))
+	g.Expect(schemas[0].Kind).To(Equal("Route"))
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0].Error()).To(ContainSubstring("malformed"))
+}
+
+func TestExtractOpenShift_DottedKindRejected(t *testing.T) {
+	// SplitN with limit=3 consumes only the first two dots, so a key with
+	// a trailing dot in the kind segment would slip past the structural
+	// parse. The explicit no-dot check rejects it.
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.route.v1.Foo.Bar": gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(schemas).To(BeEmpty())
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0].Error()).To(ContainSubstring("dotted kind"))
+}
+
+func TestExtractOpenShift_BadVersionSegment(t *testing.T) {
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.route.gamma.Route": gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(schemas).To(BeEmpty())
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0].Error()).To(ContainSubstring("unsupported version"))
+}
+
+func TestExtractOpenShift_CatalogSafetyGuard(t *testing.T) {
+	// Inject a non-OpenShift group into the dir map to prove the suffix
+	// guard fires before any Schema is emitted with a wrong group.
+	// Restored via t.Cleanup so other tests are unaffected.
+	//
+	// This test mutates a package-level map. Do NOT add t.Parallel() here
+	// or to any sibling test in this package — concurrent reads from
+	// deriveOpenShiftGVK would race with the write below.
+	g := NewWithT(t)
+	openShiftDirToGroup["badtest"] = "badtest.example.com"
+	t.Cleanup(func() { delete(openShiftDirToGroup, "badtest") })
+
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.badtest.v1.Foo": gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(schemas).To(BeEmpty())
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0].Error()).To(ContainSubstring("not under .openshift.io"))
+}
+
+func TestExtractOpenShift_DeterministicSort(t *testing.T) {
+	g := NewWithT(t)
+	data := swaggerWith(t, map[string]any{
+		"com.github.openshift.api.route.v1.Route":           gitopsKindDef(nil),
+		"com.github.openshift.api.config.v1.Build":          gitopsKindDef(nil),
+		"com.github.openshift.api.config.v1alpha1.Build":    gitopsKindDef(nil),
+		"com.github.openshift.api.apps.v1.DeploymentConfig": gitopsKindDef(nil),
+	})
+	schemas, errs := ExtractOpenShift(data)
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(schemas).To(HaveLen(4))
+	// Sorted by (Group, Version, Kind).
+	g.Expect(schemas[0].Group).To(Equal("apps.openshift.io"))
+	g.Expect(schemas[1].Group).To(Equal("config.openshift.io"))
+	g.Expect(schemas[1].Version).To(Equal("v1"))
+	g.Expect(schemas[2].Group).To(Equal("config.openshift.io"))
+	g.Expect(schemas[2].Version).To(Equal("v1alpha1"))
+	g.Expect(schemas[3].Group).To(Equal("route.openshift.io"))
+}


### PR DESCRIPTION
The `extract openshift` command reads the `openshift/api` OpenAPI v2 swagger document and writes one JSON Schema file per OpenShift resource. Only definitions in the `openshift` namespace are emitted; the upstream Kubernetes types embedded in the same document (e.g. `Pod`) are inlined.

Fetch the swagger from `openshift/api` at a release branch:

```shell
flux-schema extract openshift --ref release-4.20 -d ./schemas
```

Or supply the swagger file:

```shell
curl -sL https://raw.githubusercontent.com/openshift/api/release-4.20/openapi/openapi.json \
  flux-schema extract openshift -d ./schemas
```

The same `-f, --output-format` template used by `extract k8s` works here, so the generated files remain resolvable by `validate` with a single `--schema-location` for both Kubernetes and OpenShift resources. 