### PR TITLE
Relax RBAC name validation to match the API Server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	k8s.io/api v0.36.0
 	k8s.io/apiextensions-apiserver v0.36.0
 	k8s.io/apimachinery v0.36.0
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a
@@ -58,7 +59,6 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.36.0 // indirect
 	k8s.io/apiserver v0.36.0 // indirect
 	k8s.io/component-base v0.36.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/internal/validator/metadata.go
+++ b/internal/validator/metadata.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/validate/content"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 )
@@ -32,11 +33,11 @@ func shortenRule(s string) string {
 // that passes JSON Schema validation can still be rejected by the API
 // server at reconcile time.
 //
-// Name validation deliberately uses NameIsDNSSubdomain (the most
-// permissive of the kube name validators) because we don't know each
+// Name validation defaults to NameIsDNSSubdomain since we don't know each
 // kind's nameFn here; tighter rules like NameIsDNSLabel (Service / Pod /
 // Namespace / ConfigMap / Secret) would produce false positives across
-// kinds.
+// kinds. RBAC kinds (Role / ClusterRole / RoleBinding / ClusterRoleBinding)
+// are special-cased to use path-segment validation which allows '_' and ':'.
 func validateMetadata(doc map[string]any) []ValidationError {
 	metadata, _ := doc["metadata"].(map[string]any)
 	if metadata == nil {
@@ -44,13 +45,20 @@ func validateMetadata(doc map[string]any) []ValidationError {
 	}
 	var out []ValidationError
 
+	nameFn := apivalidation.NameIsDNSSubdomain
+	prefixFn := apivalidation.NameIsDNSSubdomain
+	if isRBACKind(doc) {
+		nameFn = pathSegmentName
+		prefixFn = pathSegmentPrefix
+	}
+
 	if name, ok := metadata["name"].(string); ok && name != "" {
-		for _, msg := range apivalidation.NameIsDNSSubdomain(name, false) {
+		for _, msg := range nameFn(name, false) {
 			out = append(out, ValidationError{Path: "/metadata/name", Msg: shortenRule(msg)})
 		}
 	}
 	if gen, ok := metadata["generateName"].(string); ok && gen != "" {
-		for _, msg := range apivalidation.NameIsDNSSubdomain(gen, true) {
+		for _, msg := range prefixFn(gen, true) {
 			out = append(out, ValidationError{Path: "/metadata/generateName", Msg: shortenRule(msg)})
 		}
 	}
@@ -117,6 +125,39 @@ func validateAnnotations(annotations map[string]any) []ValidationError {
 		})
 	}
 	return out
+}
+
+// rbacKinds enumerates the kinds the kube-apiserver validates with
+// path-segment rules instead of DNS-1123 subdomain.
+//
+// See https://github.com/kubernetes/kubernetes/blob/v1.36.0/pkg/apis/rbac/validation/validation.go#L32-L33
+var rbacKinds = map[string]struct{}{
+	"Role":               {},
+	"ClusterRole":        {},
+	"RoleBinding":        {},
+	"ClusterRoleBinding": {},
+}
+
+func isRBACKind(doc map[string]any) bool {
+	kind, _ := doc["kind"].(string)
+	if _, ok := rbacKinds[kind]; !ok {
+		return false
+	}
+	apiVersion, _ := doc["apiVersion"].(string)
+	group, _, ok := strings.Cut(apiVersion, "/")
+	if !ok {
+		// core group has no slash; RBAC kinds don't live there.
+		return false
+	}
+	return group == rbacv1.GroupName
+}
+
+func pathSegmentName(name string, _ bool) []string {
+	return content.IsPathSegmentName(name)
+}
+
+func pathSegmentPrefix(name string, _ bool) []string {
+	return content.IsPathSegmentPrefix(name)
 }
 
 func jsonPointer(parts ...string) string {

--- a/internal/validator/metadata_test.go
+++ b/internal/validator/metadata_test.go
@@ -51,6 +51,42 @@ func TestValidateMetadata_BadGenerateName(t *testing.T) {
 	g.Expect(errs[0].Path).To(Equal("/metadata/generateName"))
 }
 
+func TestValidateMetadata_RBACAllowsUnderscoreInName(t *testing.T) {
+	g := NewWithT(t)
+	for _, kind := range []string{"Role", "ClusterRole", "RoleBinding", "ClusterRoleBinding"} {
+		errs := validateMetadata(map[string]any{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       kind,
+			"metadata":   map[string]any{"name": "ops_clusterRole2"},
+		})
+		g.Expect(errs).To(BeEmpty(), "kind %s should accept underscored name", kind)
+	}
+}
+
+func TestValidateMetadata_RBACRejectsPathSegmentViolation(t *testing.T) {
+	g := NewWithT(t)
+	errs := validateMetadata(map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata":   map[string]any{"name": "bad/name"},
+	})
+	g.Expect(errs).ToNot(BeEmpty())
+	g.Expect(errs[0].Path).To(Equal("/metadata/name"))
+}
+
+func TestValidateMetadata_NonRBACKindWithRoleNameStillDNSValidated(t *testing.T) {
+	g := NewWithT(t)
+	// A CRD that happens to be named "Role" in a different group must still
+	// get DNS-subdomain validation.
+	errs := validateMetadata(map[string]any{
+		"apiVersion": "example.com/v1",
+		"kind":       "Role",
+		"metadata":   map[string]any{"name": "ops_clusterRole2"},
+	})
+	g.Expect(errs).ToNot(BeEmpty())
+	g.Expect(errs[0].Path).To(Equal("/metadata/name"))
+}
+
 func TestValidateMetadata_BadNamespace(t *testing.T) {
 	g := NewWithT(t)
 	errs := validateMetadata(map[string]any{


### PR DESCRIPTION
Part of: https://github.com/fluxcd/kustomize-controller/issues/491