### PR TITLE
Complete explain field paths

### DIFF
--- a/cmd/flux-schema/explain.go
+++ b/cmd/flux-schema/explain.go
@@ -97,7 +97,7 @@ func completeExplainResourceRefs(cmd *cobra.Command, args []string, toComplete s
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	matches, err := ex.CompleteResourceNames(cmd.Context(), toComplete)
+	matches, err := ex.CompleteReferences(cmd.Context(), toComplete)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/cmd/flux-schema/explain_test.go
+++ b/cmd/flux-schema/explain_test.go
@@ -232,6 +232,11 @@ func TestExplainCmd_CompleteResourceReferences(t *testing.T) {
 	g.Expect(out).To(ContainSubstring("helmreleases.helm.toolkit.fluxcd.io\n"))
 	g.Expect(out).To(ContainSubstring(":4"))
 
+	out, err = executeCommand([]string{"__complete", "explain", "--schema-location", catalog, "helmreleases.helm.toolkit.fluxcd.io.s"})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("helmreleases.helm.toolkit.fluxcd.io.spec\n"))
+	g.Expect(out).To(ContainSubstring(":4"))
+
 	out, err = executeCommand([]string{"__complete", "explain", "--schema-location", catalog, "p"})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(out).To(ContainSubstring("pods\n"))
@@ -240,6 +245,17 @@ func TestExplainCmd_CompleteResourceReferences(t *testing.T) {
 	out, err = executeCommand([]string{"__complete", "explain", "--schema-location", catalog, "po"})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(out).To(ContainSubstring("pods\n"))
+	g.Expect(out).To(ContainSubstring(":4"))
+
+	out, err = executeCommand([]string{"__complete", "explain", "--schema-location", catalog, "po.s"})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("po.spec\n"))
+	g.Expect(out).To(ContainSubstring("po.status\n"))
+	g.Expect(out).To(ContainSubstring(":4"))
+
+	out, err = executeCommand([]string{"__complete", "explain", "--schema-location", catalog, "po.spec.co"})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("po.spec.containers\n"))
 	g.Expect(out).To(ContainSubstring(":4"))
 }
 

--- a/docs/custom-schema-catalog.md
+++ b/docs/custom-schema-catalog.md
@@ -229,17 +229,18 @@ field render hints that are otherwise lost when OpenAPI `$ref` definitions
 are inlined, such as named nested types (`Container`, `Quantity`,
 `IntOrString`) and referenced type descriptions. Pass
 `--with-explain-type-metadata` when another index provides resource lookup and
-completion. This is the ecosystem catalog mode used with
+resource-name completion. This is the ecosystem catalog mode used with
 `--schema-location ecosystem`, where `explain` resolves resources from
-`https://schemas.fluxoperator.dev/index.json` and only needs the loaded JSON
-schema to print kubectl-style field output.
+`https://schemas.fluxoperator.dev/index.json` and uses the loaded JSON schema for
+kubectl-style field output and field-path completion.
 
 Standalone explain metadata includes the schema-local type metadata plus the
 lookup files needed when there is no separate ecosystem index: alias redirect
 JSON files, `.explain/refs/`, and `.explain/completion/`. Pass
 `--with-explain-metadata` for custom catalogs that should support
-`flux schema explain` resource references and shell completion on their own.
-This flag is a superset of `--with-explain-type-metadata`.
+`flux schema explain` resource references and resource-name shell completion on
+their own. Field-path completion is derived from the resolved JSON Schema. This
+flag is a superset of `--with-explain-type-metadata`.
 
 `--with-field-index` is separate. It writes `.fields.txt` sidecars for
 search, agents, and other catalog consumers. `explain` does not use field

--- a/docs/explain.md
+++ b/docs/explain.md
@@ -58,9 +58,13 @@ resource names, and short names are resolved from sharded metadata under
 `.explain/refs/` when custom catalogs provide it. For the `ecosystem` catalog,
 `explain` uses the hosted `https://schemas.fluxoperator.dev/index.json` to
 resolve resource references and provide shell completion without fetching
-thousands of per-resource metadata files. Completion suggests the canonical
-resource name (`plural.group`, or `plural` for core resources) for all indexed
-resources matching the typed prefix.
+thousands of per-resource metadata files. Resource completion suggests the
+canonical resource name (`plural.group`, or `plural` for core resources) for all
+indexed resources matching the typed prefix. Field completion resolves the typed
+resource reference, fetches that schema, and suggests matching child field paths
+while preserving the resource reference the user typed. Loaded schemas and
+not-found lookups are cached in memory for the life of the process; no disk
+cache is written.
 
 When `--api-version` is set, dotted group suffixes are treated like kubectl:
 the first path segment is the resource name and the remaining segments are
@@ -75,10 +79,11 @@ segments after the resource as an API group, then falls back to field lookup.
 
 The hosted `ecosystem` catalog is special. `flux schema explain -s ecosystem`
 uses `https://schemas.fluxoperator.dev/index.json` for resource lookup and
-shell completion, then fetches only the schema JSON needed for the requested
-resource. Because the index already provides plural names, short names, full
-resource names, and completion candidates, the catalog does not need alias
-redirect files or a `.explain/` tree.
+resource-name completion. Field completion and command output fetch only the
+schema JSON needed for the resolved resource. Because the index already provides
+plural names, short names, full resource names, and resource completion
+candidates, the catalog does not need alias redirect files or a `.explain/`
+tree.
 
 Schemas used with this mode should be generated with JSON-only explain type
 metadata:

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -98,6 +98,8 @@ var versionCandidates = []string{
 	"v2alpha1",
 }
 
+var errResourceNotFound = errors.New("couldn't find resource")
+
 type Options struct {
 	SchemaLocations       []string
 	MetadataLocations     []string
@@ -115,9 +117,15 @@ type Explainer struct {
 	templates []*template.Template
 	client    *retryablehttp.Client
 
+	byteCache      map[string]byteCacheEntry
 	indexLoaded    bool
 	indexResources []indexResource
 	indexErr       error
+}
+
+type byteCacheEntry struct {
+	body  []byte
+	found bool
 }
 
 type resolvedSchema struct {
@@ -252,7 +260,7 @@ func New(opts Options) (*Explainer, error) {
 		}
 	}
 	opts.SchemaLocations = locations
-	return &Explainer{opts: opts, templates: compiled, client: client}, nil
+	return &Explainer{opts: opts, templates: compiled, client: client, byteCache: map[string]byteCacheEntry{}}, nil
 }
 
 func (e *Explainer) Explain(ctx context.Context, resourceExpr string, w io.Writer) error {
@@ -312,6 +320,220 @@ func (e *Explainer) CompleteResourceNames(ctx context.Context, prefix string) ([
 	}
 	sort.Strings(out)
 	return out, nil
+}
+
+// CompleteReferences returns completion candidates for resource references and
+// field paths. Resource candidates are canonical resource names; field
+// candidates preserve the resource reference typed by the user.
+func (e *Explainer) CompleteReferences(ctx context.Context, prefix string) ([]string, error) {
+	if !strings.Contains(prefix, ".") {
+		return e.CompleteResourceNames(ctx, prefix)
+	}
+	matches, err := e.completeFieldNames(ctx, prefix)
+	if err != nil {
+		return nil, err
+	}
+	if len(matches) > 0 {
+		return matches, nil
+	}
+	return e.CompleteResourceNames(ctx, prefix)
+}
+
+func (e *Explainer) completeFieldNames(ctx context.Context, prefix string) ([]string, error) {
+	prefix = strings.TrimSpace(prefix)
+	seen := map[string]bool{}
+	var out []string
+	for _, split := range fieldCompletionSplits(prefix) {
+		resolved, found, err := e.resolveResourceOnly(ctx, split.resource)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			continue
+		}
+		names := completeFieldPath(resolved.Root, split.fields)
+		for _, name := range names {
+			match := split.resource + "." + name
+			if seen[match] {
+				continue
+			}
+			seen[match] = true
+			out = append(out, match)
+		}
+		if len(out) > 0 {
+			sort.Strings(out)
+			return out, nil
+		}
+	}
+	return nil, nil
+}
+
+type fieldCompletionSplit struct {
+	resource string
+	fields   string
+}
+
+func fieldCompletionSplits(expr string) []fieldCompletionSplit {
+	var out []fieldCompletionSplit
+	for i := len(expr) - 1; i >= 0; i-- {
+		if expr[i] != '.' {
+			continue
+		}
+		resource := strings.TrimSpace(expr[:i])
+		if resource == "" {
+			continue
+		}
+		out = append(out, fieldCompletionSplit{
+			resource: resource,
+			fields:   strings.TrimSpace(expr[i+1:]),
+		})
+	}
+	return out
+}
+
+func (e *Explainer) resolveResourceOnly(ctx context.Context, resourceExpr string) (*resolvedSchema, bool, error) {
+	gv, hasGV, err := parseAPIVersion(e.opts.APIVersion)
+	if err != nil {
+		return nil, false, err
+	}
+	candidates, err := parseResourceOnlyExpression(resourceExpr, hasGV)
+	if err != nil {
+		return nil, false, nil
+	}
+	if len(candidates) == 0 {
+		return nil, false, nil
+	}
+	if len(e.opts.IndexLocations) > 0 {
+		for _, candidate := range candidates {
+			resolved, found, err := e.resolveFromReferences(ctx, candidate, gv, hasGV)
+			if err != nil {
+				return nil, false, err
+			}
+			if found {
+				return resolved, true, nil
+			}
+		}
+		return nil, false, nil
+	}
+	resolved, fields, err := e.resolve(ctx, candidates, gv, hasGV)
+	if errors.Is(err, errResourceNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	if len(fields) > 0 {
+		return nil, false, nil
+	}
+	return resolved, true, nil
+}
+
+func parseResourceOnlyExpression(expr string, apiVersionSet bool) ([]requestCandidate, error) {
+	expr = strings.TrimSuffix(strings.TrimSpace(expr), ".")
+	if expr == "" {
+		return nil, nil
+	}
+	parts := strings.Split(expr, ".")
+	for _, part := range parts {
+		if part == "" {
+			return nil, fmt.Errorf("invalid jsonpath syntax, all nodes must be field nodes")
+		}
+	}
+	if apiVersionSet || len(parts) == 1 {
+		return []requestCandidate{{resource: parts[0]}}, nil
+	}
+	group := strings.Join(parts[1:], ".")
+	if !looksLikeAPIGroup(group) {
+		return nil, nil
+	}
+	return []requestCandidate{{resource: parts[0], group: group}}, nil
+}
+
+func completeFieldPath(root map[string]any, fieldExpr string) []string {
+	parts := strings.Split(fieldExpr, ".")
+	parent := parts[:len(parts)-1]
+	partial := parts[len(parts)-1]
+	if fieldExpr == "" {
+		parent = nil
+		partial = ""
+	}
+	for _, name := range parent {
+		if name == "" {
+			return nil
+		}
+		root = fieldChild(root, name)
+		if root == nil {
+			return nil
+		}
+	}
+	names := fieldPropertyNames(root)
+	var out []string
+	for _, name := range names {
+		if !strings.HasPrefix(name, partial) {
+			continue
+		}
+		if len(parent) > 0 {
+			name = strings.Join(append(slices.Clone(parent), name), ".")
+		}
+		out = append(out, name)
+	}
+	return out
+}
+
+func fieldChild(node map[string]any, name string) map[string]any {
+	if node == nil {
+		return nil
+	}
+	if props := schemaMap(node[keyProperties]); len(props) > 0 {
+		if child := schemaMap(props[name]); child != nil {
+			return child
+		}
+	}
+	if items := schemaMap(node[keyItems]); items != nil {
+		if child := fieldChild(items, name); child != nil {
+			return child
+		}
+	}
+	if addl := schemaMap(node[keyAddlProps]); addl != nil {
+		if child := fieldChild(addl, name); child != nil {
+			return child
+		}
+	}
+	for _, branch := range schemaList(node[keyAllOf]) {
+		if child := fieldChild(branch, name); child != nil {
+			return child
+		}
+	}
+	return nil
+}
+
+func fieldPropertyNames(node map[string]any) []string {
+	seen := map[string]bool{}
+	collectFieldPropertyNames(node, seen)
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func collectFieldPropertyNames(node map[string]any, seen map[string]bool) {
+	if node == nil {
+		return
+	}
+	for name := range schemaMap(node[keyProperties]) {
+		seen[name] = true
+	}
+	for _, branch := range schemaList(node[keyAllOf]) {
+		collectFieldPropertyNames(branch, seen)
+	}
+	if items := schemaMap(node[keyItems]); items != nil {
+		collectFieldPropertyNames(items, seen)
+	}
+	if addl := schemaMap(node[keyAddlProps]); addl != nil {
+		collectFieldPropertyNames(addl, seen)
+	}
 }
 
 func parseAPIVersion(apiVersion string) (schema.GroupVersion, bool, error) {
@@ -395,9 +617,9 @@ func (e *Explainer) resolve(ctx context.Context, requests []requestCandidate, gv
 		}
 	}
 	if len(attempted) > 0 {
-		return nil, nil, fmt.Errorf("couldn't find resource for %q", attempted[0])
+		return nil, nil, fmt.Errorf("%w for %q", errResourceNotFound, attempted[0])
 	}
-	return nil, nil, errors.New("couldn't find resource")
+	return nil, nil, errResourceNotFound
 }
 
 func (e *Explainer) resolveFromReferences(ctx context.Context, req requestCandidate, gv schema.GroupVersion, hasGV bool) (*resolvedSchema, bool, error) {
@@ -898,6 +1120,21 @@ func parseFieldIndexMetadata(data string) fieldIndexMetadata {
 }
 
 func (e *Explainer) loadBytes(ctx context.Context, location string) ([]byte, bool, error) {
+	if e.byteCache == nil {
+		e.byteCache = map[string]byteCacheEntry{}
+	}
+	if cached, ok := e.byteCache[location]; ok {
+		return slices.Clone(cached.body), cached.found, nil
+	}
+	body, found, err := e.loadBytesUncached(ctx, location)
+	if err != nil {
+		return nil, false, err
+	}
+	e.byteCache[location] = byteCacheEntry{body: slices.Clone(body), found: found}
+	return body, found, nil
+}
+
+func (e *Explainer) loadBytesUncached(ctx context.Context, location string) ([]byte, bool, error) {
 	if isHTTPURL(location) {
 		return e.loadHTTP(ctx, location)
 	}

--- a/internal/explain/explain_test.go
+++ b/internal/explain/explain_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -111,17 +112,22 @@ func TestRendererOpenAPIV2DescriptionSpacing(t *testing.T) {
 func TestEcosystemIndexResolveAndComplete(t *testing.T) {
 	g := NewWithT(t)
 
+	var helmReleaseRequests int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/index.json":
 			_, _ = fmt.Fprint(w, `{"v":3,"projects":[{"groups":[{"g":"helm.toolkit.fluxcd.io","kinds":[["helmrelease",["v2"],1,"HelmRelease",{"n":["hr"]}]]},{"g":"source.extensions.fluxcd.io","kinds":[["artifactgenerator",["v1beta1"],1,"ArtifactGenerator",{"n":["ag"]}]]}]}]}`)
 		case "/catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json":
+			atomic.AddInt32(&helmReleaseRequests, 1)
 			_, _ = fmt.Fprint(w, `{
 				"description":"HelmRelease is the Schema for the helmreleases API",
 				"properties":{
 					"apiVersion":{"type":"string"},
 					"kind":{"type":"string"},
-					"spec":{"type":"object","description":"HelmReleaseSpec defines the desired state of a Helm release."}
+					"spec":{"type":"object","description":"HelmReleaseSpec defines the desired state of a Helm release.","properties":{
+						"chart":{"type":"object","description":"Chart defines the chart template."},
+						"chartRef":{"type":"object","description":"ChartRef defines the chart source."}
+					}}
 				},
 				"type":"object"
 			}`)
@@ -155,6 +161,25 @@ func TestEcosystemIndexResolveAndComplete(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(matches).To(Equal([]string{"artifactgenerators.source.extensions.fluxcd.io"}))
 
+	matches, err = ex.CompleteReferences(context.Background(), "hr.s")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(matches).To(Equal([]string{"hr.spec"}))
+
+	matches, err = ex.CompleteReferences(context.Background(), "hr.spec.ch")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(matches).To(Equal([]string{"hr.spec.chart", "hr.spec.chartRef"}))
+
+	matches, err = ex.CompleteReferences(context.Background(), "helmreleases.helm.toolkit.fluxcd.io.spec.ch")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(matches).To(Equal([]string{
+		"helmreleases.helm.toolkit.fluxcd.io.spec.chart",
+		"helmreleases.helm.toolkit.fluxcd.io.spec.chartRef",
+	}))
+
+	matches, err = ex.CompleteReferences(context.Background(), "ag.spec.p")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(matches).To(Equal([]string{"ag.spec.pathPattern"}))
+
 	var out bytes.Buffer
 	g.Expect(ex.Explain(context.Background(), "hr.spec", &out)).To(Succeed())
 	g.Expect(out.String()).To(ContainSubstring("GROUP:      helm.toolkit.fluxcd.io\n"))
@@ -166,6 +191,7 @@ func TestEcosystemIndexResolveAndComplete(t *testing.T) {
 	g.Expect(ex.Explain(context.Background(), "helmreleases.helm.toolkit.fluxcd.io.spec", &out)).To(Succeed())
 	g.Expect(out.String()).To(ContainSubstring("KIND:       HelmRelease\n"))
 	g.Expect(out.String()).To(ContainSubstring("FIELD: spec <Object>\n"))
+	g.Expect(atomic.LoadInt32(&helmReleaseRequests)).To(Equal(int32(1)))
 
 	out.Reset()
 	g.Expect(ex.Explain(context.Background(), "ag.spec.pathPattern", &out)).To(Succeed())


### PR DESCRIPTION
## Summary
- complete field paths for `flux schema explain` after a resource reference is resolved
- preserve the typed resource reference in field completions, including short names and full `plural.group` names
- cache schema, index, reference, and 404 loads in memory for the process only; no disk cache
- document resource-name vs field-path completion for ecosystem and standalone catalogs

## Tests
- `make test`
- `make lint`
- `./bin/flux-schema __complete explain -s ecosystem hr.s`
- `./bin/flux-schema __complete explain -s ecosystem hr.spec.c`
- `./bin/flux-schema __complete explain -s ecosystem ag.spec.pat`