### PR TITLE
Publish container image to `ghcr.io/fluxcd/flux-schema`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,3 +43,54 @@ jobs:
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-checksums: '${{ github.workspace }}/dist/${{ github.event.repository.name }}_${{ steps.ver.outputs.SEMVER }}_checksums.txt'
+
+  cli-release-docker:
+    needs: [cli-release]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for pushing and signing container images.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate image meta
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ github.ref_name }}
+            type=raw,value=latest
+      - name: Push image
+        id: build-push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          sbom: true
+          provenance: true
+          push: true
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: "VERSION=${{ github.ref_name }}"
+      - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+      - name: Sign image
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          cosign sign --yes \
+          ghcr.io/${{ github.repository }}@${{ steps.build-push.outputs.digest }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,12 @@ jobs:
       - name: Run smoke test
         run: |
           flux install --export | ./bin/flux-schema validate -v --schema-location ./catalog/latest
+      - name: Build Docker image
+        run: make docker-build
+      - name: Run Docker smoke test
+        run: |
+          flux install --export | docker run --rm -i ghcr.io/fluxcd/flux-schema:latest-dev \
+            validate -v --schema-location /catalog/latest
       - name: Check if working tree is dirty
         run: |
           if [[ $(git diff --stat) != '' ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+ARG GO_VERSION=1.26
+ARG XX_VERSION=1.9.0
+
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
+
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION
+
+# Copy the build utilities.
+COPY --from=xx / /
+
+WORKDIR /workspace
+
+# copy modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# cache modules
+RUN go mod download
+
+# copy source code
+COPY cmd/flux-schema/ cmd/flux-schema/
+COPY internal/ internal/
+
+# build
+ENV CGO_ENABLED=0
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -ldflags="-s -w -X main.VERSION=${VERSION}" \
+    -a -o /usr/local/bin/flux-schema ./cmd/flux-schema/
+
+FROM alpine:3.23
+
+RUN apk --no-cache add ca-certificates \
+  && update-ca-certificates
+
+COPY catalog/ /catalog/
+COPY --from=builder /usr/local/bin/flux-schema /usr/local/bin/
+
+USER 65534:65534
+
+ENTRYPOINT [ "flux-schema" ]

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 
 # Makefile for building and testing the flux-schema CLI.
 
+DOCKER_IMAGE ?= ghcr.io/fluxcd/flux-schema:latest-dev
 VERSION_DEV ?=0.0.0-$(shell git rev-parse --abbrev-ref HEAD)-$(shell git rev-parse --short HEAD)-$(shell date +%s)
 GO_TEST_ARGS ?=
 GO_RUN_ARGS ?=
@@ -48,6 +49,10 @@ lint: golangci-lint ## Run golangci linters.
 .PHONY: build
 build: tidy fmt vet ## Build CLI binary.
 	CGO_ENABLED=0 go build -ldflags="-s -w -X main.VERSION=$(VERSION_DEV)" -o ./bin/flux-schema ./cmd/flux-schema/
+
+.PHONY: docker-build
+docker-build: ## Build docker image with the CLI.
+	docker build -t $(DOCKER_IMAGE) --build-arg VERSION=$(VERSION_DEV) -f Dockerfile .
 
 .PHONY: install
 install: test lint build ## Test, lint, build and copy the binary to GOBIN.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,15 @@ flux-schema validate ./manifests \
   --schema-location default
 ```
 
-## GitHub Actions
+## Running in CI
+
+Running flux-schema in CI shifts validation left, so schema violations are
+caught in pull requests rather than on the cluster after Flux reconciles them.
+The CLI ships as GitHub Actions for repositories hosted on GitHub,
+and as a multi-arch (AMD64 and ARM64) container image for other CI
+systems and air-gapped environments.
+
+### GitHub Actions
 
 Two composite actions cover GitOps validation pipelines:
 
@@ -126,6 +134,21 @@ jobs:
       - name: Validate manifests
         uses: fluxcd/flux-schema/actions/validate@main
 ```
+
+### Docker
+
+The `ghcr.io/fluxcd/flux-schema` image bakes the built-in catalog into
+`/catalog/latest/`, so it can validate manifests in air-gapped environments:
+
+```shell
+docker run --rm \
+  -v "$PWD/manifests:/manifests:ro" \
+  ghcr.io/fluxcd/flux-schema:latest validate /manifests \
+  --schema-location /catalog/latest
+```
+
+See the [Docker section](docs/guides/manifests-validation.md#docker) of the
+validation guide for details on running the CLI in CI using the container image.
 
 ## Commands
 

--- a/docs/guides/manifests-validation.md
+++ b/docs/guides/manifests-validation.md
@@ -270,6 +270,38 @@ Rules:
 - Manifest paths stay positional. The config file configures how to validate;
   paths are given on the command line.
 
-## CI integration
+## Running in CI
 
-For GitHub Actions, see the [validate action](../../actions/validate/README.md) reference.
+### GitHub Actions
+
+See the [validate action](../../actions/validate/README.md) reference.
+
+### Docker
+
+The `ghcr.io/fluxcd/flux-schema` image bakes the [default catalog](../../catalog/README.md)
+into `/catalog/latest/`, so manifests can be validated offline without fetching schemas from GitHub.
+
+Mount the manifests directory and point `--schema-location` at the builtin catalog:
+
+```sh
+docker run --rm \
+  -v "$PWD/manifests:/manifests:ro" \
+  ghcr.io/fluxcd/flux-schema:latest validate /manifests \
+  --schema-location /catalog/latest
+```
+
+Or pipe rendered manifests into the container over stdin
+(note the `-i` flag to keep stdin open):
+
+```sh
+kustomize build ./manifests | docker run --rm -i \
+  ghcr.io/fluxcd/flux-schema:latest validate \
+  --schema-location /catalog/latest \
+  --skip-missing-schemas
+```
+
+Notes:
+
+- Use `--schema-location /catalog/latest` rather than `default` for air-gapped environments.
+- Pin the image to a release tag e.g. `ghcr.io/fluxcd/flux-schema:v0.3.0`.
+- Tu use your own schema catalog, repeat `--schema-location` with another mounted directory.


### PR DESCRIPTION
Push multi-arch container image to `ghcr.io/fluxcd/flux-schema` at release time to allow running validation in CI using Docker.

The `ghcr.io/fluxcd/flux-schema` image bakes the [default catalog](https://github.com/fluxcd/flux-schema/tree/main/catalog) into `/catalog/latest/`, so manifests can be validated offline without fetching schemas from GitHub.

Mount the manifests directory and point `--schema-location` at the builtin catalog:

```sh
docker run --rm \
  -v "$PWD/manifests:/manifests:ro" \
  ghcr.io/fluxcd/flux-schema:latest validate /manifests \
  --schema-location /catalog/latest
```

Or pipe rendered manifests into the container over stdin (note the `-i` flag to keep stdin open):

```sh
kustomize build ./manifests | docker run --rm -i \
  ghcr.io/fluxcd/flux-schema:latest validate \
  --schema-location /catalog/latest \
  --skip-missing-schemas
```

Notes:

- Use `--schema-location /catalog/latest` rather than `default` for air-gapped environments.
- Pin the image to a release tag e.g. `ghcr.io/fluxcd/flux-schema:v0.3.0`.
- Tu use your own schema catalog, repeat `--schema-location` with another mounted directory.