### PR TITLE
Implement explain support for the ecosystem index

### DIFF
--- a/cmd/flux-schema/explain.go
+++ b/cmd/flux-schema/explain.go
@@ -11,6 +11,7 @@ import (
 
 	explainer "github.com/fluxcd/flux-schema/internal/explain"
 	"github.com/fluxcd/flux-schema/internal/flags"
+	"github.com/fluxcd/flux-schema/internal/validator"
 )
 
 var explainCmd = &cobra.Command{
@@ -63,7 +64,7 @@ func init() {
 		"Get different explanations for particular API version (API group/version)")
 	explainCmd.Flags().VarP(&explainArgs.output, "output", "o", explainArgs.output.Description())
 	explainCmd.Flags().StringArrayVarP(&explainArgs.schemaLocations, "schema-location", "s", nil,
-		"URL or file path for schemas (repeatable); 'default' points at the built-in catalog")
+		"URL or file path for schemas (repeatable); 'default' points at the built-in catalog, 'ecosystem' at schemas.fluxoperator.dev")
 	explainCmd.Flags().BoolVar(&explainArgs.insecureSkipTLSVerify, "insecure-skip-tls-verify", false,
 		"disable TLS certificate verification when fetching schemas over HTTPS")
 	explainCmd.Flags().StringVarP(&explainArgs.configFile, "config", "f", "", configFlagUsage())
@@ -126,6 +127,7 @@ func buildExplainerOptions() (explainer.Options, error) {
 	return explainer.Options{
 		SchemaLocations:       locations,
 		MetadataLocations:     buildExplainMetadataLocations(locations),
+		IndexLocations:        buildExplainIndexLocations(locations),
 		APIVersion:            explainArgs.apiVersion,
 		OutputFormat:          explainArgs.output.String(),
 		Recursive:             explainArgs.recursive,
@@ -144,6 +146,9 @@ func buildExplainSchemaLocations() ([]string, error) {
 func buildExplainMetadataLocations(schemaLocations []string) []string {
 	var out []string
 	for _, location := range schemaLocations {
+		if isEcosystemSchemaLocation(location) {
+			continue
+		}
 		metadataLocation, ok := explainMetadataLocation(location)
 		if !ok || containsString(out, metadataLocation) {
 			continue
@@ -151,6 +156,27 @@ func buildExplainMetadataLocations(schemaLocations []string) []string {
 		out = append(out, metadataLocation)
 	}
 	return out
+}
+
+func buildExplainIndexLocations(schemaLocations []string) []string {
+	var out []string
+	for _, location := range schemaLocations {
+		if !isEcosystemSchemaLocation(location) || containsString(out, validator.EcosystemIndexLocation) {
+			continue
+		}
+		out = append(out, validator.EcosystemIndexLocation)
+	}
+	return out
+}
+
+func isEcosystemSchemaLocation(location string) bool {
+	base, _ := splitLocationTail(location)
+	idx := strings.Index(base, "{{")
+	if idx >= 0 {
+		base = base[:idx]
+	}
+	base = strings.TrimRight(base, "/\\")
+	return strings.EqualFold(base, validator.EcosystemSchemaBase)
 }
 
 func explainMetadataLocation(location string) (string, bool) {

--- a/cmd/flux-schema/explain_test.go
+++ b/cmd/flux-schema/explain_test.go
@@ -86,13 +86,13 @@ func TestExplainCmd_OpenAPIV2Output(t *testing.T) {
 	g.Expect(out).To(HavePrefix("KIND:     Pod\n" +
 		"VERSION:  v1\n" +
 		"\n" +
-		"RESOURCE: spec <Object>\n" +
+		"RESOURCE: spec <PodSpec>\n" +
 		"\n" +
 		"DESCRIPTION:\n" +
 		"     Specification of the desired behavior of the pod.\n" +
 		"\n" +
 		"FIELDS:\n" +
-		"   containers\t<[]Object> -required-\n"))
+		"   containers\t<[]Container> -required-\n"))
 }
 
 func TestExplainCmd_Recursive(t *testing.T) {

--- a/cmd/flux-schema/explain_test.go
+++ b/cmd/flux-schema/explain_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+
+	"github.com/fluxcd/flux-schema/internal/validator"
 )
 
 func TestExplainCmd_Resource(t *testing.T) {
@@ -298,15 +300,17 @@ func TestExplainSchemaLocationDefaultExpansion(t *testing.T) {
 	g := NewWithT(t)
 	defer resetCmdArgs()
 
-	explainArgs.schemaLocations = []string{"default", "./catalog"}
+	explainArgs.schemaLocations = []string{"default", "ecosystem", "./catalog"}
 	locations, err := buildExplainSchemaLocations()
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(locations).To(Equal([]string{
 		"https://raw.githubusercontent.com/fluxcd/flux-schema/main/catalog/latest/{{.Group}}/{{.Kind}}_{{.Version}}.json",
+		validator.EcosystemSchemaLocation,
 		"./catalog/{{.Group}}/{{.Kind}}_{{.Version}}.json",
 	}))
 	g.Expect(buildExplainMetadataLocations(locations)).To(Equal([]string{
 		"https://raw.githubusercontent.com/fluxcd/flux-schema/main/catalog/latest/.explain",
 		"./catalog/.explain",
 	}))
+	g.Expect(buildExplainIndexLocations(locations)).To(Equal([]string{validator.EcosystemIndexLocation}))
 }

--- a/cmd/flux-schema/extract.go
+++ b/cmd/flux-schema/extract.go
@@ -31,6 +31,19 @@ func init() {
 	rootCmd.AddCommand(extractCmd)
 }
 
+// stripExplainMetadataForOutput applies the requested explain metadata level
+// before the schema is written.
+func stripExplainMetadataForOutput(node any, out flags.ExtractOutput) {
+	switch {
+	case out.WithExplainMetadata:
+		return
+	case out.WithExplainTypeMetadata:
+		extractor.StripExplainLookupMetadata(node)
+	default:
+		extractor.StripExplainMetadata(node)
+	}
+}
+
 // runSwaggerExtract is the shared `extract k8s`/`extract openshift` pipeline:
 // it creates the output dir, runs extract on the swagger data, optionally
 // strips descriptions, writes each schema, and reports per-document failures.
@@ -63,9 +76,7 @@ func runSwaggerExtract(cmd *cobra.Command, source string, data []byte, out flags
 			}
 		}
 
-		if !out.WithExplainMetadata {
-			extractor.StripExplainMetadata(schemaDoc.JSON)
-		}
+		stripExplainMetadataForOutput(schemaDoc.JSON, out)
 		if out.StripDescription {
 			extractor.StripDescriptions(schemaDoc.JSON)
 		}

--- a/cmd/flux-schema/extract_crd.go
+++ b/cmd/flux-schema/extract_crd.go
@@ -105,9 +105,7 @@ func extractCRDCmdRun(cmd *cobra.Command, args []string) error {
 				}
 			}
 
-			if !extractCRDArgs.WithExplainMetadata {
-				extractor.StripExplainMetadata(crd.JSON)
-			}
+			stripExplainMetadataForOutput(crd.JSON, extractCRDArgs.ExtractOutput)
 			if extractCRDArgs.StripDescription {
 				extractor.StripDescriptions(crd.JSON)
 			}

--- a/cmd/flux-schema/extract_k8s_test.go
+++ b/cmd/flux-schema/extract_k8s_test.go
@@ -35,6 +35,41 @@ const minimalSwagger = `{
   }
 }`
 
+const refSwagger = `{
+  "paths": {
+    "/apis/example.com/v1/widgets": {
+      "get": {
+        "x-kubernetes-group-version-kind": {
+          "group": "example.com",
+          "version": "v1",
+          "kind": "Widget"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "example.v1.WidgetSpec": {
+      "type": "object",
+      "description": "WidgetSpec defines nested widget settings.",
+      "properties": {
+        "name": {"type": "string"}
+      }
+    },
+    "example.v1.Widget": {
+      "type": "object",
+      "properties": {
+        "spec": {
+          "$ref": "#/definitions/example.v1.WidgetSpec",
+          "description": "Spec configures the widget."
+        }
+      },
+      "x-kubernetes-group-version-kind": [
+        {"group": "example.com", "version": "v1", "kind": "Widget"}
+      ]
+    }
+  }
+}`
+
 const minimalNamespacedSwagger = `{
   "paths": {
     "/apis/example.com/v1/namespaces/{namespace}/widgets": {
@@ -131,6 +166,73 @@ func TestExtractK8sCmd_StripDescription(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join(outDir, "example.com", "widget_v1.json"))
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(string(data)).ToNot(ContainSubstring(`"description"`))
+}
+
+func TestExtractK8sCmd_DefaultStripsExplainTypeMetadata(t *testing.T) {
+	g := NewWithT(t)
+
+	outDir := t.TempDir()
+	input := writeSwaggerDataFixture(t, refSwagger)
+
+	_, err := executeCommand([]string{"extract", "k8s", input, "--output-dir", outDir})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	data, err := os.ReadFile(filepath.Join(outDir, "example.com", "widget_v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(data)).ToNot(ContainSubstring("x-flux-schema-type"))
+	g.Expect(string(data)).ToNot(ContainSubstring("x-flux-schema-type-description"))
+}
+
+func TestExtractK8sCmd_WithExplainTypeMetadata(t *testing.T) {
+	g := NewWithT(t)
+
+	outDir := t.TempDir()
+	input := writeSwaggerDataFixture(t, refSwagger)
+
+	_, err := executeCommand([]string{
+		"extract", "k8s", input,
+		"--output-dir", outDir,
+		"--with-explain-type-metadata",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	data, err := os.ReadFile(filepath.Join(outDir, "example.com", "widget_v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(data)).To(ContainSubstring(`"x-flux-schema-type": "WidgetSpec"`))
+	g.Expect(string(data)).To(ContainSubstring(`"x-flux-schema-type-description": "WidgetSpec defines nested widget settings."`))
+	g.Expect(string(data)).ToNot(ContainSubstring("x-flux-schema-group-version-kind"))
+	g.Expect(string(data)).ToNot(ContainSubstring("x-flux-schema-resource"))
+
+	_, err = os.Stat(filepath.Join(outDir, ".explain"))
+	g.Expect(os.IsNotExist(err)).To(BeTrue())
+	_, err = os.Stat(filepath.Join(outDir, "example.com", "widgets_v1.json"))
+	g.Expect(os.IsNotExist(err)).To(BeTrue())
+}
+
+func TestExtractK8sCmd_WithExplainMetadataIncludesTypeAndLookupMetadata(t *testing.T) {
+	g := NewWithT(t)
+
+	outDir := t.TempDir()
+	input := writeSwaggerDataFixture(t, refSwagger)
+
+	_, err := executeCommand([]string{
+		"extract", "k8s", input,
+		"--output-dir", outDir,
+		"--with-explain-metadata",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	data, err := os.ReadFile(filepath.Join(outDir, "example.com", "widget_v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(data)).To(ContainSubstring(`"x-flux-schema-type": "WidgetSpec"`))
+	g.Expect(string(data)).To(ContainSubstring(`"x-flux-schema-type-description": "WidgetSpec defines nested widget settings."`))
+	g.Expect(string(data)).To(ContainSubstring("x-flux-schema-group-version-kind"))
+	g.Expect(string(data)).To(ContainSubstring("x-flux-schema-resource"))
+
+	_, err = os.Stat(filepath.Join(outDir, ".explain", "refs", "widgets.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+	_, err = os.Stat(filepath.Join(outDir, "example.com", "widgets_v1.json"))
+	g.Expect(err).ToNot(HaveOccurred())
 }
 
 func TestExtractK8sCmd_WithFieldIndexNamespacedScope(t *testing.T) {

--- a/docs/config.md
+++ b/docs/config.md
@@ -87,7 +87,7 @@ The `explain` section configures defaults for the `flux schema explain` flags.
 
 | Field                   | Description                                                    |
 |-------------------------|----------------------------------------------------------------|
-| `schemaLocation[]`      | Schema URLs, file paths, or templates tried in order.          |
+| `schemaLocation[]`      | Schema URLs, file paths, or templates tried in order. Aliases: `default` (built-in catalog), `ecosystem` ([schemas.fluxoperator.dev](https://schemas.fluxoperator.dev/)). |
 | `apiVersion`            | API group/version to explain by default.                       |
 | `recursive`             | Print fields of fields.                                        |
 | `insecureSkipTLSVerify` | Disable TLS certificate verification when downloading schemas. |

--- a/docs/custom-schema-catalog.md
+++ b/docs/custom-schema-catalog.md
@@ -75,10 +75,11 @@ emits one schema file per CRD version.
 | `-d, --output-dir`     | Directory to write JSON Schema files to (mutually exclusive with `--output-archive`).        |
 | `-a, --output-archive` | Path to write a gzipped tar archive of JSON Schema files to.                                 |
 | `-f, --output-format`  | Go template for output file paths (default: `{{ .Group }}/{{ .Kind }}_{{ .Version }}.json`). |
-| `--index-source`          | Source name and version recorded in field index headers, overriding auto-detection.      |
-| `--strip-description`     | Drop `description` fields from the generated schemas to reduce their size.               |
-| `--with-field-index`      | Also write a `.fields.txt` field index next to each schema.                              |
-| `--with-explain-metadata` | Include `x-flux-schema-*` annotations, alias redirects, and `.explain/` lookup shards used by `flux schema explain`. |
+| `--index-source` | Source name and version recorded in field index headers, overriding auto-detection. |
+| `--strip-description` | Drop `description` fields from the generated schemas to reduce their size. |
+| `--with-field-index` | Also write a `.fields.txt` field index next to each schema. |
+| `--with-explain-type-metadata` | Keep JSON-only explain type hints, without writing explain lookup files. |
+| `--with-explain-metadata` | Include JSON type hints, alias redirects, and `.explain/` lookup shards used by standalone `flux schema explain` catalogs. |
 
 Generate schemas for every CRD installed in a cluster:
 
@@ -113,10 +114,11 @@ standalone files.
 | `--version X.Y.Z`     | Fetch the swagger from `github.com/kubernetes/kubernetes` for the given release tag (mutually exclusive with a swagger file). |
 | `-d, --output-dir`    | Directory to write JSON Schema files to.                                                                                      |
 | `-f, --output-format` | Go template for output file paths (default: `{{ .Group }}/{{ .Kind }}_{{ .Version }}.json`).                                  |
-| `--index-source`          | Source name and version recorded in field index headers, overriding auto-detection.                                   |
-| `--strip-description`     | Drop `description` fields from the generated schemas to reduce their size.                                            |
-| `--with-field-index`      | Also write a `.fields.txt` field index next to each schema.                                                           |
-| `--with-explain-metadata` | Include `x-flux-schema-*` annotations, alias redirects, and `.explain/` lookup shards used by `flux schema explain`.                                          |
+| `--index-source` | Source name and version recorded in field index headers, overriding auto-detection. |
+| `--strip-description` | Drop `description` fields from the generated schemas to reduce their size. |
+| `--with-field-index` | Also write a `.fields.txt` field index next to each schema. |
+| `--with-explain-type-metadata` | Keep JSON-only explain type hints, without writing explain lookup files. |
+| `--with-explain-metadata` | Include JSON type hints, alias redirects, and `.explain/` lookup shards used by standalone `flux schema explain` catalogs. |
 
 Pin the catalog to a specific Kubernetes release:
 
@@ -147,10 +149,11 @@ emitted; embedded upstream Kubernetes types (e.g. `Pod`) are inlined.
 | `--ref REF`           | Fetch the swagger from `github.com/openshift/api` at the given git ref (e.g. `release-4.20`); mutually exclusive with a swagger file. |
 | `-d, --output-dir`    | Directory to write JSON Schema files to.                                                                                              |
 | `-f, --output-format` | Go template for output file paths (default: `{{ .Group }}/{{ .Kind }}_{{ .Version }}.json`).                                          |
-| `--index-source`          | Source name and version recorded in field index headers, overriding auto-detection.                                           |
-| `--strip-description`     | Drop `description` fields from the generated schemas to reduce their size.                                                    |
-| `--with-field-index`      | Also write a `.fields.txt` field index next to each schema.                                                                   |
-| `--with-explain-metadata` | Include `x-flux-schema-*` annotations, alias redirects, and `.explain/` lookup shards used by `flux schema explain`.                                                  |
+| `--index-source` | Source name and version recorded in field index headers, overriding auto-detection. |
+| `--strip-description` | Drop `description` fields from the generated schemas to reduce their size. |
+| `--with-field-index` | Also write a `.fields.txt` field index next to each schema. |
+| `--with-explain-type-metadata` | Keep JSON-only explain type hints, without writing explain lookup files. |
+| `--with-explain-metadata` | Include JSON type hints, alias redirects, and `.explain/` lookup shards used by standalone `flux schema explain` catalogs. |
 
 Pin to an OpenShift release branch:
 
@@ -213,11 +216,40 @@ constraints the Kubernetes API server enforces:
   API server's behavior of accepting `null` for unset optional values.
 - `apiVersion` and `kind` are injected into every kind's properties and
   required list.
-- `x-flux-schema-*` explain annotations, resource alias redirects, and the
-  sharded `.explain/` metadata tree are omitted by default. Pass
-  `--with-explain-metadata` only for catalogs that need exact
-  `flux schema explain` kind names, short names, plural names, full resource
-  names, type-reference shell completion, and field type names.
+- `x-flux-schema-*` explain annotations are omitted by default. They are
+  documentation-only and do not affect JSON Schema validation.
+
+## Explain metadata
+
+`extract` can write two layers of metadata used by `flux schema explain`.
+They are opt-in so validation-only catalogs do not grow by default.
+
+Schema-local type metadata is stored inside each JSON Schema. It preserves
+field render hints that are otherwise lost when OpenAPI `$ref` definitions
+are inlined, such as named nested types (`Container`, `Quantity`,
+`IntOrString`) and referenced type descriptions. Pass
+`--with-explain-type-metadata` when another index provides resource lookup and
+completion. This is the ecosystem catalog mode used with
+`--schema-location ecosystem`, where `explain` resolves resources from
+`https://schemas.fluxoperator.dev/index.json` and only needs the loaded JSON
+schema to print kubectl-style field output.
+
+Standalone explain metadata includes the schema-local type metadata plus the
+lookup files needed when there is no separate ecosystem index: alias redirect
+JSON files, `.explain/refs/`, and `.explain/completion/`. Pass
+`--with-explain-metadata` for custom catalogs that should support
+`flux schema explain` resource references and shell completion on their own.
+This flag is a superset of `--with-explain-type-metadata`.
+
+`--with-field-index` is separate. It writes `.fields.txt` sidecars for
+search, agents, and other catalog consumers. `explain` does not use field
+indexes for resource lookup, completion, field rendering, type names, or
+descriptions. It can read `.fields.txt` only as a compatibility fallback to
+recover root `apiVersion` and `kind` when JSON explain metadata is absent.
+
+Catalogs generated with `--strip-description` still validate resources and
+resolve fields, but they cannot reproduce kubectl's descriptive output
+byte-for-byte because descriptions and explain type descriptions are removed.
 
 ## Field indexes
 
@@ -225,7 +257,7 @@ Pass `--with-field-index` to the `extract` commands to write greppable,
 LLM-friendly field indexes alongside the extracted schemas: one
 `.fields.txt` file per schema, with one self-contained line per field.
 See the [field index reference](field-index.md) for the file naming, line
-grammar, and annotations.
+grammar, and annotations. Field indexes are independent from explain metadata.
 
 ## Hosting
 

--- a/docs/explain.md
+++ b/docs/explain.md
@@ -27,7 +27,7 @@ flux schema explain pods --api-version=v1 --recursive --schema-location ./catalo
 
 | Flag                         | Description                                                                                              |
 |------------------------------|----------------------------------------------------------------------------------------------------------|
-| `-s, --schema-location`      | URL or file path for schemas (repeatable); `default` points at the built-in validation catalog.          |
+| `-s, --schema-location`      | URL or file path for schemas (repeatable); `default` points at the built-in validation catalog, `ecosystem` at the CNCF ecosystem catalog. |
 | `-f, --config`               | YAML config file with `explain` defaults; defaults to `$FLUX_SCHEMA_CONFIG`, else `<executable>.config`. |
 | `--api-version`              | Get different explanations for a particular API version (`group/version`).                               |
 | `--recursive`                | Print fields of fields.                                                                                  |
@@ -55,10 +55,12 @@ kind names (`OCIRepository.spec.verify`), plural resource names
 (`po.spec`, `hr.spec`, `ag.spec`). Built-in Kubernetes short names are
 recognized by the command. CRD kinds, plural names, singular names, full
 resource names, and short names are resolved from sharded metadata under
-`.explain/refs/` when the catalog provides it. Shell completion uses
-`.explain/completion/` shards and suggests the canonical resource name
-(`plural.group`, or `plural` for core resources) for all indexed resources
-matching the typed prefix.
+`.explain/refs/` when custom catalogs provide it. For the `ecosystem` catalog,
+`explain` uses the hosted `https://schemas.fluxoperator.dev/index.json` to
+resolve resource references and provide shell completion without fetching
+thousands of per-resource metadata files. Completion suggests the canonical
+resource name (`plural.group`, or `plural` for core resources) for all indexed
+resources matching the typed prefix.
 
 When `--api-version` is set, dotted group suffixes are treated like kubectl:
 the first path segment is the resource name and the remaining segments are
@@ -67,8 +69,11 @@ segments after the resource as an API group, then falls back to field lookup.
 
 ## Catalogs
 
-For best parity with kubectl, use a description-preserving catalog generated
-with:
+The hosted `ecosystem` catalog preserves descriptions and ships an optimized
+index used by `flux schema explain -s ecosystem`.
+
+For custom catalogs, best parity with kubectl comes from a description-preserving
+catalog generated with:
 
 ```shell
 flux schema extract k8s --with-explain-metadata --with-field-index -d ./catalog

--- a/docs/explain.md
+++ b/docs/explain.md
@@ -69,25 +69,51 @@ segments after the resource as an API group, then falls back to field lookup.
 
 ## Catalogs
 
-The hosted `ecosystem` catalog preserves descriptions and ships an optimized
-index used by `flux schema explain -s ecosystem`.
+`explain` has two catalog modes.
 
-For custom catalogs, best parity with kubectl comes from a description-preserving
-catalog generated with:
+### Ecosystem index mode
+
+The hosted `ecosystem` catalog is special. `flux schema explain -s ecosystem`
+uses `https://schemas.fluxoperator.dev/index.json` for resource lookup and
+shell completion, then fetches only the schema JSON needed for the requested
+resource. Because the index already provides plural names, short names, full
+resource names, and completion candidates, the catalog does not need alias
+redirect files or a `.explain/` tree.
+
+Schemas used with this mode should be generated with JSON-only explain type
+metadata:
 
 ```shell
-flux schema extract k8s --with-explain-metadata --with-field-index -d ./catalog
-flux schema extract crd --with-explain-metadata --with-field-index -d ./catalog
+flux schema extract k8s --with-explain-type-metadata -d ./catalog
 ```
 
-`--with-explain-metadata` is opt-in. It keeps validation-only catalogs small
-by default, and when enabled it adds `x-flux-schema-*` annotations, small alias
-redirect files, `.explain/refs/` exact lookup files, and `.explain/completion/`
-prefix shards used to resolve kubectl-style resource references and provide
-type-reference shell completion. Those annotations let `explain` recover exact
-kind names, discovery aliases, and named field types such as `ObjectMeta`,
-`PodSpec`, and `HelmReleaseSpec`.
+`--with-explain-type-metadata` keeps only schema-local JSON hints used after a
+schema has been loaded, such as named field types (`Container`, `Quantity`,
+`IntOrString`) and referenced type descriptions. It does not write alias JSON
+files, `.explain/refs/`, or `.explain/completion/`.
 
-Catalogs generated with `--strip-description` still resolve fields, but
-descriptions are empty and nested object type names may fall back to `Object`
-when the schema lacks explain metadata.
+### Standalone catalog mode
+
+Use standalone mode for custom catalogs that must contain everything
+`flux schema explain` needs without the ecosystem index.
+
+```shell
+flux schema extract k8s --with-explain-metadata -d ./catalog
+flux schema extract crd --with-explain-metadata -d ./catalog
+```
+
+`--with-explain-metadata` is the full explain mode. It is a superset of
+`--with-explain-type-metadata`: it keeps the schema-local JSON type hints and
+also writes alias redirects, `.explain/refs/` lookup files, and
+`.explain/completion/` shards used for kubectl-style resource references and
+type-reference shell completion.
+
+`--with-field-index` is independent from both modes. It writes `.fields.txt`
+sidecars for search and agent workflows. `explain` does not use field indexes
+for resource lookup, completion, field rendering, type names, or descriptions.
+It can read them only as a fallback for root `apiVersion` and `kind` when JSON
+explain metadata is missing.
+
+Catalogs generated with `--strip-description` still resolve fields, but they
+cannot reproduce kubectl's descriptive output byte-for-byte because regular
+descriptions and explain type descriptions are removed.

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -99,6 +99,7 @@ var versionCandidates = []string{
 type Options struct {
 	SchemaLocations       []string
 	MetadataLocations     []string
+	IndexLocations        []string
 	APIVersion            string
 	OutputFormat          string
 	Recursive             bool
@@ -111,6 +112,10 @@ type Explainer struct {
 	opts      Options
 	templates []*template.Template
 	client    *retryablehttp.Client
+
+	indexLoaded    bool
+	indexResources []indexResource
+	indexErr       error
 }
 
 type resolvedSchema struct {
@@ -154,6 +159,57 @@ type completionShard struct {
 type completionResource struct {
 	Name    string   `json:"name"`
 	Aliases []string `json:"aliases,omitempty"`
+}
+
+type catalogIndex struct {
+	Projects []catalogIndexProject `json:"projects,omitempty"`
+}
+
+type catalogIndexProject struct {
+	Groups []catalogIndexGroup `json:"groups,omitempty"`
+}
+
+type catalogIndexGroup struct {
+	Group string             `json:"g,omitempty"`
+	Kinds []catalogIndexKind `json:"kinds,omitempty"`
+}
+
+type catalogIndexKind struct {
+	Name     string
+	Versions []string
+	Kind     string
+}
+
+type indexResource struct {
+	Group   string
+	Version string
+	Kind    string
+	Name    string
+}
+
+func (k *catalogIndexKind) UnmarshalJSON(data []byte) error {
+	var tuple []json.RawMessage
+	if err := json.Unmarshal(data, &tuple); err != nil {
+		return err
+	}
+	if len(tuple) < 2 {
+		return fmt.Errorf("index kind tuple has %d entries, want at least 2", len(tuple))
+	}
+	if err := json.Unmarshal(tuple[0], &k.Name); err != nil {
+		return fmt.Errorf("parse index kind name: %w", err)
+	}
+	if err := json.Unmarshal(tuple[1], &k.Versions); err != nil {
+		return fmt.Errorf("parse index kind versions: %w", err)
+	}
+	if len(tuple) >= 4 {
+		if err := json.Unmarshal(tuple[3], &k.Kind); err != nil {
+			return fmt.Errorf("parse index kind display name: %w", err)
+		}
+	}
+	if k.Kind == "" {
+		k.Kind = fallbackKind(k.Name)
+	}
+	return nil
 }
 
 func New(opts Options) (*Explainer, error) {
@@ -223,6 +279,18 @@ func (e *Explainer) CompleteResourceNames(ctx context.Context, prefix string) ([
 			seen[resource.Name] = true
 			out = append(out, resource.Name)
 		}
+	}
+	indexResources, err := e.loadResourceIndex(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, resource := range indexResources {
+		name := resource.canonicalName()
+		if !resource.matchesCompletionPrefix(prefix) || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
 	}
 	sort.Strings(out)
 	return out, nil
@@ -330,6 +398,9 @@ func (e *Explainer) resolveFromReferences(ctx context.Context, req requestCandid
 		if !found {
 			continue
 		}
+		if target.Kind != "" {
+			resolved.Kind = target.Kind
+		}
 		resolved.RequestedKind = req.resource
 		return resolved, true, nil
 	}
@@ -366,6 +437,15 @@ func (e *Explainer) loadResourceReference(ctx context.Context, key string) ([]re
 		}
 		out = append(out, ref.Targets...)
 	}
+	indexResources, err := e.loadResourceIndex(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, resource := range indexResources {
+		if resource.matchesReferenceKey(key) {
+			out = append(out, resource.target())
+		}
+	}
 	return out, nil
 }
 
@@ -387,6 +467,144 @@ func (e *Explainer) loadCompletionShard(ctx context.Context, key string) ([]comp
 		out = append(out, shard.Resources...)
 	}
 	return out, nil
+}
+
+func (e *Explainer) loadResourceIndex(ctx context.Context) ([]indexResource, error) {
+	if e.indexLoaded {
+		return e.indexResources, e.indexErr
+	}
+	e.indexLoaded = true
+	for _, location := range e.opts.IndexLocations {
+		body, found, err := e.loadBytes(ctx, location)
+		if err != nil {
+			e.indexErr = err
+			return nil, err
+		}
+		if !found {
+			continue
+		}
+		var index catalogIndex
+		if err := decodeJSON(body, &index); err != nil {
+			e.indexErr = fmt.Errorf("%s: parse catalog index: %w", location, err)
+			return nil, e.indexErr
+		}
+		e.indexResources = append(e.indexResources, index.resources()...)
+	}
+	return e.indexResources, nil
+}
+
+func (i catalogIndex) resources() []indexResource {
+	var out []indexResource
+	for _, project := range i.Projects {
+		for _, group := range project.Groups {
+			for _, kind := range group.Kinds {
+				name := strings.ToLower(strings.TrimSpace(kind.Name))
+				if name == "" {
+					continue
+				}
+				for _, version := range kind.Versions {
+					version = strings.TrimSpace(version)
+					if version == "" {
+						continue
+					}
+					out = append(out, indexResource{
+						Group:   strings.ToLower(strings.TrimSpace(group.Group)),
+						Version: version,
+						Kind:    kind.Kind,
+						Name:    name,
+					})
+				}
+			}
+		}
+	}
+	return out
+}
+
+func (r indexResource) target() resourceTarget {
+	return resourceTarget{Group: r.Group, Version: r.Version, Kind: r.Kind}
+}
+
+func (r indexResource) canonicalName() string {
+	name := pluralResourceName(r.Name)
+	if r.Group == "" {
+		return name
+	}
+	return name + "." + r.Group
+}
+
+func (r indexResource) matchesReferenceKey(key string) bool {
+	for _, alias := range r.aliases() {
+		if key == alias {
+			return true
+		}
+	}
+	return false
+}
+
+func (r indexResource) matchesCompletionPrefix(prefix string) bool {
+	if prefix == "" || strings.HasPrefix(r.canonicalName(), prefix) {
+		return true
+	}
+	for _, alias := range r.aliases() {
+		if strings.HasPrefix(alias, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r indexResource) aliases() []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(alias string) {
+		alias = strings.ToLower(strings.TrimSpace(alias))
+		if alias == "" || seen[alias] {
+			return
+		}
+		seen[alias] = true
+		out = append(out, alias)
+	}
+	bases := []string{r.Name, strings.ToLower(r.Kind), pluralResourceName(r.Name)}
+	for short, candidates := range builtinResourceAliases {
+		for _, candidate := range candidates {
+			if candidate == r.Name {
+				bases = append(bases, short)
+				break
+			}
+		}
+	}
+	for _, alias := range bases {
+		add(alias)
+		if r.Group != "" {
+			add(alias + "." + r.Group)
+		}
+	}
+	return out
+}
+
+func pluralResourceName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		return ""
+	}
+	if strings.HasSuffix(name, "y") && len(name) > 1 && !isVowel(name[len(name)-2]) {
+		return strings.TrimSuffix(name, "y") + "ies"
+	}
+	for _, suffix := range []string{"ch", "sh", "s", "x", "z"} {
+		if strings.HasSuffix(name, suffix) {
+			return name + "es"
+		}
+	}
+	return name + "s"
+}
+
+func isVowel(b byte) bool {
+	switch b {
+	case 'a', 'e', 'i', 'o', 'u':
+		return true
+	default:
+		return false
+	}
 }
 
 func metadataLocation(root string, elems ...string) string {
@@ -638,36 +856,44 @@ func isHTTPURL(s string) bool {
 }
 
 var builtinResourceAliases = map[string][]string{
-	"cm":     {"configmap"},
-	"cs":     {"componentstatus"},
-	"ep":     {"endpoints"},
-	"ev":     {"event"},
-	"limits": {"limitrange"},
-	"ns":     {"namespace"},
-	"no":     {"node"},
-	"po":     {"pod"},
-	"pvc":    {"persistentvolumeclaim"},
-	"pv":     {"persistentvolume"},
-	"quota":  {"resourcequota"},
-	"rc":     {"replicationcontroller"},
-	"sa":     {"serviceaccount"},
-	"svc":    {"service"},
-	"crd":    {"customresourcedefinition"},
-	"crds":   {"customresourcedefinition"},
-	"deploy": {"deployment"},
-	"ds":     {"daemonset"},
-	"rs":     {"replicaset"},
-	"sts":    {"statefulset"},
-	"hpa":    {"horizontalpodautoscaler"},
-	"cj":     {"cronjob"},
-	"ing":    {"ingress"},
-	"netpol": {"networkpolicy"},
-	"pdb":    {"poddisruptionbudget"},
-	"pc":     {"priorityclass"},
-	"sc":     {"storageclass"},
-	"csr":    {"certificatesigningrequest"},
-	"ip":     {"ipaddress"},
-	"vac":    {"volumeattributesclass"},
+	"cm":        {"configmap"},
+	"cs":        {"componentstatus"},
+	"ep":        {"endpoints"},
+	"ev":        {"event"},
+	"limits":    {"limitrange"},
+	"ns":        {"namespace"},
+	"no":        {"node"},
+	"po":        {"pod"},
+	"pvc":       {"persistentvolumeclaim"},
+	"pv":        {"persistentvolume"},
+	"quota":     {"resourcequota"},
+	"rc":        {"replicationcontroller"},
+	"sa":        {"serviceaccount"},
+	"svc":       {"service"},
+	"crd":       {"customresourcedefinition"},
+	"crds":      {"customresourcedefinition"},
+	"deploy":    {"deployment"},
+	"ds":        {"daemonset"},
+	"rs":        {"replicaset"},
+	"sts":       {"statefulset"},
+	"hpa":       {"horizontalpodautoscaler"},
+	"cj":        {"cronjob"},
+	"ing":       {"ingress"},
+	"netpol":    {"networkpolicy"},
+	"pdb":       {"poddisruptionbudget"},
+	"pc":        {"priorityclass"},
+	"sc":        {"storageclass"},
+	"csr":       {"certificatesigningrequest"},
+	"ip":        {"ipaddress"},
+	"vac":       {"volumeattributesclass"},
+	"gitrepo":   {"gitrepository"},
+	"helmrepo":  {"helmrepository"},
+	"hr":        {"helmrelease"},
+	"imgpol":    {"imagepolicy"},
+	"imgrepo":   {"imagerepository"},
+	"imgupdate": {"imageupdateautomation"},
+	"ks":        {"kustomization"},
+	"ocirepo":   {"ocirepository"},
 }
 
 func kindNameCandidates(resource string) []string {

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubeversion "k8s.io/apimachinery/pkg/version"
 
 	"github.com/fluxcd/flux-schema/internal/tmpl"
 )
@@ -178,13 +179,24 @@ type catalogIndexKind struct {
 	Name     string
 	Versions []string
 	Kind     string
+	Resource catalogIndexResource
+}
+
+type catalogIndexResource struct {
+	Singular   string   `json:"s,omitempty"`
+	Plural     string   `json:"p,omitempty"`
+	ShortNames []string `json:"n,omitempty"`
 }
 
 type indexResource struct {
-	Group   string
-	Version string
-	Kind    string
-	Name    string
+	Group      string
+	Version    string
+	Kind       string
+	Name       string
+	Singular   string
+	Plural     string
+	ShortNames []string
+	order      int
 }
 
 func (k *catalogIndexKind) UnmarshalJSON(data []byte) error {
@@ -201,9 +213,14 @@ func (k *catalogIndexKind) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(tuple[1], &k.Versions); err != nil {
 		return fmt.Errorf("parse index kind versions: %w", err)
 	}
-	if len(tuple) >= 4 {
+	if len(tuple) >= 4 && string(tuple[3]) != "null" {
 		if err := json.Unmarshal(tuple[3], &k.Kind); err != nil {
 			return fmt.Errorf("parse index kind display name: %w", err)
+		}
+	}
+	if len(tuple) >= 5 {
+		if err := json.Unmarshal(tuple[4], &k.Resource); err != nil {
+			return fmt.Errorf("parse index kind resource names: %w", err)
 		}
 	}
 	if k.Kind == "" {
@@ -488,8 +505,13 @@ func (e *Explainer) loadResourceIndex(ctx context.Context) ([]indexResource, err
 			e.indexErr = fmt.Errorf("%s: parse catalog index: %w", location, err)
 			return nil, e.indexErr
 		}
-		e.indexResources = append(e.indexResources, index.resources()...)
+		resources := index.resources()
+		for i := range resources {
+			resources[i].order = len(e.indexResources) + i
+		}
+		e.indexResources = append(e.indexResources, resources...)
 	}
+	sortIndexResources(e.indexResources)
 	return e.indexResources, nil
 }
 
@@ -508,10 +530,13 @@ func (i catalogIndex) resources() []indexResource {
 						continue
 					}
 					out = append(out, indexResource{
-						Group:   strings.ToLower(strings.TrimSpace(group.Group)),
-						Version: version,
-						Kind:    kind.Kind,
-						Name:    name,
+						Group:      normalizeIndexGroup(group.Group),
+						Version:    version,
+						Kind:       kind.Kind,
+						Name:       name,
+						Singular:   strings.ToLower(strings.TrimSpace(kind.Resource.Singular)),
+						Plural:     strings.ToLower(strings.TrimSpace(kind.Resource.Plural)),
+						ShortNames: normalizedNames(kind.Resource.ShortNames),
 					})
 				}
 			}
@@ -525,7 +550,7 @@ func (r indexResource) target() resourceTarget {
 }
 
 func (r indexResource) canonicalName() string {
-	name := pluralResourceName(r.Name)
+	name := r.pluralName()
 	if r.Group == "" {
 		return name
 	}
@@ -564,15 +589,9 @@ func (r indexResource) aliases() []string {
 		seen[alias] = true
 		out = append(out, alias)
 	}
-	bases := []string{r.Name, strings.ToLower(r.Kind), pluralResourceName(r.Name)}
-	for short, candidates := range builtinResourceAliases {
-		for _, candidate := range candidates {
-			if candidate == r.Name {
-				bases = append(bases, short)
-				break
-			}
-		}
-	}
+	bases := make([]string, 0, 4+len(r.ShortNames))
+	bases = append(bases, r.Name, strings.ToLower(r.Kind), r.singularName(), r.pluralName())
+	bases = append(bases, r.ShortNames...)
 	for _, alias := range bases {
 		add(alias)
 		if r.Group != "" {
@@ -580,6 +599,93 @@ func (r indexResource) aliases() []string {
 		}
 	}
 	return out
+}
+
+func (r indexResource) singularName() string {
+	if r.Singular != "" {
+		return r.Singular
+	}
+	return r.Name
+}
+
+func (r indexResource) pluralName() string {
+	if r.Plural != "" {
+		return r.Plural
+	}
+	return pluralResourceName(r.Name)
+}
+
+func normalizeIndexGroup(group string) string {
+	group = strings.ToLower(strings.TrimSpace(group))
+	if group == "core" {
+		return ""
+	}
+	return group
+}
+
+func normalizedNames(names []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, name := range names {
+		name = strings.ToLower(strings.TrimSpace(name))
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	return out
+}
+
+func sortIndexResources(resources []indexResource) {
+	sort.SliceStable(resources, func(i, j int) bool {
+		return compareIndexResources(resources[i], resources[j]) < 0
+	})
+}
+
+func compareIndexResources(a, b indexResource) int {
+	if c := compareGroupPriority(a.Group, b.Group); c != 0 {
+		return c
+	}
+	if c := kubeversion.CompareKubeAwareVersionStrings(a.Version, b.Version); c != 0 {
+		if c > 0 {
+			return -1
+		}
+		return 1
+	}
+	if c := strings.Compare(strings.ToLower(a.Kind), strings.ToLower(b.Kind)); c != 0 {
+		return c
+	}
+	if c := strings.Compare(a.pluralName(), b.pluralName()); c != 0 {
+		return c
+	}
+	switch {
+	case a.order < b.order:
+		return -1
+	case a.order > b.order:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func compareGroupPriority(a, b string) int {
+	aRank, aGroup := groupPriority(a)
+	bRank, bGroup := groupPriority(b)
+	if aRank != bRank {
+		return aRank - bRank
+	}
+	return strings.Compare(aGroup, bGroup)
+}
+
+func groupPriority(group string) (int, string) {
+	group = normalizeIndexGroup(group)
+	for i, known := range kubernetesGroups {
+		if group == known {
+			return i, ""
+		}
+	}
+	return len(kubernetesGroups), group
 }
 
 func pluralResourceName(name string) string {
@@ -856,44 +962,36 @@ func isHTTPURL(s string) bool {
 }
 
 var builtinResourceAliases = map[string][]string{
-	"cm":        {"configmap"},
-	"cs":        {"componentstatus"},
-	"ep":        {"endpoints"},
-	"ev":        {"event"},
-	"limits":    {"limitrange"},
-	"ns":        {"namespace"},
-	"no":        {"node"},
-	"po":        {"pod"},
-	"pvc":       {"persistentvolumeclaim"},
-	"pv":        {"persistentvolume"},
-	"quota":     {"resourcequota"},
-	"rc":        {"replicationcontroller"},
-	"sa":        {"serviceaccount"},
-	"svc":       {"service"},
-	"crd":       {"customresourcedefinition"},
-	"crds":      {"customresourcedefinition"},
-	"deploy":    {"deployment"},
-	"ds":        {"daemonset"},
-	"rs":        {"replicaset"},
-	"sts":       {"statefulset"},
-	"hpa":       {"horizontalpodautoscaler"},
-	"cj":        {"cronjob"},
-	"ing":       {"ingress"},
-	"netpol":    {"networkpolicy"},
-	"pdb":       {"poddisruptionbudget"},
-	"pc":        {"priorityclass"},
-	"sc":        {"storageclass"},
-	"csr":       {"certificatesigningrequest"},
-	"ip":        {"ipaddress"},
-	"vac":       {"volumeattributesclass"},
-	"gitrepo":   {"gitrepository"},
-	"helmrepo":  {"helmrepository"},
-	"hr":        {"helmrelease"},
-	"imgpol":    {"imagepolicy"},
-	"imgrepo":   {"imagerepository"},
-	"imgupdate": {"imageupdateautomation"},
-	"ks":        {"kustomization"},
-	"ocirepo":   {"ocirepository"},
+	"cm":     {"configmap"},
+	"cs":     {"componentstatus"},
+	"ep":     {"endpoints"},
+	"ev":     {"event"},
+	"limits": {"limitrange"},
+	"ns":     {"namespace"},
+	"no":     {"node"},
+	"po":     {"pod"},
+	"pvc":    {"persistentvolumeclaim"},
+	"pv":     {"persistentvolume"},
+	"quota":  {"resourcequota"},
+	"rc":     {"replicationcontroller"},
+	"sa":     {"serviceaccount"},
+	"svc":    {"service"},
+	"crd":    {"customresourcedefinition"},
+	"crds":   {"customresourcedefinition"},
+	"deploy": {"deployment"},
+	"ds":     {"daemonset"},
+	"rs":     {"replicaset"},
+	"sts":    {"statefulset"},
+	"hpa":    {"horizontalpodautoscaler"},
+	"cj":     {"cronjob"},
+	"ing":    {"ingress"},
+	"netpol": {"networkpolicy"},
+	"pdb":    {"poddisruptionbudget"},
+	"pc":     {"priorityclass"},
+	"sc":     {"storageclass"},
+	"csr":    {"certificatesigningrequest"},
+	"ip":     {"ipaddress"},
+	"vac":    {"volumeattributesclass"},
 }
 
 func kindNameCandidates(resource string) []string {

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -52,9 +52,10 @@ const (
 	keyAddlProps  = "additionalProperties"
 	keyAllOf      = "allOf"
 
-	keyFluxSchemaType  = "x-flux-schema-type"
-	keyFluxSchemaGVK   = "x-flux-schema-group-version-kind"
-	keyFluxSchemaAlias = "x-flux-schema-alias"
+	keyFluxSchemaType            = "x-flux-schema-type"
+	keyFluxSchemaTypeDescription = "x-flux-schema-type-description"
+	keyFluxSchemaGVK             = "x-flux-schema-group-version-kind"
+	keyFluxSchemaAlias           = "x-flux-schema-alias"
 
 	maxAliasDepth = 8
 	typeObject    = "Object"
@@ -1437,6 +1438,9 @@ func typeNameV2(node map[string]any) string {
 	if branches := schemaList(node[keyAllOf]); len(branches) == 1 && len(schemaMap(node[keyProperties])) == 0 {
 		return typeNameV2(branches[0])
 	}
+	if name, ok := node[keyFluxSchemaType].(string); ok && name != "" {
+		return name
+	}
 	if t, ok := singleType(node); ok {
 		if t == "object" {
 			return typeObject
@@ -1456,9 +1460,10 @@ func appendDescription(out *strings.Builder, node map[string]any) {
 	if node == nil {
 		return
 	}
-	if desc, ok := node[keyDesc].(string); ok && desc != "" {
-		out.WriteString(desc)
-		out.WriteByte('\n')
+	desc, _ := node[keyDesc].(string)
+	appendDescriptionString(out, desc)
+	if typeDesc, ok := node[keyFluxSchemaTypeDescription].(string); ok && !sameDescription(desc, typeDesc) {
+		appendDescriptionString(out, typeDesc)
 	}
 	for _, branch := range schemaList(node[keyAllOf]) {
 		appendDescription(out, branch)
@@ -1469,6 +1474,18 @@ func appendDescription(out *strings.Builder, node map[string]any) {
 	if addl := schemaMap(node[keyAddlProps]); addl != nil {
 		appendDescription(out, addl)
 	}
+}
+
+func appendDescriptionString(out *strings.Builder, desc string) {
+	if desc == "" {
+		return
+	}
+	out.WriteString(desc)
+	out.WriteByte('\n')
+}
+
+func sameDescription(a, b string) bool {
+	return strings.TrimSpace(a) == strings.TrimSpace(b)
 }
 
 func schemaMap(v any) map[string]any {

--- a/internal/explain/explain_test.go
+++ b/internal/explain/explain_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package explain
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestEcosystemIndexResolveAndComplete(t *testing.T) {
+	g := NewWithT(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/index.json":
+			_, _ = fmt.Fprint(w, `{"v":2,"projects":[{"groups":[{"g":"helm.toolkit.fluxcd.io","kinds":[["helmrelease",["v2"],1,"HelmRelease"]]}]}]}`)
+		case "/catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json":
+			_, _ = fmt.Fprint(w, `{
+				"description":"HelmRelease is the Schema for the helmreleases API",
+				"properties":{
+					"apiVersion":{"type":"string"},
+					"kind":{"type":"string"},
+					"spec":{"type":"object","description":"HelmReleaseSpec defines the desired state of a Helm release."}
+				},
+				"type":"object"
+			}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	ex, err := New(Options{
+		SchemaLocations: []string{srv.URL + "/catalog/{{.Group}}/{{.Kind}}_{{.Version}}.json"},
+		IndexLocations:  []string{srv.URL + "/index.json"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	matches, err := ex.CompleteResourceNames(context.Background(), "hr")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(matches).To(Equal([]string{"helmreleases.helm.toolkit.fluxcd.io"}))
+
+	var out bytes.Buffer
+	g.Expect(ex.Explain(context.Background(), "hr.spec", &out)).To(Succeed())
+	g.Expect(out.String()).To(ContainSubstring("GROUP:      helm.toolkit.fluxcd.io\n"))
+	g.Expect(out.String()).To(ContainSubstring("KIND:       HelmRelease\n"))
+	g.Expect(out.String()).To(ContainSubstring("VERSION:    v2\n"))
+	g.Expect(out.String()).To(ContainSubstring("FIELD: spec <Object>\n"))
+
+	out.Reset()
+	g.Expect(ex.Explain(context.Background(), "helmreleases.helm.toolkit.fluxcd.io.spec", &out)).To(Succeed())
+	g.Expect(out.String()).To(ContainSubstring("KIND:       HelmRelease\n"))
+	g.Expect(out.String()).To(ContainSubstring("FIELD: spec <Object>\n"))
+}
+
+func TestCatalogIndexKindDecode(t *testing.T) {
+	g := NewWithT(t)
+
+	var kind catalogIndexKind
+	g.Expect(kind.UnmarshalJSON([]byte(`["ocirepository",["v1"],1,"OCIRepository"]`))).To(Succeed())
+	g.Expect(kind.Name).To(Equal("ocirepository"))
+	g.Expect(kind.Versions).To(Equal([]string{"v1"}))
+	g.Expect(kind.Kind).To(Equal("OCIRepository"))
+}

--- a/internal/explain/explain_test.go
+++ b/internal/explain/explain_test.go
@@ -20,7 +20,7 @@ func TestEcosystemIndexResolveAndComplete(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/index.json":
-			_, _ = fmt.Fprint(w, `{"v":2,"projects":[{"groups":[{"g":"helm.toolkit.fluxcd.io","kinds":[["helmrelease",["v2"],1,"HelmRelease"]]}]}]}`)
+			_, _ = fmt.Fprint(w, `{"v":3,"projects":[{"groups":[{"g":"helm.toolkit.fluxcd.io","kinds":[["helmrelease",["v2"],1,"HelmRelease",{"n":["hr"]}]]},{"g":"source.extensions.fluxcd.io","kinds":[["artifactgenerator",["v1beta1"],1,"ArtifactGenerator",{"n":["ag"]}]]}]}]}`)
 		case "/catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json":
 			_, _ = fmt.Fprint(w, `{
 				"description":"HelmRelease is the Schema for the helmreleases API",
@@ -28,6 +28,16 @@ func TestEcosystemIndexResolveAndComplete(t *testing.T) {
 					"apiVersion":{"type":"string"},
 					"kind":{"type":"string"},
 					"spec":{"type":"object","description":"HelmReleaseSpec defines the desired state of a Helm release."}
+				},
+				"type":"object"
+			}`)
+		case "/catalog/source.extensions.fluxcd.io/artifactgenerator_v1beta1.json":
+			_, _ = fmt.Fprint(w, `{
+				"description":"ArtifactGenerator is the Schema for the artifactgenerators API",
+				"properties":{
+					"apiVersion":{"type":"string"},
+					"kind":{"type":"string"},
+					"spec":{"type":"object","properties":{"pathPattern":{"type":"string","description":"PathPattern specifies a directory traversal pattern."}}}
 				},
 				"type":"object"
 			}`)
@@ -47,6 +57,10 @@ func TestEcosystemIndexResolveAndComplete(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(matches).To(Equal([]string{"helmreleases.helm.toolkit.fluxcd.io"}))
 
+	matches, err = ex.CompleteResourceNames(context.Background(), "ag")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(matches).To(Equal([]string{"artifactgenerators.source.extensions.fluxcd.io"}))
+
 	var out bytes.Buffer
 	g.Expect(ex.Explain(context.Background(), "hr.spec", &out)).To(Succeed())
 	g.Expect(out.String()).To(ContainSubstring("GROUP:      helm.toolkit.fluxcd.io\n"))
@@ -58,14 +72,109 @@ func TestEcosystemIndexResolveAndComplete(t *testing.T) {
 	g.Expect(ex.Explain(context.Background(), "helmreleases.helm.toolkit.fluxcd.io.spec", &out)).To(Succeed())
 	g.Expect(out.String()).To(ContainSubstring("KIND:       HelmRelease\n"))
 	g.Expect(out.String()).To(ContainSubstring("FIELD: spec <Object>\n"))
+
+	out.Reset()
+	g.Expect(ex.Explain(context.Background(), "ag.spec.pathPattern", &out)).To(Succeed())
+	g.Expect(out.String()).To(ContainSubstring("GROUP:      source.extensions.fluxcd.io\n"))
+	g.Expect(out.String()).To(ContainSubstring("KIND:       ArtifactGenerator\n"))
+	g.Expect(out.String()).To(ContainSubstring("FIELD: pathPattern <string>\n"))
+}
+
+func TestEcosystemIndexPrefersResourcePriority(t *testing.T) {
+	g := NewWithT(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/index.json":
+			_, _ = fmt.Fprint(w, `{"v":3,"projects":[{"groups":[{"g":"events.k8s.io","kinds":[["event",["v1"],1,"Event",{"n":["ev"]}]]},{"g":"core","kinds":[["event",["v1"],1,"Event",{"n":["ev"]}]]}]}]}`)
+		case "/catalog/core/event_v1.json":
+			_, _ = fmt.Fprint(w, `{
+				"description":"Core Event describes a cluster event.",
+				"properties":{"metadata":{"type":"object"}},
+				"type":"object"
+			}`)
+		case "/catalog/events.k8s.io/event_v1.json":
+			_, _ = fmt.Fprint(w, `{
+				"description":"Events API Event describes a cluster event.",
+				"properties":{"metadata":{"type":"object"}},
+				"type":"object"
+			}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	ex, err := New(Options{
+		SchemaLocations: []string{srv.URL + "/catalog/{{.Group}}/{{.Kind}}_{{.Version}}.json"},
+		IndexLocations:  []string{srv.URL + "/index.json"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	var out bytes.Buffer
+	g.Expect(ex.Explain(context.Background(), "events", &out)).To(Succeed())
+	g.Expect(out.String()).To(ContainSubstring("KIND:       Event\n"))
+	g.Expect(out.String()).To(ContainSubstring("VERSION:    v1\n"))
+	g.Expect(out.String()).To(ContainSubstring("Core Event describes a cluster event."))
+	g.Expect(out.String()).ToNot(ContainSubstring("GROUP:"))
+
+	out.Reset()
+	g.Expect(ex.Explain(context.Background(), "events.events.k8s.io", &out)).To(Succeed())
+	g.Expect(out.String()).To(ContainSubstring("GROUP:      events.k8s.io\n"))
+	g.Expect(out.String()).To(ContainSubstring("Events API Event describes a cluster event."))
+
+	exWithVersion, err := New(Options{
+		SchemaLocations: []string{srv.URL + "/catalog/{{.Group}}/{{.Kind}}_{{.Version}}.json"},
+		IndexLocations:  []string{srv.URL + "/index.json"},
+		APIVersion:      "events.k8s.io/v1",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	out.Reset()
+	g.Expect(exWithVersion.Explain(context.Background(), "ev", &out)).To(Succeed())
+	g.Expect(out.String()).To(ContainSubstring("GROUP:      events.k8s.io\n"))
+	g.Expect(out.String()).To(ContainSubstring("Events API Event describes a cluster event."))
+}
+
+func TestEcosystemIndexPrefersKubeAwareVersionPriority(t *testing.T) {
+	g := NewWithT(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/index.json":
+			_, _ = fmt.Fprint(w, `{"v":3,"projects":[{"groups":[{"g":"example.com","kinds":[["widget",["v1alpha1","v1beta1","v1"],1,"Widget"]]}]}]}`)
+		case "/catalog/example.com/widget_v1.json":
+			_, _ = fmt.Fprint(w, `{"description":"Widget v1.","properties":{},"type":"object"}`)
+		case "/catalog/example.com/widget_v1beta1.json":
+			_, _ = fmt.Fprint(w, `{"description":"Widget v1beta1.","properties":{},"type":"object"}`)
+		case "/catalog/example.com/widget_v1alpha1.json":
+			_, _ = fmt.Fprint(w, `{"description":"Widget v1alpha1.","properties":{},"type":"object"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	ex, err := New(Options{
+		SchemaLocations: []string{srv.URL + "/catalog/{{.Group}}/{{.Kind}}_{{.Version}}.json"},
+		IndexLocations:  []string{srv.URL + "/index.json"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	var out bytes.Buffer
+	g.Expect(ex.Explain(context.Background(), "widgets", &out)).To(Succeed())
+	g.Expect(out.String()).To(ContainSubstring("GROUP:      example.com\n"))
+	g.Expect(out.String()).To(ContainSubstring("VERSION:    v1\n"))
+	g.Expect(out.String()).To(ContainSubstring("Widget v1."))
 }
 
 func TestCatalogIndexKindDecode(t *testing.T) {
 	g := NewWithT(t)
 
 	var kind catalogIndexKind
-	g.Expect(kind.UnmarshalJSON([]byte(`["ocirepository",["v1"],1,"OCIRepository"]`))).To(Succeed())
+	g.Expect(kind.UnmarshalJSON([]byte(`["ocirepository",["v1"],1,"OCIRepository",{"n":["ocirepo"]}]`))).To(Succeed())
 	g.Expect(kind.Name).To(Equal("ocirepository"))
 	g.Expect(kind.Versions).To(Equal([]string{"v1"}))
 	g.Expect(kind.Kind).To(Equal("OCIRepository"))
+	g.Expect(kind.Resource.ShortNames).To(Equal([]string{"ocirepo"}))
 }

--- a/internal/explain/explain_test.go
+++ b/internal/explain/explain_test.go
@@ -9,10 +9,46 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
 )
+
+func TestRendererUsesExplainTypeMetadata(t *testing.T) {
+	g := NewWithT(t)
+
+	spec := map[string]any{
+		"type":                       "object",
+		"description":                "Spec configures the pod.",
+		keyFluxSchemaType:            "PodSpec",
+		keyFluxSchemaTypeDescription: "PodSpec is a description of a pod.",
+		"properties":                 map[string]any{},
+	}
+	root := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"spec": spec,
+		},
+	}
+
+	var out bytes.Buffer
+	r := renderer{w: &out, format: OutputPlaintext}
+	g.Expect(r.render(&resolvedSchema{Root: root, Kind: "Pod", Version: "v1"}, []string{"spec"})).To(Succeed())
+	g.Expect(out.String()).To(ContainSubstring("FIELD: spec <PodSpec>\n"))
+	g.Expect(out.String()).To(ContainSubstring("Spec configures the pod."))
+	g.Expect(out.String()).To(ContainSubstring("PodSpec is a description of a pod."))
+	g.Expect(typeNameV2(spec)).To(Equal("PodSpec"))
+
+	arrayNode := map[string]any{
+		"description": "List of containers.",
+		"items": map[string]any{
+			"description":                "Container describes a single container.",
+			keyFluxSchemaTypeDescription: "Container describes a single container.",
+		},
+	}
+	g.Expect(strings.Count(descriptionText(arrayNode), "Container describes a single container.")).To(Equal(1))
+}
 
 func TestEcosystemIndexResolveAndComplete(t *testing.T) {
 	g := NewWithT(t)

--- a/internal/extractor/kubernetes_test.go
+++ b/internal/extractor/kubernetes_test.go
@@ -139,7 +139,8 @@ func TestExtractKubernetes_InlinesRef(t *testing.T) {
 	doc := map[string]any{
 		"definitions": map[string]any{
 			"example.v1.Helper": map[string]any{
-				"type": "object",
+				"type":        "object",
+				"description": "Helper defines nested widget settings.",
 				"properties": map[string]any{
 					"name": map[string]any{"type": "string"},
 				},
@@ -147,7 +148,10 @@ func TestExtractKubernetes_InlinesRef(t *testing.T) {
 			"example.v1.Widget": map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"helper": map[string]any{"$ref": "#/definitions/example.v1.Helper"},
+					"helper": map[string]any{
+						"$ref":        "#/definitions/example.v1.Helper",
+						"description": "Helper configures the widget.",
+					},
 				},
 				"required": []any{"helper"},
 				"x-kubernetes-group-version-kind": []any{
@@ -174,8 +178,10 @@ func TestExtractKubernetes_InlinesRef(t *testing.T) {
 
 	helper := props["helper"].(map[string]any)
 	g.Expect(helper["type"]).To(Equal("object"))
+	g.Expect(helper["description"]).To(Equal("Helper configures the widget."))
 	g.Expect(helper).To(HaveKey("properties"))
 	g.Expect(helper[keyFluxSchemaType]).To(Equal("Helper"))
+	g.Expect(helper[keyFluxSchemaTypeDescription]).To(Equal("Helper defines nested widget settings."))
 }
 
 func TestExtractKubernetes_CoreGroupKept(t *testing.T) {

--- a/internal/extractor/transformers.go
+++ b/internal/extractor/transformers.go
@@ -18,6 +18,7 @@ import (
 
 const keyProperties = "properties"
 const keyFluxSchemaType = "x-flux-schema-type"
+const keyFluxSchemaTypeDescription = "x-flux-schema-type-description"
 const keyFluxSchemaGVK = "x-flux-schema-group-version-kind"
 const keyFluxSchemaResource = "x-flux-schema-resource"
 
@@ -100,6 +101,9 @@ func resolveRef(node map[string]any, refVal string, defs map[string]any, visitin
 	if _, ok := m[keyFluxSchemaType]; !ok {
 		m[keyFluxSchemaType] = shortDefinitionName(name)
 	}
+	if desc, ok := definitionDescription(target); ok {
+		m[keyFluxSchemaTypeDescription] = desc
+	}
 	return overlaySiblings(m, node)
 }
 
@@ -136,6 +140,15 @@ func shortDefinitionName(name string) string {
 		return name[i+1:]
 	}
 	return name
+}
+
+func definitionDescription(def any) (string, bool) {
+	m, ok := def.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	desc, ok := m["description"].(string)
+	return desc, ok && desc != ""
 }
 
 // unresolvedPlaceholder returns a stand-in object used by resolveRef when a
@@ -497,13 +510,26 @@ func keepVendorExtension(k string) bool {
 
 // --- explain metadata stripping ---
 
-// StripExplainMetadata removes flux-schema explain annotations from the tree.
-// The annotations are useful for `flux schema explain`, but are opt-in for
-// catalogs because they are documentation-only and increase schema size.
+// StripExplainMetadata removes all flux-schema explain annotations from the
+// tree. The annotations are useful for `flux schema explain`, but are opt-in
+// for catalogs because they are documentation-only and increase schema size.
 func StripExplainMetadata(node any) {
+	stripExplainMetadata(node, true)
+}
+
+// StripExplainLookupMetadata removes resource lookup annotations while keeping
+// type annotations used to render kubectl-style field type names.
+func StripExplainLookupMetadata(node any) {
+	stripExplainMetadata(node, false)
+}
+
+func stripExplainMetadata(node any, stripTypes bool) {
 	switch n := node.(type) {
 	case map[string]any:
-		delete(n, keyFluxSchemaType)
+		if stripTypes {
+			delete(n, keyFluxSchemaType)
+			delete(n, keyFluxSchemaTypeDescription)
+		}
 		delete(n, keyFluxSchemaGVK)
 		delete(n, keyFluxSchemaResource)
 		delete(n, KeyFluxSchemaAlias)
@@ -511,16 +537,16 @@ func StripExplainMetadata(node any) {
 			if isSchemaNameMap(k) {
 				if m, ok := v.(map[string]any); ok {
 					for _, child := range m {
-						StripExplainMetadata(child)
+						stripExplainMetadata(child, stripTypes)
 					}
 					continue
 				}
 			}
-			StripExplainMetadata(v)
+			stripExplainMetadata(v, stripTypes)
 		}
 	case []any:
 		for _, v := range n {
-			StripExplainMetadata(v)
+			stripExplainMetadata(v, stripTypes)
 		}
 	}
 }
@@ -541,6 +567,7 @@ func StripDescriptions(node any) {
 	switch n := node.(type) {
 	case map[string]any:
 		delete(n, "description")
+		delete(n, keyFluxSchemaTypeDescription)
 		for k, v := range n {
 			if isSchemaNameMap(k) {
 				if m, ok := v.(map[string]any); ok {

--- a/internal/flags/extract.go
+++ b/internal/flags/extract.go
@@ -11,12 +11,13 @@ const DefaultExtractFormat = "{{ .Group }}/{{ .Kind }}_{{ .Version }}.json"
 // ExtractOutput holds the output-shaping flags that
 // are identical across `extract k8s` and `extract crd`.
 type ExtractOutput struct {
-	Dir                 string
-	Format              string
-	StripDescription    bool
-	WithFieldIndex      bool
-	WithExplainMetadata bool
-	IndexSource         string
+	Dir                     string
+	Format                  string
+	StripDescription        bool
+	WithFieldIndex          bool
+	WithExplainTypeMetadata bool
+	WithExplainMetadata     bool
+	IndexSource             string
 }
 
 // NewExtractOutput returns an ExtractOutput populated with the default values
@@ -43,8 +44,10 @@ func (e *ExtractOutput) Register(cmd *cobra.Command) {
 		"also write a .fields.txt field index next to each schema: one greppable line "+
 			"per field with its dotted path, type, constraints, and description; "+
 			"map values are addressed as path.<key>.field")
+	cmd.Flags().BoolVar(&e.WithExplainTypeMetadata, "with-explain-type-metadata", e.WithExplainTypeMetadata,
+		"include x-flux-schema type annotations in JSON Schemas without writing explain lookup files")
 	cmd.Flags().BoolVar(&e.WithExplainMetadata, "with-explain-metadata", e.WithExplainMetadata,
-		"include x-flux-schema annotations used by explain to print exact kind and type names")
+		"include full explain metadata: JSON annotations, alias redirects, and .explain lookup files")
 	cmd.Flags().StringVar(&e.IndexSource, "index-source", e.IndexSource,
 		"source name and version recorded in the field index header, overriding auto-detection "+
 			"(e.g. 'my-operator v1.2.3')")

--- a/internal/validator/defaults.go
+++ b/internal/validator/defaults.go
@@ -9,13 +9,19 @@ package validator
 // to in the validate CLI's --schema-location flag.
 const DefaultSchemaLocation = "https://raw.githubusercontent.com/fluxcd/flux-schema/main/catalog/latest/" + DefaultSchemaLayout
 
-// EcosystemSchemaLocation points at the CNCF ecosystem catalog hosted at
+// EcosystemSchemaBase points at the CNCF ecosystem catalog hosted at
 // https://schemas.fluxoperator.dev, covering Kubernetes core and the CRDs of
 // CNCF ecosystem projects, extracted from upstream releases and rebuilt daily.
-// Unlike the built-in catalog, its schemas preserve field descriptions. It is
-// the target that the literal value "ecosystem" resolves to in the
-// --schema-location flag.
-const EcosystemSchemaLocation = "https://schemas.fluxoperator.dev/catalog/" + DefaultSchemaLayout
+// Unlike the built-in catalog, its schemas preserve field descriptions.
+const EcosystemSchemaBase = "https://schemas.fluxoperator.dev/catalog"
+
+// EcosystemSchemaLocation is the schema template that the literal value
+// "ecosystem" resolves to in the --schema-location flag.
+const EcosystemSchemaLocation = EcosystemSchemaBase + "/" + DefaultSchemaLayout
+
+// EcosystemIndexLocation is the compact resource index used by explain for
+// resource lookup and shell completion against the ecosystem catalog.
+const EcosystemIndexLocation = "https://schemas.fluxoperator.dev/index.json"
 
 // DefaultSchemaLayout is the Go-template tail appended to any schema location
 // value that doesn't already end in ".json", so a bare path/URL like


### PR DESCRIPTION
Adds ecosystem index support for `flux schema explain -s ecosystem`.

- Uses the ecosystem `index.json` for resource lookup and completion instead of `.explain/` files.
- Resolves kind, plural, full resource name, and short-name references from compact v3 metadata; v2 index data still supports kind/plural fallback.
- Sorts duplicate matches by Kubernetes group priority and kube-aware API version priority; `--api-version` disambiguates.
- Adds `extract --with-explain-type-metadata`, a JSON-only subset of `--with-explain-metadata` for catalogs whose lookup/completion comes from an external index. Full `--with-explain-metadata` remains the standalone catalog mode with aliases and `.explain/` files.
- Uses schema-local type metadata to render named field types and referenced type descriptions.

Tests: `make test`, `make lint`.
