### PR TITLE
fix: `int-or-string/oneOf` for CEL structural schema

### DIFF
--- a/internal/extractor/crd.go
+++ b/internal/extractor/crd.go
@@ -59,6 +59,11 @@ func parseDocument(raw []byte) ([]map[string]any, error) {
 		return nil, fmt.Errorf("JSON decode error: %w", err)
 	}
 
+	// Comment-only documents parse to null; treat them as empty.
+	if doc == nil {
+		return nil, nil
+	}
+
 	m, ok := doc.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("document is not a YAML mapping")

--- a/internal/extractor/crd_test.go
+++ b/internal/extractor/crd_test.go
@@ -359,6 +359,15 @@ spec:
 	g.Expect(crds[1].DeprecationWarning).To(BeEmpty())
 }
 
+func TestExtractCRDs_CommentOnlyDocumentIsSkipped(t *testing.T) {
+	g := NewWithT(t)
+	data := "# Copyright The Flux Authors\n# SPDX-License-Identifier: Apache-2.0\n---\n" + bareCRD
+	crds, errs := ExtractCRDs([]byte(data))
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(crds).To(HaveLen(1))
+	g.Expect(crds[0].Kind).To(Equal("Widget"))
+}
+
 func TestExtractCRDs_NonMappingDocumentIsError(t *testing.T) {
 	g := NewWithT(t)
 	_, errs := ExtractCRDs([]byte("- just\n- a\n- list\n"))

--- a/internal/validator/cel.go
+++ b/internal/validator/cel.go
@@ -19,6 +19,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
+const (
+	jsonSchemaTypeInteger = "integer"
+	jsonSchemaTypeString  = "string"
+)
+
 // celValidator wraps the kube-apiserver's x-kubernetes-validations evaluator
 // for a single resolved schema. Construction can fail (bad JSON shape,
 // unsupported structural features); evaluation cannot fail to start, but rule
@@ -51,10 +56,15 @@ func newCELValidator(raw map[string]any) (*celValidator, error) {
 		return nil, nil
 	}
 
+	// The JSON Schema path still needs the extracted oneOf form. Build the
+	// structural/CEL schema from a private copy that restores int-or-string to
+	// the representation Kubernetes' CEL type-checker understands.
+	celRaw := rewriteIntOrStringOneOfForCEL(raw).(map[string]any)
+
 	// The internal apiextensions.JSONSchemaProps has no JSON tags, so the
 	// versioned type is the only viable unmarshal target on the way to
 	// NewStructural.
-	body, err := json.Marshal(raw)
+	body, err := json.Marshal(celRaw)
 	if err != nil {
 		return nil, fmt.Errorf("marshal schema: %w", err)
 	}
@@ -174,6 +184,63 @@ func hasJSONNull(node any) bool {
 		}
 	}
 	return false
+}
+
+// rewriteIntOrStringOneOfForCEL deep-copies node while rewriting the exact
+// int-or-string oneOf shape emitted by the extractor back to the Kubernetes
+// structural-schema extension required by CEL. Parent metadata/default siblings
+// are preserved; oneOf branches with extra constraints are left untouched.
+func rewriteIntOrStringOneOfForCEL(node any) any {
+	switch n := node.(type) {
+	case map[string]any:
+		if isExtractedIntOrStringOneOf(n) {
+			out := make(map[string]any, len(n))
+			for k, v := range n {
+				if k == "oneOf" {
+					continue
+				}
+				out[k] = rewriteIntOrStringOneOfForCEL(v)
+			}
+			out["x-kubernetes-int-or-string"] = true
+			return out
+		}
+		out := make(map[string]any, len(n))
+		for k, v := range n {
+			out[k] = rewriteIntOrStringOneOfForCEL(v)
+		}
+		return out
+	case []any:
+		out := make([]any, len(n))
+		for i, v := range n {
+			out[i] = rewriteIntOrStringOneOfForCEL(v)
+		}
+		return out
+	default:
+		return n
+	}
+}
+
+func isExtractedIntOrStringOneOf(m map[string]any) bool {
+	if _, hasType := m["type"]; hasType {
+		return false
+	}
+	oneOf, ok := m["oneOf"].([]any)
+	if !ok || len(oneOf) != 2 {
+		return false
+	}
+	seen := map[string]bool{}
+	for _, branch := range oneOf {
+		bm, ok := branch.(map[string]any)
+		if !ok || len(bm) != 1 {
+			return false
+		}
+		t, ok := bm["type"].(string)
+		if !ok || (t != jsonSchemaTypeString && t != jsonSchemaTypeInteger) || seen[t] {
+			return false
+		}
+		seen[t] = true
+	}
+	return seen[jsonSchemaTypeString] && seen[jsonSchemaTypeInteger]
 }
 
 // hasCELRules walks the raw schema tree and returns true on the first

--- a/internal/validator/cel_test.go
+++ b/internal/validator/cel_test.go
@@ -44,6 +44,97 @@ func TestNewCELValidator_NoRulesReturnsNil(t *testing.T) {
 	g.Expect(v).To(BeNil())
 }
 
+func TestRewriteIntOrStringOneOfForCEL(t *testing.T) {
+	g := NewWithT(t)
+	raw := schemaFromJSON(t, `{
+		"type": "object",
+		"properties": {
+			"forward": {
+				"oneOf": [
+					{ "type": "string" },
+					{ "type": "integer" }
+				]
+			},
+			"reverse": {
+				"description": "resource quantity",
+				"oneOf": [
+					{ "type": "integer" },
+					{ "type": "string" }
+				]
+			},
+			"typed": {
+				"type": "string",
+				"oneOf": [
+					{ "type": "string" },
+					{ "type": "integer" }
+				]
+			},
+			"extraMember": {
+				"oneOf": [
+					{ "type": "string" },
+					{ "type": "integer" },
+					{ "type": "null" }
+				]
+			},
+			"otherType": {
+				"oneOf": [
+					{ "type": "string" },
+					{ "type": "number" }
+				]
+			},
+			"extraConstraint": {
+				"oneOf": [
+					{ "type": "string", "pattern": "^[0-9]+$" },
+					{ "type": "integer" }
+				]
+			},
+			"array": {
+				"type": "array",
+				"items": {
+					"oneOf": [
+						{ "type": "string" },
+						{ "type": "integer" }
+					]
+				}
+			},
+			"map": {
+				"type": "object",
+				"additionalProperties": {
+					"oneOf": [
+						{ "type": "integer" },
+						{ "type": "string" }
+					]
+				}
+			}
+		}
+	}`)
+
+	got := rewriteIntOrStringOneOfForCEL(raw).(map[string]any)
+	props := got["properties"].(map[string]any)
+	g.Expect(props["forward"]).To(Equal(map[string]any{
+		"x-kubernetes-int-or-string": true,
+	}))
+	g.Expect(props["reverse"]).To(Equal(map[string]any{
+		"description":                "resource quantity",
+		"x-kubernetes-int-or-string": true,
+	}))
+	g.Expect(props["array"].(map[string]any)["items"]).To(Equal(map[string]any{
+		"x-kubernetes-int-or-string": true,
+	}))
+	g.Expect(props["map"].(map[string]any)["additionalProperties"]).To(Equal(map[string]any{
+		"x-kubernetes-int-or-string": true,
+	}))
+	for _, name := range []string{"typed", "extraMember", "otherType", "extraConstraint"} {
+		prop := props[name].(map[string]any)
+		g.Expect(prop).To(HaveKey("oneOf"))
+		g.Expect(prop).ToNot(HaveKey("x-kubernetes-int-or-string"))
+	}
+
+	rawProps := raw["properties"].(map[string]any)
+	g.Expect(rawProps["forward"].(map[string]any)).To(HaveKey("oneOf"))
+	g.Expect(rawProps["forward"].(map[string]any)).ToNot(HaveKey("x-kubernetes-int-or-string"))
+}
+
 func TestNewCELValidator_RuleViolationProducesError(t *testing.T) {
 	g := NewWithT(t)
 	// Top-level rule: spec.foo must equal "ok".

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -313,6 +313,164 @@ spec:
 	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("sectionName must be specified"))
 }
 
+const clusterQueueIntOrStringCRD = `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterqueues.kueue.x-k8s.io
+spec:
+  group: kueue.x-k8s.io
+  scope: Cluster
+  names:
+    kind: ClusterQueue
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [apiVersion, kind, metadata, spec]
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              properties:
+                cohort:
+                  type: string
+                namespaceSelector:
+                  type: object
+                resourceGroups:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      coveredResources:
+                        type: array
+                        items:
+                          type: string
+                      flavors:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            resources:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  nominalQuota:
+                                    x-kubernetes-int-or-string: true
+                                  borrowingLimit:
+                                    x-kubernetes-int-or-string: true
+                                  lendingLimit:
+                                    x-kubernetes-int-or-string: true
+              x-kubernetes-validations:
+                - rule: "!has(self.cohort) && has(self.resourceGroups) ? self.resourceGroups.all(rg, rg.flavors.all(f, f.resources.all(r, !has(r.borrowingLimit)))) : true"
+                  message: "borrowingLimit must not be set when cohort is empty"
+`
+
+func writeExtractedClusterQueueSchema(t *testing.T, dir string, reverseOneOf bool) {
+	t.Helper()
+	schemas, errs := extractor.ExtractCRDs([]byte(clusterQueueIntOrStringCRD))
+	if len(errs) > 0 {
+		t.Fatalf("extract CRD: %v", errs)
+	}
+	if len(schemas) != 1 {
+		t.Fatalf("extract CRD: got %d schemas, want 1", len(schemas))
+	}
+	if reverseOneOf {
+		reverseIntOrStringOneOfMembers(schemas[0].JSON)
+	}
+	b, err := json.MarshalIndent(schemas[0].JSON, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	path := filepath.Join(dir, "clusterqueue-kueue-v1beta1.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+}
+
+func reverseIntOrStringOneOfMembers(node any) {
+	switch n := node.(type) {
+	case map[string]any:
+		if oneOf, ok := n["oneOf"].([]any); ok && isStringIntegerOneOf(oneOf) {
+			oneOf[0], oneOf[1] = oneOf[1], oneOf[0]
+		}
+		for _, v := range n {
+			reverseIntOrStringOneOfMembers(v)
+		}
+	case []any:
+		for _, v := range n {
+			reverseIntOrStringOneOfMembers(v)
+		}
+	}
+}
+
+func isStringIntegerOneOf(oneOf []any) bool {
+	if len(oneOf) != 2 {
+		return false
+	}
+	first, ok := oneOf[0].(map[string]any)
+	if !ok || len(first) != 1 {
+		return false
+	}
+	second, ok := oneOf[1].(map[string]any)
+	if !ok || len(second) != 1 {
+		return false
+	}
+	firstType, _ := first["type"].(string)
+	secondType, _ := second["type"].(string)
+	return firstType == "string" && secondType == "integer"
+}
+
+func TestValidateBytes_ExtractedCRDIntOrStringCEL(t *testing.T) {
+	cases := map[string]bool{
+		"string integer": false,
+		"integer string": true,
+	}
+	for name, reverseOneOf := range cases {
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+			dir := t.TempDir()
+			writeExtractedClusterQueueSchema(t, dir, reverseOneOf)
+			v := newLocalValidator(t, dir, false)
+
+			valid := []byte(`apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: cluster-queue
+spec:
+  namespaceSelector: {}
+  resourceGroups:
+    - coveredResources: ["cpu", "memory"]
+      flavors:
+        - name: default-flavor
+          resources:
+            - name: cpu
+              nominalQuota: 100
+            - name: memory
+              nominalQuota: 200Gi
+`)
+			results := v.ValidateBytes(context.Background(), "clusterqueue.yaml", valid)
+			g.Expect(results).To(HaveLen(1))
+			g.Expect(results[0].Status).To(Equal(StatusValid), "errors: %+v", results[0].Errors)
+			g.Expect(results[0].Errors).To(BeEmpty())
+		})
+	}
+}
+
 func TestValidateBytes_InvalidFieldType(t *testing.T) {
 	g := NewWithT(t)
 	dir := t.TempDir()


### PR DESCRIPTION
Skip comment-only YAML documents and fix `int-or-string `handling in `oneOf`