### PR TITLE
Add ecosystem schema catalog alias and `-s` shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ flux schema validate ./manifests \
 Build a kustomize overlay and validate the generated manifests:
 
 ```shell
-kustomize build ./clusters/production | flux schema validate --verbose
+kustomize build ./clusters/production | flux schema validate -s ecosystem -v
 ```
 
 Render a Helm chart and validate the generated manifests:
@@ -78,13 +78,13 @@ helm template ./charts/app | flux schema validate -v --skip-missing-schemas
 Build a [ResourceSet](https://fluxoperator.dev/docs/resourcesets/introduction/) and validate the generated manifests:
 
 ```shell
-flux operator build rset -f tenants.yaml | flux schema validate
+flux operator build rset -f tenants.yaml | flux schema validate -s ecosystem
 ```
 
 Emit a structured report for CI tooling:
 
 ```shell
-flux schema validate ./manifests -o json
+flux schema validate ./manifests -s ecosystem -o json
 ```
 
 Extract JSON Schemas and field indexes from your CRDs, then layer them on top of the built-in catalog:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ refreshed automatically from upstream stable releases.
   checked against API server rules (DNS-1123, qualified names).
 - **Built-in catalog** — JSON Schemas with CEL rules for Kubernetes, OpenShift,
   Gateway API, Flux, Flagger, and Flux Operator CRDs, refreshed automatically against upstream.
+- **Ecosystem catalog** — the `ecosystem` schema location resolves to
+  [schemas.fluxoperator.dev](https://schemas.fluxoperator.dev), a CDN-hosted catalog with
+  description-preserving schemas for hundreds of CNCF ecosystem projects, extracted from upstream
+  releases and rebuilt daily.
 - **Custom catalogs** — extract JSON Schemas from Kubernetes CRDs and OpenAPI swagger files,
   then layer your catalog on top of the default schemas.
 - **Field indexes** — generate greppable field indexes from extracted schemas
@@ -51,12 +55,12 @@ For GitHub Actions runners, use the [`actions/setup`](actions/setup) action.
 
 ## Quickstart
 
-Validate a directory tree against the built-in catalog and 3rd-party schemas:
+Validate a directory tree against the built-in catalog and the CNCF ecosystem catalog:
 
 ```shell
 flux schema validate ./manifests \
 --schema-location default \
---schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main
+--schema-location ecosystem
 ```
 
 Build a kustomize overlay and validate the generated manifests:
@@ -184,6 +188,8 @@ Run `flux schema <command> --help` for the full flag list.
   JSON Schema for `--config`.
 - [Built-in catalog](catalog/README.md) — Kubernetes, OpenShift, Gateway
   API, and Flux ecosystem CRDs covered by the default `default` schema location.
+- [Ecosystem catalog](https://schemas.fluxoperator.dev) — browsable CNCF
+  ecosystem schemas behind the `ecosystem` schema location.
 
 ## License
 

--- a/actions/validate/README.md
+++ b/actions/validate/README.md
@@ -59,7 +59,7 @@ kind: Config
 validate:
   schemaLocation:
     - default
-    - https://raw.githubusercontent.com/datreeio/CRDs-catalog/main
+    - ecosystem
   skipJSONPath:
     - Secret:/sops
   skipMissingSchemas: true

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -3,6 +3,9 @@
 This is the catalog of JSON Schemas used by the Flux Schema validation tool
 and the GitHub Action [fluxcd/flux-schema/actions/validate](../actions/validate).
 
+For CRDs not covered by the built-in catalog, the ecosystem catalog is available
+via `--schema-location ecosystem` and browsable at https://schemas.fluxoperator.dev.
+
 <!-- versions:start -->
 | Source | Version |
 | --- | --- |

--- a/cmd/flux-schema/explain.go
+++ b/cmd/flux-schema/explain.go
@@ -62,7 +62,7 @@ func init() {
 	explainCmd.Flags().StringVar(&explainArgs.apiVersion, "api-version", "",
 		"Get different explanations for particular API version (API group/version)")
 	explainCmd.Flags().VarP(&explainArgs.output, "output", "o", explainArgs.output.Description())
-	explainCmd.Flags().StringArrayVar(&explainArgs.schemaLocations, "schema-location", nil,
+	explainCmd.Flags().StringArrayVarP(&explainArgs.schemaLocations, "schema-location", "s", nil,
 		"URL or file path for schemas (repeatable); 'default' points at the built-in catalog")
 	explainCmd.Flags().BoolVar(&explainArgs.insecureSkipTLSVerify, "insecure-skip-tls-verify", false,
 		"disable TLS certificate verification when fetching schemas over HTTPS")

--- a/cmd/flux-schema/extract_crd.go
+++ b/cmd/flux-schema/extract_crd.go
@@ -20,7 +20,7 @@ import (
 var extractCRDCmd = &cobra.Command{
 	Use:   "crd [files...]",
 	Short: "Extract JSON Schemas from Kubernetes CRD YAML files",
-	Example: `  # Extract schemas using the datreeio CRDs-catalog layout (default)
+	Example: `  # Extract schemas using the '{{.Group}}/{{.Kind}}_{{.Version}}.json' layout (default)
   kubectl get crd ocirepositories.source.toolkit.fluxcd.io -o yaml > oci-crd.yaml
   flux-schema extract crd oci-crd.yaml -d ./schemas
 

--- a/cmd/flux-schema/testdata/validate/README.md
+++ b/cmd/flux-schema/testdata/validate/README.md
@@ -30,12 +30,12 @@ Test the schemas:
 --verbose
 ```
 
-Compare with datreeio catalog:
+Compare with the ecosystem catalog:
 
 ```sh
 ./bin/flux-schema validate \
 ./cmd/flux-schema/testdata/validate/manifests/valid-*.yaml \
---schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.Kind}}_{{.Version}}.json' \
+--schema-location ecosystem \
 --skip-missing-schemas \
 --verbose
 ```

--- a/cmd/flux-schema/validate.go
+++ b/cmd/flux-schema/validate.go
@@ -84,7 +84,7 @@ var validateArgs = validateFlags{
 }
 
 func init() {
-	validateCmd.Flags().StringArrayVar(&validateArgs.schemaLocations, "schema-location", nil,
+	validateCmd.Flags().StringArrayVarP(&validateArgs.schemaLocations, "schema-location", "s", nil,
 		"URL or file path for schemas (repeatable); 'default' points at the built-in catalog, 'ecosystem' at schemas.fluxoperator.dev")
 	validateCmd.Flags().BoolVar(&validateArgs.skipMissingSchemas, "skip-missing-schemas", false,
 		"skip documents for which no schema can be found instead of failing")

--- a/cmd/flux-schema/validate.go
+++ b/cmd/flux-schema/validate.go
@@ -36,11 +36,11 @@ var validateCmd = &cobra.Command{
     --schema-location default \
     --schema-location './schemas/{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json'
 
-  # Read manifests from a pipe and add remote schema fallback
+  # Read manifests from a pipe and add CNCF project CRDs from the ecosystem catalog
   kustomize build . | flux-schema validate \
     --schema-location default \
     --schema-location ./crd-schemas \
-    --schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main
+    --schema-location ecosystem
 
   # Skip specific kinds by Kind or apiVersion/Kind
   flux-schema validate ./manifests \
@@ -85,7 +85,7 @@ var validateArgs = validateFlags{
 
 func init() {
 	validateCmd.Flags().StringArrayVar(&validateArgs.schemaLocations, "schema-location", nil,
-		"URL or file path for schemas (repeatable); 'default' points at the built-in catalog")
+		"URL or file path for schemas (repeatable); 'default' points at the built-in catalog, 'ecosystem' at schemas.fluxoperator.dev")
 	validateCmd.Flags().BoolVar(&validateArgs.skipMissingSchemas, "skip-missing-schemas", false,
 		"skip documents for which no schema can be found instead of failing")
 	validateCmd.Flags().StringArrayVar(&validateArgs.skipKinds, "skip-kind", nil,
@@ -311,6 +311,7 @@ func writeReport(cmd *cobra.Command, mode string, report apiv1.Report) error {
 // pass either a full Go template or a bare path/URL:
 //
 //   - A case-insensitive literal "default" expands to validator.DefaultSchemaLocation.
+//   - A case-insensitive literal "ecosystem" expands to validator.EcosystemSchemaLocation.
 //   - A value ending in ".json" is assumed to already be a complete template and
 //     is taken verbatim.
 //   - Anything else has validator.DefaultSchemaLayout appended under a single "/", so
@@ -331,6 +332,10 @@ func expandSchemaLocations(locations []string) ([]string, error) {
 		}
 		if strings.EqualFold(loc, "default") {
 			out[i] = validator.DefaultSchemaLocation
+			continue
+		}
+		if strings.EqualFold(loc, "ecosystem") {
+			out[i] = validator.EcosystemSchemaLocation
 			continue
 		}
 		if !strings.HasSuffix(loc, ".json") {

--- a/cmd/flux-schema/validate_test.go
+++ b/cmd/flux-schema/validate_test.go
@@ -183,7 +183,7 @@ func TestValidateCmd_MultiDoc_CountsAndPlurals(t *testing.T) {
 }
 
 // TestValidateCmd_FluxManifestsFixtures runs the CLI against the real Flux
-// manifest fixtures in testdata/validate/ using the datreeio-style schema
+// manifest fixtures in testdata/validate/ using the default catalog schema
 // layout (Group/Kind_Version.json). Exercises the happy path end-to-end with
 // real schemas across multiple files, including the --skip-missing-schemas
 // behavior for the core Secret.
@@ -891,6 +891,15 @@ func TestExpandSchemaLocations(t *testing.T) {
 
 	g.Expect(expand([]string{"DEFAULT", "Default"})).
 		To(Equal([]string{validator.DefaultSchemaLocation, validator.DefaultSchemaLocation}))
+
+	g.Expect(expand([]string{"ecosystem"})).
+		To(Equal([]string{validator.EcosystemSchemaLocation}))
+
+	g.Expect(expand([]string{"ECOSYSTEM", "Ecosystem"})).
+		To(Equal([]string{validator.EcosystemSchemaLocation, validator.EcosystemSchemaLocation}))
+
+	g.Expect(expand([]string{"default", "ecosystem"})).
+		To(Equal([]string{validator.DefaultSchemaLocation, validator.EcosystemSchemaLocation}))
 
 	g.Expect(expand([]string{"./local/{{.Kind}}.json"})).
 		To(Equal([]string{"./local/{{.Kind}}.json"}))

--- a/cmd/flux-schema/validate_test.go
+++ b/cmd/flux-schema/validate_test.go
@@ -145,6 +145,20 @@ func TestValidateCmd_Verbose_PrintsValidLines(t *testing.T) {
 	g.Expect(out).To(ContainSubstring(path + " - Widget/default/ok-widget is valid"))
 }
 
+func TestValidateCmd_SchemaLocationFlagShorthand(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractWidgetSchema(t)
+	manifestDir := t.TempDir()
+	path := writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir, "-v",
+		"-s", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring(path + " - Widget/default/ok-widget is valid"))
+}
+
 func TestValidateCmd_MissingNameOrGenerateName(t *testing.T) {
 	g := NewWithT(t)
 	manifestDir := t.TempDir()

--- a/docs/config.md
+++ b/docs/config.md
@@ -16,7 +16,6 @@ apiVersion: schema.plugin.fluxcd.io/v1beta1
 kind: Config
 validate:
   schemaLocation:
-    - default
     - ecosystem
   skipKind:
     - source.toolkit.fluxcd.io/v1/ExternalArtifact
@@ -34,7 +33,7 @@ validate:
   output: text
 explain:
   schemaLocation:
-    - https://raw.githubusercontent.com/controlplaneio-fluxcd/schema-catalog/main/catalog
+    - ecosystem
   apiVersion: v1
   recursive: false
   insecureSkipTLSVerify: false
@@ -66,19 +65,19 @@ passed, for example `~/.fluxcd/plugins/flux-schema.config`.
 
 The `validate` section configures defaults for the `flux schema validate` flags.
 
-| Field                      | Description                                                    |
-|----------------------------|----------------------------------------------------------------|
-| `schemaLocation[]`         | Schema URLs, file paths, or templates tried in order. Aliases: `default` (built-in catalog), `ecosystem` (schemas.fluxoperator.dev). |
-| `skipMissingSchemas`       | Skip documents for which no schema can be found.               |
-| `skipKind[]`               | Kind or apiVersion/kind patterns excluded from validation.     |
-| `skipJSONPath[]`           | JSON Pointers stripped before validation.                      |
-| `skipFile[]`               | Basename glob patterns excluded from validation.               |
-| `skipCELRules`             | Disable evaluation of `x-kubernetes-validations` CEL rules.    |
-| `verbose`                  | Print a line for every document, including valid and skipped.  |
-| `failFast`                 | Exit after the first invalid document.                         |
-| `concurrent`               | Number of concurrent validation workers.                       |
-| `insecureSkipTLSVerify`    | Disable TLS certificate verification when downloading schemas. |
-| `output`                   | Output format: `text`, `json`, or `yaml`.                      |
+| Field                   | Description                                                                                                                                                               |
+|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `schemaLocation[]`      | Schema URLs, file paths, or templates tried in order. Aliases: `default` (built-in catalog), `ecosystem` ([schemas.fluxoperator.dev](https://schemas.fluxoperator.dev/)). |
+| `skipMissingSchemas`    | Skip documents for which no schema can be found.                                                                                                                          |
+| `skipKind[]`            | Kind or apiVersion/kind patterns excluded from validation.                                                                                                                |
+| `skipJSONPath[]`        | JSON Pointers stripped before validation.                                                                                                                                 |
+| `skipFile[]`            | Basename glob patterns excluded from validation.                                                                                                                          |
+| `skipCELRules`          | Disable evaluation of `x-kubernetes-validations` CEL rules.                                                                                                               |
+| `verbose`               | Print a line for every document, including valid and skipped.                                                                                                             |
+| `failFast`              | Exit after the first invalid document.                                                                                                                                    |
+| `concurrent`            | Number of concurrent validation workers.                                                                                                                                  |
+| `insecureSkipTLSVerify` | Disable TLS certificate verification when downloading schemas.                                                                                                            |
+| `output`                | Output format: `text`, `json`, or `yaml`.                                                                                                                                 |
 
 When the `output` field is set to `json` or `yaml`, the result has the [Report API](report.md) shape.
 
@@ -86,10 +85,10 @@ When the `output` field is set to `json` or `yaml`, the result has the [Report A
 
 The `explain` section configures defaults for the `flux schema explain` flags.
 
-| Field                   | Description                                                   |
-|-------------------------|---------------------------------------------------------------|
-| `schemaLocation[]`      | Schema URLs, file paths, or templates tried in order.         |
-| `apiVersion`            | API group/version to explain by default.                      |
-| `recursive`             | Print fields of fields.                                       |
+| Field                   | Description                                                    |
+|-------------------------|----------------------------------------------------------------|
+| `schemaLocation[]`      | Schema URLs, file paths, or templates tried in order.          |
+| `apiVersion`            | API group/version to explain by default.                       |
+| `recursive`             | Print fields of fields.                                        |
 | `insecureSkipTLSVerify` | Disable TLS certificate verification when downloading schemas. |
-| `output`                | Output format: `plaintext` or `plaintext-openapiv2`.          |
+| `output`                | Output format: `plaintext` or `plaintext-openapiv2`.           |

--- a/docs/config.md
+++ b/docs/config.md
@@ -17,7 +17,7 @@ kind: Config
 validate:
   schemaLocation:
     - default
-    - https://raw.githubusercontent.com/datreeio/CRDs-catalog/main
+    - ecosystem
   skipKind:
     - source.toolkit.fluxcd.io/v1/ExternalArtifact
   skipJSONPath:
@@ -68,7 +68,7 @@ The `validate` section configures defaults for the `flux schema validate` flags.
 
 | Field                      | Description                                                    |
 |----------------------------|----------------------------------------------------------------|
-| `schemaLocation[]`         | Schema URLs, file paths, or templates tried in order.          |
+| `schemaLocation[]`         | Schema URLs, file paths, or templates tried in order. Aliases: `default` (built-in catalog), `ecosystem` (schemas.fluxoperator.dev). |
 | `skipMissingSchemas`       | Skip documents for which no schema can be found.               |
 | `skipKind[]`               | Kind or apiVersion/kind patterns excluded from validation.     |
 | `skipJSONPath[]`           | JSON Pointers stripped before validation.                      |

--- a/docs/custom-schema-catalog.md
+++ b/docs/custom-schema-catalog.md
@@ -10,6 +10,9 @@ and `kind`. The built-in [Flux Schema catalog](../catalog/README.md) ships
 schemas for Kubernetes, OpenShift, Gateway API, and the Flux ecosystem;
 custom catalogs let you cover internal CRDs, pin specific upstream versions,
 or assemble a layout that fits your tooling.
+For third-party CRDs you don't want to extract yourself, the hosted
+[ecosystem catalog](https://schemas.fluxoperator.dev) is available via
+`--schema-location ecosystem`.
 
 ## Layout
 

--- a/docs/explain.md
+++ b/docs/explain.md
@@ -14,8 +14,7 @@ Examples:
 flux schema explain pods --api-version=v1 --schema-location ./catalog
 
 # Explain a Flux resource from a description-preserving remote catalog
-flux schema explain hr.spec \
-  --schema-location https://raw.githubusercontent.com/controlplaneio-fluxcd/schema-catalog/main/catalog
+flux schema explain hr.spec -s ecosystem
 
 # Explain a nested field
 flux schema explain pods.spec.containers --api-version=v1 --schema-location ./catalog
@@ -26,14 +25,14 @@ flux schema explain pods --api-version=v1 --recursive --schema-location ./catalo
 
 ## Flags
 
-| Flag | Description |
-|------|-------------|
-| `--schema-location` | URL or file path for schemas (repeatable); `default` points at the built-in validation catalog. |
-| `-f, --config` | YAML config file with `explain` defaults; defaults to `$FLUX_SCHEMA_CONFIG`, else `<executable>.config`. |
-| `--api-version` | Get different explanations for a particular API version (`group/version`). |
-| `--recursive` | Print fields of fields. |
-| `-o, --output` | Output format, one of `plaintext` or `plaintext-openapiv2` (default: `plaintext`). |
-| `--insecure-skip-tls-verify` | Disable TLS certificate verification when fetching schemas over HTTPS. |
+| Flag                         | Description                                                                                              |
+|------------------------------|----------------------------------------------------------------------------------------------------------|
+| `-s, --schema-location`      | URL or file path for schemas (repeatable); `default` points at the built-in validation catalog.          |
+| `-f, --config`               | YAML config file with `explain` defaults; defaults to `$FLUX_SCHEMA_CONFIG`, else `<executable>.config`. |
+| `--api-version`              | Get different explanations for a particular API version (`group/version`).                               |
+| `--recursive`                | Print fields of fields.                                                                                  |
+| `-o, --output`               | Output format, one of `plaintext` or `plaintext-openapiv2` (default: `plaintext`).                       |
+| `--insecure-skip-tls-verify` | Disable TLS certificate verification when fetching schemas over HTTPS.                                   |
 
 When `--schema-location` is not passed, `explain` reads config from
 `--config`, then `$FLUX_SCHEMA_CONFIG`, then a file next to the running binary
@@ -44,7 +43,7 @@ apiVersion: schema.plugin.fluxcd.io/v1beta1
 kind: Config
 explain:
   schemaLocation:
-    - https://raw.githubusercontent.com/controlplaneio-fluxcd/schema-catalog/main/catalog
+    - https://schemas.fluxoperator.dev/catalog
 ```
 
 ## Resource References

--- a/docs/manifests-validation.md
+++ b/docs/manifests-validation.md
@@ -24,7 +24,7 @@ A non-zero exit code is returned when any document is invalid or errored.
 
 | Flag                         | Description                                                                                              |
 |------------------------------|----------------------------------------------------------------------------------------------------------|
-| `--schema-location`          | URL or file path for schemas (repeatable, tried in order); `default` points at the built-in catalog.     |
+| `--schema-location`          | URL or file path for schemas (repeatable, tried in order); `default` points at the built-in catalog, `ecosystem` at the CNCF ecosystem catalog. |
 | `--skip-missing-schemas`     | Skip documents for which no schema can be found.                                                         |
 | `--skip-kind`                | Skip documents matching `kind` or `apiVersion/kind` (repeatable).                                        |
 | `--skip-json-path`           | Strip a JSON Pointer field before validation, optionally scoped: `[apiVersion/kind:]/path` (repeatable). |
@@ -71,9 +71,14 @@ Flux Schema catalog alongside your own schemas:
 ```shell
 flux schema validate ./manifests \
   --schema-location default \
-  --schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main \
+  --schema-location ecosystem \
   --schema-location './schemas/{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json'
 ```
+
+The literal value `ecosystem` resolves to the
+[CNCF ecosystem catalog](https://schemas.fluxoperator.dev) served from
+`https://schemas.fluxoperator.dev/catalog/`, covering CRDs of hundreds of CNCF
+projects and rebuilt daily from upstream releases.
 
 See [custom catalogs](custom-schema-catalog.md) for guidance on building and hosting
 your own schema catalog.
@@ -252,7 +257,7 @@ kind: Config
 validate:
   schemaLocation:
     - default
-    - https://raw.githubusercontent.com/datreeio/CRDs-catalog/main
+    - ecosystem
   skipKind:
     - source.toolkit.fluxcd.io/v1/ExternalArtifact
   skipJSONPath:

--- a/docs/manifests-validation.md
+++ b/docs/manifests-validation.md
@@ -24,7 +24,7 @@ A non-zero exit code is returned when any document is invalid or errored.
 
 | Flag                         | Description                                                                                              |
 |------------------------------|----------------------------------------------------------------------------------------------------------|
-| `--schema-location`          | URL or file path for schemas (repeatable, tried in order); `default` points at the built-in catalog, `ecosystem` at the CNCF ecosystem catalog. |
+| `-s, --schema-location`      | URL or file path for schemas (repeatable, tried in order); `default` points at the built-in catalog, `ecosystem` at the CNCF ecosystem catalog. |
 | `--skip-missing-schemas`     | Skip documents for which no schema can be found.                                                         |
 | `--skip-kind`                | Skip documents matching `kind` or `apiVersion/kind` (repeatable).                                        |
 | `--skip-json-path`           | Strip a JSON Pointer field before validation, optionally scoped: `[apiVersion/kind:]/path` (repeatable). |

--- a/internal/validator/defaults.go
+++ b/internal/validator/defaults.go
@@ -9,6 +9,14 @@ package validator
 // to in the validate CLI's --schema-location flag.
 const DefaultSchemaLocation = "https://raw.githubusercontent.com/fluxcd/flux-schema/main/catalog/latest/" + DefaultSchemaLayout
 
+// EcosystemSchemaLocation points at the CNCF ecosystem catalog hosted at
+// https://schemas.fluxoperator.dev, covering Kubernetes core and the CRDs of
+// CNCF ecosystem projects, extracted from upstream releases and rebuilt daily.
+// Unlike the built-in catalog, its schemas preserve field descriptions. It is
+// the target that the literal value "ecosystem" resolves to in the
+// --schema-location flag.
+const EcosystemSchemaLocation = "https://schemas.fluxoperator.dev/catalog/" + DefaultSchemaLayout
+
 // DefaultSchemaLayout is the Go-template tail appended to any schema location
 // value that doesn't already end in ".json", so a bare path/URL like
 // "./my-schemas" expands to "./my-schemas/{{.Group}}/{{.Kind}}_{{.Version}}.json".


### PR DESCRIPTION
Introduce  the `ecosystem` schema location that resolves to [schemas.fluxoperator.dev](https://schemas.fluxoperator.dev), a CDN-hosted catalog with description-preserving schemas for hundreds of CNCF ecosystem projects, extracted from upstream releases and rebuilt daily.

Add `flux schema validate -s ecosystem` shorthand for `--schema-location`.