### PR TITLE
Use strict YAML decoding to preserve integer types

### DIFF
--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/santhosh-tekuri/jsonschema/v6"
+	utiljson "k8s.io/apimachinery/pkg/util/json"
 	"sigs.k8s.io/yaml"
 
 	"github.com/fluxcd/flux-schema/internal/tmpl"
@@ -603,13 +604,13 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 		return StatusInvalid
 	}
 
-	var doc map[string]any
-	if err := yaml.UnmarshalStrict(raw, &doc); err != nil {
+	doc, err := decodeDoc(raw, true)
+	if err != nil {
 		// Lenient re-parse so callers can still render Kind/Namespace/Name
 		// for a doc that failed admission (e.g. duplicate keys), rather
 		// than the anonymous "/#1".
-		var lenient map[string]any
-		if yaml.Unmarshal(raw, &lenient) == nil && lenient != nil {
+		lenient, _ := decodeDoc(raw, false)
+		if lenient != nil {
 			r.APIVersion, r.Kind, r.Namespace, r.Name = extractIdentity(lenient)
 		}
 		if r.Name == "" {
@@ -730,6 +731,39 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 	return r, true
 }
 
+// decodeDoc parses one YAML document into a map[string]any while preserving
+// the int/float distinction that CEL evaluation requires.
+//
+// We deliberately avoid sigs.k8s.io/yaml's Unmarshal helpers: they finish the
+// YAML→JSON→Go round-trip with stdlib encoding/json, which decodes every JSON
+// number into float64 when the target is interface{}. apiserver's CEL
+// UnstructuredToVal then rejects integer-typed fields with "expected int, got
+// float64". apimachinery's util/json.Unmarshal preserves the int distinction
+// (kjson.UnmarshalCaseSensitivePreserveInts under the hood), matching how the
+// kube-apiserver decodes admission payloads before invoking CEL.
+//
+// strict=true triggers YAMLToJSONStrict, which surfaces duplicate YAML keys
+// as an error.
+func decodeDoc(raw []byte, strict bool) (map[string]any, error) {
+	var (
+		jsonBytes []byte
+		err       error
+	)
+	if strict {
+		jsonBytes, err = yaml.YAMLToJSONStrict(raw)
+	} else {
+		jsonBytes, err = yaml.YAMLToJSON(raw)
+	}
+	if err != nil {
+		return nil, err
+	}
+	var doc map[string]any
+	if err := utiljson.Unmarshal(jsonBytes, &doc); err != nil {
+		return nil, err
+	}
+	return doc, nil
+}
+
 // splitYAMLError turns a YAML decode error into clean, per-violation details
 // the CLI can render on indented sub-lines, the same way JSON Schema
 // violations are rendered.
@@ -743,13 +777,22 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 // that doesn't match a known shape is returned verbatim rather than
 // dropped.
 func splitYAMLError(err error) []ValidationError {
+	// decodeDoc surfaces yaml errors directly from yaml.YAMLToJSONStrict (e.g.
+	// "yaml: unmarshal errors:\n  line N: ..."). The "error converting YAML
+	// to JSON: " variants are kept for back-compat in case any code path
+	// still routes through sigs.k8s.io/yaml's higher-level Unmarshal helpers.
 	const (
-		multiPrefix  = "error converting YAML to JSON: yaml: unmarshal errors:"
-		singlePrefix = "error converting YAML to JSON: yaml: "
-		rawPrefix    = "yaml: "
+		multiPrefixWrapped = "error converting YAML to JSON: yaml: unmarshal errors:"
+		multiPrefixBare    = "yaml: unmarshal errors:"
+		singlePrefix       = "error converting YAML to JSON: yaml: "
+		rawPrefix          = "yaml: "
 	)
 	msg := err.Error()
-	if rest, ok := strings.CutPrefix(msg, multiPrefix); ok {
+	for _, prefix := range []string{multiPrefixWrapped, multiPrefixBare} {
+		rest, ok := strings.CutPrefix(msg, prefix)
+		if !ok {
+			continue
+		}
 		var out []ValidationError
 		for line := range strings.SplitSeq(rest, "\n") {
 			t := strings.TrimSpace(line)

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -88,6 +88,92 @@ spec:
 	g.Expect(results[0].Errors).To(BeEmpty())
 }
 
+// writeWidgetSchemaWithIntCEL writes a Widget schema with an integer-typed
+// field guarded by an x-kubernetes-validations rule. The rule ("self.port >
+// 0") forces the apiserver CEL evaluator to bind self.port as an int — which
+// only works if the YAML decoder hands back an int rather than a JSON-default
+// float64. Used by the regression test below to lock in that wiring.
+func writeWidgetSchemaWithIntCEL(t *testing.T, dir string) {
+	t.Helper()
+	schema := map[string]any{
+		"type":     "object",
+		"required": []any{"apiVersion", "kind", "spec"},
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"type": "string"},
+			"kind":       map[string]any{"type": "string"},
+			"metadata":   map[string]any{"type": "object"},
+			"spec": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"required":             []any{"port"},
+				"properties": map[string]any{
+					"port": map[string]any{"type": "integer", "format": "int32"},
+				},
+				"x-kubernetes-validations": []any{
+					map[string]any{"rule": "self.port > 0", "message": "port must be positive"},
+				},
+			},
+		},
+	}
+	b, err := json.MarshalIndent(schema, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	path := filepath.Join(dir, "widget-example-v1.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+}
+
+// Regression: a CEL rule that references an integer field used to fail with
+// "invalid data, expected int, got float64" because sigs.k8s.io/yaml decoded
+// JSON numbers via stdlib encoding/json (float64 by default for any).
+// The validator now decodes via apimachinery's util/json, which preserves
+// the int distinction the apiserver CEL evaluator requires.
+func TestValidateBytes_CELRuleOnIntegerField(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchemaWithIntCEL(t, dir)
+	v := newLocalValidator(t, dir, false)
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+  namespace: default
+spec:
+  port: 80
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusValid), "errors: %+v", results[0].Errors)
+	g.Expect(results[0].Errors).To(BeEmpty())
+}
+
+// Companion test: the same rule must still fire when the manifest violates
+// it. Guards against a regression where decode-side coercion accidentally
+// makes every integer compare unevaluable.
+func TestValidateBytes_CELRuleOnIntegerField_Violation(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchemaWithIntCEL(t, dir)
+	v := newLocalValidator(t, dir, false)
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec:
+  port: 0
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Reason).To(Equal(ReasonCELViolation))
+	g.Expect(results[0].Errors).ToNot(BeEmpty())
+	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("port must be positive"))
+}
+
 func TestValidateBytes_InvalidFieldType(t *testing.T) {
 	g := NewWithT(t)
 	dir := t.TempDir()


### PR DESCRIPTION
Parse YAML document into a` map[string]any` while preserving the int/float distinction that CEL evaluation requires.