### PR TITLE
Add GitHub Action for validating GitOps repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,37 @@ Rules:
 - Setting `--config` overrides `FLUX_SCHEMA_CONFIG`. When both are set, the flag wins and the env var is ignored.
 - Manifest paths stay positional. The config file configures how to validate; paths are given on the command line.
 
+#### GitHub Action
+
+For GitOps repositories, the [`fluxcd/flux-schema/actions/validate`](actions/validate)
+action runs validation across a directory tree on every pull request.
+It auto-detects kustomize overlays, builds them with `kubectl kustomize`, and
+validates the rendered manifests against the catalog (including CEL rules):
+
+```yaml
+name: validate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: azure/setup-kubectl@v4
+      - uses: fluxcd/flux-schema/actions/setup@main
+      - uses: fluxcd/flux-schema/actions/validate@main
+        with:
+          path: "."
+          schema-location: |
+            default
+            https://raw.githubusercontent.com/datreeio/CRDs-catalog/main
+```
+
+See the [action README](actions/validate/README.md) for the full input reference.
+
 ### Kubernetes CRD Extraction
 
 The `extract crd` command reads Kubernetes CustomResourceDefinition YAML
@@ -267,7 +298,7 @@ Fetch the upstream swagger for a Kubernetes release and generate schemas:
 flux-schema extract k8s --version 1.35.0 -d ./schemas
 ```
 
-Supply the swagger file from the cluster:
+You can also supply the swagger file directly, e.g. from a live cluster:
 
 ```shell
 kubectl get --raw /openapi/v2 | flux-schema extract k8s -d ./schemas
@@ -301,7 +332,7 @@ Fetch the swagger from `openshift/api` at a release branch:
 flux-schema extract openshift --ref release-4.20 -d ./schemas
 ```
 
-Supply the swagger file:
+You can also supply the swagger file directly, e.g. from a URL:
 
 ```shell
 curl -sL https://raw.githubusercontent.com/openshift/api/release-4.20/openapi/openapi.json \

--- a/actions/validate/README.md
+++ b/actions/validate/README.md
@@ -1,0 +1,48 @@
+# Validate GitOps Repository GitHub Action
+
+This GitHub Action validates Kubernetes YAML manifests and kustomize overlays
+against the Flux Schema catalog, including CEL rule evaluation. It is intended
+to run in CI before changes are merged to a branch synced by Flux.
+
+The action wraps [`validate.sh`](validate.sh), which
+auto-detects kustomize overlays and skips Helm chart and Terraform directories.
+
+## Prerequisites
+
+The action expects `kubectl` (for the built-in `kubectl kustomize`)
+and `flux-schema` to be on `PATH`. Compose with
+[`fluxcd/flux-schema/actions/setup`](../setup) and an installer like
+[`azure/setup-kubectl`](https://github.com/Azure/setup-kubectl):
+
+```yaml
+name: validate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: azure/setup-kubectl@v4
+      - uses: fluxcd/flux-schema/actions/setup@main
+      - uses: fluxcd/flux-schema/actions/validate@main
+        with:
+          path: ./clusters/production
+          exclude: |
+            charts
+            terraform
+          schema-location: |
+            default
+            https://raw.githubusercontent.com/datreeio/CRDs-catalog/main
+```
+
+## Action Inputs
+
+| Name              | Description                                                                                                                 | Default                 |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------|-------------------------|
+| `path`            | Root directory to validate (relative to the repository root).                                                               | `.`                     |
+| `exclude`         | Newline-separated list of directories to exclude from validation.                                                           | `""`                    |
+| `schema-location` | Newline-separated list of schema sources (URL or path). The literal `default` selects the built-in catalog; tried in order. | `""` (built-in catalog) |

--- a/actions/validate/action.yaml
+++ b/actions/validate/action.yaml
@@ -1,0 +1,47 @@
+name: Validate Kubernetes manifests
+description: Validate Flux custom resources and kustomize overlays against the Flux Schema catalog
+author: Stefan Prodan
+branding:
+  color: blue
+  icon: check-circle
+inputs:
+  path:
+    description: Root directory to validate (relative to the repository root)
+    required: false
+    default: "."
+  exclude:
+    description: Newline-separated list of directories to exclude from validation
+    required: false
+    default: ""
+  schema-location:
+    description: |
+      Newline-separated list of --schema-location values passed to flux-schema.
+      Use the literal value 'default' to select the built-in catalog. When
+      empty, the built-in catalog is used.
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Validate manifests
+      shell: bash
+      env:
+        ROOT_DIR: ${{ inputs.path }}
+        EXCLUDE_DIRS: ${{ inputs.exclude }}
+        SCHEMA_LOCATIONS: ${{ inputs.schema-location }}
+      run: |
+        set -euo pipefail
+        args=("-d" "$ROOT_DIR")
+        if [[ -n "$EXCLUDE_DIRS" ]]; then
+          while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            args+=("-e" "$line")
+          done <<< "$EXCLUDE_DIRS"
+        fi
+        if [[ -n "$SCHEMA_LOCATIONS" ]]; then
+          while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            args+=("-s" "$line")
+          done <<< "$SCHEMA_LOCATIONS"
+        fi
+        "${GITHUB_ACTION_PATH}/validate.sh" "${args[@]}"

--- a/actions/validate/validate.sh
+++ b/actions/validate/validate.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Flux authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script validates Kubernetes manifests using the Flux Schema CLI.
+# It builds kustomize overlays and validating the output against the Flux schema catalog.
+# This script is meant to be run locally and in CI before the changes
+# are merged on the main branch that's synced by Flux.
+
+# Prerequisites
+# - kubectl >= 1.36
+# - flux-schema >= 0.1
+
+# Usage example:
+#   validate.sh \
+#     -d ./manifests \
+#     -s default \
+#     -s ./my-schemas \
+#     -s https://raw.githubusercontent.com/datreeio/CRDs-catalog/main
+
+set -o errexit
+set -o pipefail
+
+# mirror kustomize-controller build options
+kustomize_flags=("--load-restrictor=LoadRestrictionsNone")
+kustomize_config="kustomization.yaml"
+
+# Strip SOPS-encrypted fields before validation (Flux removes these at apply
+# time) and skip documents whose schema is not in the catalog.
+flux_schema_flags=("--skip-json-path=/sops" "--skip-missing-schemas" "--verbose")
+
+# root directory to validate
+root_dir="."
+
+# directories to exclude from validation
+exclude_dirs=()
+
+# extra --schema-location values to pass through to flux-schema (repeatable)
+schema_locations=()
+
+# directories auto-detected as non-Kubernetes (terraform, helm charts)
+declare -a auto_skip_dirs=()
+
+# directories that are kustomize overlays
+declare -a kustomize_dirs=()
+
+usage() {
+  echo "Usage: $0 [-d <dir>] [-e <dir>]... [-s <location>]... [-h]"
+  echo ""
+  echo "Validate Flux custom resources and kustomize overlays using flux-schema."
+  echo ""
+  echo "Options:"
+  echo "  -d, --dir <dir>                  Root directory to validate (default: current directory)"
+  echo "  -e, --exclude <dir>              Directory to exclude from validation (can be repeated)"
+  echo "  -s, --schema-location <location> Schema URL or file path passed to flux-schema; 'default'"
+  echo "                                   selects the built-in catalog (can be repeated; tried in order)"
+  echo "  -h, --help                       Show this help message"
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -d|--dir)
+        if [[ -z "${2:-}" ]]; then
+          echo "ERROR - --dir requires a directory argument" >&2
+          exit 1
+        fi
+        root_dir="${2%/}"
+        shift 2
+        ;;
+      -e|--exclude)
+        if [[ -z "${2:-}" ]]; then
+          echo "ERROR - --exclude requires a directory argument" >&2
+          exit 1
+        fi
+        exclude_dirs+=("./${2#./}")
+        shift 2
+        ;;
+      -s|--schema-location)
+        if [[ -z "${2:-}" ]]; then
+          echo "ERROR - --schema-location requires a URL or file path argument" >&2
+          exit 1
+        fi
+        schema_locations+=("--schema-location=$2")
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "ERROR - Unknown argument: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+  done
+}
+
+check_prerequisites() {
+  local missing=0
+  for cmd in kubectl flux-schema; do
+    if ! command -v "$cmd" &> /dev/null; then
+      echo "ERROR - $cmd is not installed" >&2
+      missing=1
+    fi
+  done
+  if [[ $missing -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+# Normalize a path by stripping leading "./" for consistent comparisons
+normalize_path() {
+  local p="${1#./}"
+  echo "${p%/}"
+}
+
+# Check if a path is under a user-excluded, auto-skipped, or kustomize directory
+is_excluded_dir() {
+  local path
+  path="$(normalize_path "$1")"
+  for dir in "${exclude_dirs[@]}"; do
+    local d
+    d="$(normalize_path "$dir")"
+    if [[ "$path" == "$d"/* || "$path" == "$d" ]]; then
+      return 0
+    fi
+  done
+  for dir in "${auto_skip_dirs[@]}"; do
+    local d
+    d="$(normalize_path "$dir")"
+    if [[ "$path" == "$d"/* || "$path" == "$d" ]]; then
+      return 0
+    fi
+  done
+  for dir in "${kustomize_dirs[@]}"; do
+    local d
+    d="$(normalize_path "$dir")"
+    if [[ "$path" == "$d"/* || "$path" == "$d" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Check if a path is under a user-excluded or auto-skipped directory (but not kustomize dirs)
+is_non_kustomize_excluded_dir() {
+  local path
+  path="$(normalize_path "$1")"
+  for dir in "${exclude_dirs[@]}" "${auto_skip_dirs[@]}"; do
+    local d
+    d="$(normalize_path "$dir")"
+    if [[ "$path" == "$d"/* || "$path" == "$d" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Detect directories containing Terraform files, Helm charts, or kustomize overlays
+detect_excluded_dirs() {
+  while IFS= read -r -d $'\0' file; do
+    auto_skip_dirs+=("$(dirname "$file")")
+  done < <(find "$root_dir" -path '*/.*' -prune -o -type f \( -name '*.tf' -o -name 'Chart.yaml' \) -print0)
+
+  while IFS= read -r -d $'\0' file; do
+    kustomize_dirs+=("$(dirname "$file")")
+  done < <(find "$root_dir" -path '*/.*' -prune -o -type f -name "$kustomize_config" -print0)
+}
+
+validate_kubernetes_manifests() {
+  echo "INFO - Validating Kubernetes manifests"
+  local files=()
+  while IFS= read -r -d $'\0' file; do
+    dir="$(dirname "$file")"
+    if is_excluded_dir "$dir"; then
+      continue
+    fi
+    files+=("$file")
+  done < <(find "$root_dir" -path '*/.*' -prune -o -type f -name '*.yaml' -print0)
+  if [[ ${#files[@]} -gt 0 ]]; then
+    flux-schema validate "${flux_schema_flags[@]}" "${schema_locations[@]}" "${files[@]}"
+  fi
+}
+
+validate_kustomize_overlays() {
+  while IFS= read -r -d $'\0' file; do
+    dir="$(dirname "$file")"
+    if is_non_kustomize_excluded_dir "$dir"; then
+      continue
+    fi
+    echo "INFO - Validating kustomize overlay ${file/%$kustomize_config}"
+    kubectl kustomize "${file/%$kustomize_config}" "${kustomize_flags[@]}" | \
+      flux-schema validate "${flux_schema_flags[@]}" "${schema_locations[@]}"
+    if [[ ${PIPESTATUS[0]} != 0 || ${PIPESTATUS[1]} != 0 ]]; then
+      exit 1
+    fi
+  done < <(find "$root_dir" -path '*/.*' -prune -o -type f -name "$kustomize_config" -print0)
+}
+
+# Main
+parse_args "$@"
+check_prerequisites
+detect_excluded_dirs
+validate_kubernetes_manifests
+validate_kustomize_overlays
+echo "INFO - All validations passed"

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -1,6 +1,7 @@
 # Flux Schema Catalog
 
-This is the catalog of JSON Schemas used by the `flux schema validation` tool.
+This is the catalog of JSON Schemas used by the `flux schema validation` tool
+and the GitHub Action [fluxcd/flux-schema/actions/validate](../actions/validate).
 
 <!-- versions:start -->
 | Source | Version |
@@ -26,6 +27,28 @@ Extracted from the CRDs shipped by the latest stable Flux distribution, Flagger 
 - `flagger.app` — `Canary`, `MetricTemplate`, `AlertProvider`
 - `fluxcd.controlplane.io` — `FluxInstance`, `FluxReport`, `ResourceSet`, `ResourceSetInputProvider`
 
+## Gateway API
+
+Extracted from the CRDs shipped by the latest stable release of the Kubernetes Gateway API.
+
+- `gateway.networking.k8s.io` — `Gateway`, `GatewayClass`, `GRPCRoute`, `HTTPRoute`, etc.
+
+If you need schemas for the Gateway API [experimental](https://gateway-api.sigs.k8s.io/concepts/versioning/)
+channel, you can generate them with:
+
+```shell
+kubectl kustomize https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=main | \
+  flux-schema extract crd -d ./gwapi-experimental
+```
+
+And use them with `--schema-location`, before the `default` catalog, when validating:
+
+```shell
+flux-schema validate ./manifests \
+  --schema-location ./gwapi-experimental \
+  --schema-location default
+```
+
 ## Kubernetes APIs
 
 Extracted from the OpenAPI v2 swagger of the latest stable version of Kubernetes.
@@ -41,30 +64,6 @@ Extracted from the OpenAPI v2 swagger of the latest stable version of Kubernetes
 - `networking.k8s.io`, `node.k8s.io`
 - `rbac.authorization.k8s.io`, `resource.k8s.io`
 - `scheduling.k8s.io`, `storage.k8s.io`, `storagemigration.k8s.io`
-
-## Gateway API
-
-Extracted from the CRDs shipped by the latest stable release of the Kubernetes Gateway API.
-
-- `gateway.networking.k8s.io` — `Gateway`, `GatewayClass`, `GRPCRoute`, `HTTPRoute`, etc.
-
-If you need schemas for the Gateway API [experimental](https://gateway-api.sigs.k8s.io/concepts/versioning/)
-channel, you can generate them with:
-
-```shell
-kubectl kustomize https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=main | \
-    flux-schema extract crd /dev/stdin \
-    -d ./gwapi-experimental \
-    -f '{{ .Group }}/{{ .Kind }}_{{ .Version }}.json'
-```
-
-And use them with `--schema-location`, before the `default` catalog, when validating:
-
-```shell
-flux-schema validate ./manifests \
-  --schema-location './gwapi-experimental/{{.Group}}/{{.Kind}}_{{.Version}}.json' \
-  --schema-location default
-```
 
 ## OpenShift APIs
 


### PR DESCRIPTION

For GitOps repositories, the `fluxcd/flux-schema/actions/validate` action runs validation across a directory tree on every pull request. It auto-detects kustomize overlays, builds them with `kubectl kustomize`, and validates the rendered manifests against the catalog (including CEL rules):

Example usage:

```yaml
name: validate

on:
  pull_request:
    branches: [main]

jobs:
  validate:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v6
      - uses: azure/setup-kubectl@v4
      - uses: fluxcd/flux-schema/actions/setup@main
      - uses: fluxcd/flux-schema/actions/validate@main
        with:
          path: "."
          schema-location: |
            default
            https://raw.githubusercontent.com/datreeio/CRDs-catalog/main
```
