### PR TITLE
Sort schema enum values for deterministic output

### DIFF
--- a/catalog/latest/schema.plugin.fluxcd.io/report_v1beta1.json
+++ b/catalog/latest/schema.plugin.fluxcd.io/report_v1beta1.json
@@ -89,9 +89,9 @@
               "status": {
                 "description": "Status is the validation outcome for the document.",
                 "enum": [
-                  "valid",
                   "invalid",
-                  "skipped"
+                  "skipped",
+                  "valid"
                 ],
                 "type": "string"
               },

--- a/docs/report-v1beta1.json
+++ b/docs/report-v1beta1.json
@@ -89,9 +89,9 @@
               "status": {
                 "description": "Status is the validation outcome for the document.",
                 "enum": [
-                  "valid",
                   "invalid",
-                  "skipped"
+                  "skipped",
+                  "valid"
                 ],
                 "type": "string"
               },

--- a/tools/schema-gen/main.go
+++ b/tools/schema-gen/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -378,6 +379,7 @@ func transformNode(v any) any {
 		for k, child := range x {
 			x[k] = transformNode(child)
 		}
+		sortEnum(x)
 		if x["type"] == "object" {
 			if _, ok := x["properties"]; ok {
 				x["additionalProperties"] = false
@@ -406,6 +408,30 @@ func transformNode(v any) any {
 		return x
 	default:
 		return v
+	}
+}
+
+// sortEnum stabilizes the order of a schema node's enum values. controller-gen
+// emits enum members in a non-deterministic order (it flips between marker and
+// alphabetical order across runs), which makes the generated schema churn. We
+// only reorder when every member is a string, which holds for the Kubernetes
+// enums in this API; mixed or non-string enums are left untouched.
+func sortEnum(node map[string]any) {
+	values, ok := node["enum"].([]any)
+	if !ok {
+		return
+	}
+	strs := make([]string, 0, len(values))
+	for _, v := range values {
+		s, ok := v.(string)
+		if !ok {
+			return
+		}
+		strs = append(strs, s)
+	}
+	sort.Strings(strs)
+	for i, s := range strs {
+		values[i] = s
 	}
 }
 

--- a/tools/schema-gen/main_test.go
+++ b/tools/schema-gen/main_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestTransformNode_SortsEnum(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []any
+		want  []any
+	}{
+		{
+			name:  "marker order is sorted",
+			input: []any{"kubernetes-manifests", "kustomize-overlay", "helm-chart", "terraform-module"},
+			want:  []any{"helm-chart", "kubernetes-manifests", "kustomize-overlay", "terraform-module"},
+		},
+		{
+			name:  "already sorted is stable",
+			input: []any{"invalid", "skipped", "valid"},
+			want:  []any{"invalid", "skipped", "valid"},
+		},
+		{
+			name:  "non-string enum is left untouched",
+			input: []any{3, 1, 2},
+			want:  []any{3, 1, 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			node := map[string]any{
+				"type": "string",
+				"enum": tt.input,
+			}
+			out, ok := transformNode(node).(map[string]any)
+			g.Expect(ok).To(BeTrue())
+			g.Expect(out["enum"]).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestTransformNode_SortsNestedEnum(t *testing.T) {
+	g := NewWithT(t)
+	node := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"status": map[string]any{
+				"type": "string",
+				"enum": []any{"valid", "invalid", "skipped"},
+			},
+		},
+	}
+	out := transformNode(node).(map[string]any)
+	status := out["properties"].(map[string]any)["status"].(map[string]any)
+	g.Expect(status["enum"]).To(Equal([]any{"invalid", "skipped", "valid"}))
+}


### PR DESCRIPTION
controller-gen emits enum members in a non-deterministic order, flipping between marker and alphabetical order across runs. The schema-gen tool preserved that order verbatim, so regenerating the JSON Schemas produced spurious diffs and intermittently failed the CI dirty-tree check.

Sort string enum values in transformNode so generation is stable regardless of controller-gen's output order, and regenerate the report schema to its sorted form.


Assisted-by: Claude/claude-opus-4-8