### PR TITLE
fix: handle subschemas  in `oneOf/anyOf/allOf/not`

### DIFF
--- a/internal/extractor/transformers.go
+++ b/internal/extractor/transformers.go
@@ -346,6 +346,16 @@ func markNullable(prop map[string]any) {
 // server accepts arbitrary keys there (status subresources, free-form map
 // fields like HelmRelease.spec.values); forcing additionalProperties:false
 // would reject valid documents.
+//
+// The oneOf/anyOf/allOf/not branch subschemas are NOT closed: they are partial
+// value-validation constraints combined with the structural (parent) schema,
+// not standalone objects. A branch that lists a subset of properties — e.g.
+// Cilium's spec.oneOf anchors a requirement with {properties:{endpointSelector:
+// {}}, required:[endpointSelector]} — would, with additionalProperties:false,
+// reject every sibling property the parent legitimately defines, making the
+// combinator unsatisfiable for real resources. Kubernetes derives
+// additionalProperties from the structural schema only, never from these
+// value-validation keywords, so we mirror that and leave the branches open.
 func closeAdditionalProperties(node any) {
 	switch n := node.(type) {
 	case map[string]any:
@@ -357,7 +367,10 @@ func closeAdditionalProperties(node any) {
 				n["additionalProperties"] = false
 			}
 		}
-		for _, v := range n {
+		for k, v := range n {
+			if isCombinatorKey(k) {
+				continue
+			}
 			closeAdditionalProperties(v)
 		}
 	case []any:
@@ -367,11 +380,24 @@ func closeAdditionalProperties(node any) {
 	}
 }
 
+// isCombinatorKey reports whether k is a JSON Schema value-validation combinator
+// whose branch subschemas must not have additionalProperties:false injected.
+func isCombinatorKey(k string) bool {
+	switch k {
+	case "oneOf", "anyOf", "allOf", "not":
+		return true
+	default:
+		return false
+	}
+}
+
 // closeAdditionalPropertiesChildren is closeAdditionalProperties but leaves
 // the root object's own additionalProperties untouched. Used by the CRD
 // pipeline, where the openAPIV3Schema describes a custom resource whose root
 // often omits the apiVersion/kind/metadata wrapper added by the API server;
-// closing the root would reject that wrapper.
+// closing the root would reject that wrapper. Combinators at the root are
+// skipped for the same reason as everywhere else: their branches are partial
+// value-validation constraints, not standalone objects.
 func closeAdditionalPropertiesChildren(node any) {
 	m, ok := node.(map[string]any)
 	if !ok {
@@ -380,7 +406,10 @@ func closeAdditionalPropertiesChildren(node any) {
 	if preserve, _ := m["x-kubernetes-preserve-unknown-fields"].(bool); preserve {
 		return
 	}
-	for _, v := range m {
+	for k, v := range m {
+		if isCombinatorKey(k) {
+			continue
+		}
 		closeAdditionalProperties(v)
 	}
 }

--- a/internal/extractor/transformers_test.go
+++ b/internal/extractor/transformers_test.go
@@ -64,6 +64,98 @@ func TestCloseAdditionalProperties_ClosesRoot(t *testing.T) {
 	g.Expect(schema["additionalProperties"]).To(BeFalse(), "root must be closed")
 }
 
+// A structural object that also carries oneOf/anyOf branches (Cilium's
+// CiliumNetworkPolicy spec pattern): the object itself is closed, but the
+// branch subschemas — which list only a subset of properties to anchor a
+// requirement — must stay open, else a real resource carrying sibling
+// properties matches no branch and is wrongly rejected.
+func TestCloseAdditionalProperties_LeavesCombinatorBranchesOpen(t *testing.T) {
+	g := NewWithT(t)
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"endpointSelector": map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"matchLabels": map[string]any{"type": "object"}},
+			},
+			"ingress":      map[string]any{"type": "array"},
+			"nodeSelector": map[string]any{"type": "object"},
+		},
+		"oneOf": []any{
+			map[string]any{
+				"properties": map[string]any{"endpointSelector": map[string]any{}},
+				"required":   []any{"endpointSelector"},
+			},
+			map[string]any{
+				"properties": map[string]any{"nodeSelector": map[string]any{}},
+				"required":   []any{"nodeSelector"},
+			},
+		},
+		"anyOf": []any{
+			map[string]any{"required": []any{"ingress"}},
+		},
+		"allOf": []any{
+			map[string]any{
+				"properties": map[string]any{"ingress": map[string]any{}},
+			},
+		},
+		"not": map[string]any{
+			"properties": map[string]any{"ingress": map[string]any{}},
+			"required":   []any{"ingress", "nodeSelector"},
+		},
+	}
+	closeAdditionalProperties(schema)
+
+	g.Expect(schema["additionalProperties"]).To(BeFalse(), "structural object must be closed")
+
+	for _, key := range []string{"oneOf", "anyOf", "allOf"} {
+		for i, branch := range schema[key].([]any) {
+			_, hasAP := branch.(map[string]any)["additionalProperties"]
+			g.Expect(hasAP).To(BeFalse(), "%s branch %d must stay open", key, i)
+		}
+	}
+	_, notHasAP := schema["not"].(map[string]any)["additionalProperties"]
+	g.Expect(notHasAP).To(BeFalse(), "not subschema must stay open")
+	// The structural properties themselves are still closed.
+	sel := schema["properties"].(map[string]any)["endpointSelector"].(map[string]any)
+	g.Expect(sel["additionalProperties"]).To(BeFalse(), "nested structural object must be closed")
+}
+
+// Combinators at the openAPIV3Schema root (e.g. oneOf requiring spec or
+// specs) must stay open on the CRD pipeline's root pass too, not only when
+// reached through recursion.
+func TestCloseAdditionalPropertiesChildren_LeavesRootCombinatorBranchesOpen(t *testing.T) {
+	g := NewWithT(t)
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"spec": map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"name": map[string]any{"type": "string"}},
+			},
+			"specs": map[string]any{"type": "array"},
+		},
+		"oneOf": []any{
+			map[string]any{
+				"properties": map[string]any{"spec": map[string]any{}},
+				"required":   []any{"spec"},
+			},
+			map[string]any{
+				"properties": map[string]any{"specs": map[string]any{}},
+				"required":   []any{"specs"},
+			},
+		},
+	}
+	closeAdditionalPropertiesChildren(schema)
+
+	for i, branch := range schema["oneOf"].([]any) {
+		_, hasAP := branch.(map[string]any)["additionalProperties"]
+		g.Expect(hasAP).To(BeFalse(), "root oneOf branch %d must stay open", i)
+	}
+	spec := schema["properties"].(map[string]any)["spec"].(map[string]any)
+	g.Expect(spec["additionalProperties"]).To(BeFalse(), "structural child must be closed")
+}
+
 func TestReplaceIntOrString_LegacyFormat(t *testing.T) {
 	g := NewWithT(t)
 	input := map[string]any{


### PR DESCRIPTION
closeAdditionalProperties set additionalProperties:false on every object carrying a properties key, including the subschemas under oneOf/anyOf/allOf/ not. Those branches are partial value-validation constraints combined with the structural (parent) schema, not standalone objects: a branch listing a subset of properties to anchor a requirement — e.g. a CiliumNetworkPolicy spec.oneOf branch {properties:{endpointSelector:{}}, required:[endpointSelector]} — would then forbid every sibling property the parent defines, making the combinator unsatisfiable and rejecting valid resources.

Kubernetes derives additionalProperties from the structural schema only, never from these keywords, so skip oneOf/anyOf/allOf/not when closing.