### PR TITLE
Fix explain v2 formatting

### DIFF
--- a/cmd/flux-schema/explain_test.go
+++ b/cmd/flux-schema/explain_test.go
@@ -83,7 +83,7 @@ func TestExplainCmd_OpenAPIV2Output(t *testing.T) {
 		"--schema-location", filepath.Join("testdata", "explain", "catalog"),
 	})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(out).To(HavePrefix("KIND:     Pod\n" +
+	g.Expect(out).To(Equal("KIND:     Pod\n" +
 		"VERSION:  v1\n" +
 		"\n" +
 		"RESOURCE: spec <PodSpec>\n" +
@@ -92,7 +92,9 @@ func TestExplainCmd_OpenAPIV2Output(t *testing.T) {
 		"     Specification of the desired behavior of the pod.\n" +
 		"\n" +
 		"FIELDS:\n" +
-		"   containers\t<[]Container> -required-\n"))
+		"   containers\t<[]Container> -required-\n" +
+		"     List of containers belonging to the pod.\n" +
+		"\n"))
 }
 
 func TestExplainCmd_Recursive(t *testing.T) {

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -1066,6 +1066,9 @@ func (r renderer) render(resolved *resolvedSchema, fields []string) error {
 	if err := r.renderOutput(resolved.Root, fields); err != nil {
 		return err
 	}
+	if r.openAPIV2() {
+		return nil
+	}
 	_, err := fmt.Fprintln(r.w)
 	return err
 }
@@ -1126,6 +1129,9 @@ func (r renderer) renderOutputV2(node map[string]any, fields []string) error {
 		if len(fieldList) == 0 {
 			return nil
 		}
+		if _, err := fmt.Fprintln(r.w); err != nil {
+			return err
+		}
 		if _, err := fmt.Fprintln(r.w, "FIELDS:"); err != nil {
 			return err
 		}
@@ -1171,6 +1177,9 @@ func (r renderer) renderFieldV2(name string, node map[string]any) error {
 		if len(fieldList) == 0 {
 			return nil
 		}
+		if _, err := fmt.Fprintln(r.w); err != nil {
+			return err
+		}
 		if _, err := fmt.Fprintln(r.w, "FIELDS:"); err != nil {
 			return err
 		}
@@ -1187,17 +1196,23 @@ func (r renderer) writeDescriptionV2(node map[string]any) error {
 	if _, err := fmt.Fprintln(r.w, "DESCRIPTION:"); err != nil {
 		return err
 	}
-	desc := strings.TrimSuffix(descriptionText(node), "\n")
-	if desc == "" {
-		desc = "<empty>"
+	sections := descriptionSectionsV2(node)
+	if len(sections) == 0 {
+		sections = []string{"<empty>"}
 	}
-	for _, line := range wrapString(desc, 75) {
-		if _, err := fmt.Fprintf(r.w, "     %s\n", line); err != nil {
-			return err
+	for i, desc := range sections {
+		if i > 0 {
+			if _, err := fmt.Fprintln(r.w); err != nil {
+				return err
+			}
+		}
+		for _, line := range wrapString(desc, 75) {
+			if _, err := fmt.Fprintf(r.w, "     %s\n", line); err != nil {
+				return err
+			}
 		}
 	}
-	_, err := fmt.Fprintln(r.w)
-	return err
+	return nil
 }
 
 func (r renderer) writeFieldHeader(name string, node map[string]any) error {
@@ -1448,6 +1463,40 @@ func typeNameV2(node map[string]any) string {
 		return t
 	}
 	return typeObject
+}
+
+func descriptionSectionsV2(node map[string]any) []string {
+	var sections []string
+	appendDescriptionSectionsV2(&sections, node)
+	return sections
+}
+
+func appendDescriptionSectionsV2(sections *[]string, node map[string]any) {
+	if node == nil {
+		return
+	}
+	desc, _ := node[keyDesc].(string)
+	appendDescriptionSection(sections, desc)
+	if typeDesc, ok := node[keyFluxSchemaTypeDescription].(string); ok && !sameDescription(desc, typeDesc) {
+		appendDescriptionSection(sections, typeDesc)
+	}
+	for _, branch := range schemaList(node[keyAllOf]) {
+		appendDescriptionSectionsV2(sections, branch)
+	}
+	if items := schemaMap(node[keyItems]); items != nil {
+		appendDescriptionSectionsV2(sections, items)
+	}
+	if addl := schemaMap(node[keyAddlProps]); addl != nil {
+		appendDescriptionSectionsV2(sections, addl)
+	}
+}
+
+func appendDescriptionSection(sections *[]string, desc string) {
+	desc = strings.TrimSuffix(desc, "\n")
+	if desc == "" {
+		return
+	}
+	*sections = append(*sections, desc)
 }
 
 func descriptionText(node map[string]any) string {

--- a/internal/explain/explain_test.go
+++ b/internal/explain/explain_test.go
@@ -50,6 +50,64 @@ func TestRendererUsesExplainTypeMetadata(t *testing.T) {
 	g.Expect(strings.Count(descriptionText(arrayNode), "Container describes a single container.")).To(Equal(1))
 }
 
+func TestRendererOpenAPIV2DescriptionSpacing(t *testing.T) {
+	g := NewWithT(t)
+
+	primitive := map[string]any{
+		"type":                       "object",
+		"description":                "Spec configures the pod.",
+		keyFluxSchemaType:            "PodSpec",
+		keyFluxSchemaTypeDescription: "PodSpec is a description of a pod.",
+	}
+	root := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"spec": primitive,
+		},
+	}
+
+	var out bytes.Buffer
+	r := renderer{w: &out, format: OutputPlaintextOpenAPIV2}
+	g.Expect(r.render(&resolvedSchema{Root: root, Kind: "Pod", Version: "v1"}, []string{"spec"})).To(Succeed())
+	g.Expect(out.String()).To(Equal("KIND:     Pod\n" +
+		"VERSION:  v1\n" +
+		"\n" +
+		"FIELD:    spec <PodSpec>\n" +
+		"\n" +
+		"DESCRIPTION:\n" +
+		"     Spec configures the pod.\n" +
+		"\n" +
+		"     PodSpec is a description of a pod.\n"))
+
+	resource := map[string]any{
+		"type":                       "object",
+		"description":                "Spec configures the pod.",
+		keyFluxSchemaType:            "PodSpec",
+		keyFluxSchemaTypeDescription: "PodSpec is a description of a pod.",
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string", "description": "Name of the pod."},
+		},
+	}
+	root["properties"].(map[string]any)["spec"] = resource
+
+	out.Reset()
+	g.Expect(r.render(&resolvedSchema{Root: root, Kind: "Pod", Version: "v1"}, []string{"spec"})).To(Succeed())
+	g.Expect(out.String()).To(Equal("KIND:     Pod\n" +
+		"VERSION:  v1\n" +
+		"\n" +
+		"RESOURCE: spec <PodSpec>\n" +
+		"\n" +
+		"DESCRIPTION:\n" +
+		"     Spec configures the pod.\n" +
+		"\n" +
+		"     PodSpec is a description of a pod.\n" +
+		"\n" +
+		"FIELDS:\n" +
+		"   name\t<string>\n" +
+		"     Name of the pod.\n" +
+		"\n"))
+}
+
 func TestEcosystemIndexResolveAndComplete(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
Fixes the remaining explain formatting gaps for the legacy `plaintext-openapiv2` output path.

- Separates collected descriptions with kubectl-style blank lines.
- Avoids adding a trailing blank line after scalar field descriptions.
- Emits the blank line before `FIELDS:` only when a field list follows.
- Tightens regression tests to exact output strings.

Tests: `make test`, `make lint`.
