### PR TITLE
Fix schema corruption for fields named properties

### DIFF
--- a/internal/extractor/transformers.go
+++ b/internal/extractor/transformers.go
@@ -428,7 +428,7 @@ func closeAdditionalProperties(node any) {
 			}
 		}
 		for k, v := range n {
-			if isCombinatorKey(k) {
+			if isCombinatorKey(k) || isValueKeyword(k) {
 				continue
 			}
 			if closeAdditionalPropertiesNameMap(k, v) {
@@ -454,6 +454,16 @@ func isCombinatorKey(k string) bool {
 	}
 }
 
+// isValueKeyword reports whether k carries arbitrary JSON values, not schemas.
+func isValueKeyword(k string) bool {
+	switch k {
+	case "default", "example", "enum", "const":
+		return true
+	default:
+		return false
+	}
+}
+
 // closeAdditionalPropertiesChildren is closeAdditionalProperties but leaves
 // the root object's own additionalProperties untouched. Used by the CRD
 // pipeline, where the openAPIV3Schema describes a custom resource whose root
@@ -470,7 +480,7 @@ func closeAdditionalPropertiesChildren(node any) {
 		return
 	}
 	for k, v := range m {
-		if isCombinatorKey(k) {
+		if isCombinatorKey(k) || isValueKeyword(k) {
 			continue
 		}
 		if closeAdditionalPropertiesNameMap(k, v) {

--- a/internal/extractor/transformers.go
+++ b/internal/extractor/transformers.go
@@ -397,12 +397,15 @@ func markNullable(prop map[string]any) {
 
 // --- additionalProperties closing ---
 
-// closeAdditionalProperties walks node and sets additionalProperties:false on
-// every object that declares "properties" but doesn't already set it. Subtrees
-// under x-kubernetes-preserve-unknown-fields:true are skipped because the API
-// server accepts arbitrary keys there (status subresources, free-form map
-// fields like HelmRelease.spec.values); forcing additionalProperties:false
-// would reject valid documents.
+// closeAdditionalProperties walks schema nodes and sets
+// additionalProperties:false on every object that declares "properties" but
+// doesn't already set it. Name-to-schema maps like "properties" and
+// "patternProperties" are traversed through their values so field names are not
+// confused with schema keywords. Subtrees under
+// x-kubernetes-preserve-unknown-fields:true are skipped because the API server
+// accepts arbitrary keys there (status subresources, free-form map fields like
+// HelmRelease.spec.values); forcing additionalProperties:false would reject
+// valid documents.
 //
 // The oneOf/anyOf/allOf/not branch subschemas are NOT closed: they are partial
 // value-validation constraints combined with the structural (parent) schema,
@@ -426,6 +429,9 @@ func closeAdditionalProperties(node any) {
 		}
 		for k, v := range n {
 			if isCombinatorKey(k) {
+				continue
+			}
+			if closeAdditionalPropertiesNameMap(k, v) {
 				continue
 			}
 			closeAdditionalProperties(v)
@@ -467,8 +473,25 @@ func closeAdditionalPropertiesChildren(node any) {
 		if isCombinatorKey(k) {
 			continue
 		}
+		if closeAdditionalPropertiesNameMap(k, v) {
+			continue
+		}
 		closeAdditionalProperties(v)
 	}
+}
+
+func closeAdditionalPropertiesNameMap(k string, v any) bool {
+	if !isSchemaNameMap(k) {
+		return false
+	}
+	m, ok := v.(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, child := range m {
+		closeAdditionalProperties(child)
+	}
+	return true
 }
 
 // --- vendor extension stripping ---

--- a/internal/extractor/transformers_test.go
+++ b/internal/extractor/transformers_test.go
@@ -64,6 +64,76 @@ func TestCloseAdditionalProperties_ClosesRoot(t *testing.T) {
 	g.Expect(schema["additionalProperties"]).To(BeFalse(), "root must be closed")
 }
 
+func TestCloseAdditionalProperties_PreservesFieldNamedProperties(t *testing.T) {
+	tests := []struct {
+		name          string
+		transform     func(any)
+		wantRootClose bool
+	}{
+		{
+			name:          "close root",
+			transform:     closeAdditionalProperties,
+			wantRootClose: true,
+		},
+		{
+			name:      "close children only",
+			transform: closeAdditionalPropertiesChildren,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			schema := map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"status": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"conditions": map[string]any{"type": "array"},
+							"properties": map[string]any{
+								"type": "array",
+								"items": map[string]any{
+									"type": "object",
+									"properties": map[string]any{
+										"name":  map[string]any{"type": "string"},
+										"value": map[string]any{"type": "string"},
+									},
+								},
+							},
+							"version": map[string]any{"type": "string"},
+						},
+					},
+				},
+			}
+
+			tt.transform(schema)
+
+			_, rootHasAP := schema["additionalProperties"]
+			g.Expect(rootHasAP).To(Equal(tt.wantRootClose))
+
+			status := schema["properties"].(map[string]any)["status"].(map[string]any)
+			g.Expect(status["additionalProperties"]).To(BeFalse(), "real object schema must be closed")
+
+			statusProps := status["properties"].(map[string]any)
+			g.Expect(statusProps).To(HaveLen(3), "properties map must contain only real field names")
+			g.Expect(statusProps).To(HaveKey("conditions"))
+			g.Expect(statusProps).To(HaveKey("properties"))
+			g.Expect(statusProps).To(HaveKey("version"))
+			g.Expect(statusProps).ToNot(HaveKey("additionalProperties"))
+
+			propertiesField := statusProps["properties"].(map[string]any)
+			items := propertiesField["items"].(map[string]any)
+			g.Expect(items["additionalProperties"]).To(BeFalse(), "nested object schema must still be closed")
+			itemProps := items["properties"].(map[string]any)
+			g.Expect(itemProps).To(HaveLen(2), "nested properties map must contain only real field names")
+			g.Expect(itemProps).To(HaveKey("name"))
+			g.Expect(itemProps).To(HaveKey("value"))
+			g.Expect(itemProps).ToNot(HaveKey("additionalProperties"))
+		})
+	}
+}
+
 // A structural object that also carries oneOf/anyOf branches (Cilium's
 // CiliumNetworkPolicy spec pattern): the object itself is closed, but the
 // branch subschemas — which list only a subset of properties to anchor a

--- a/internal/extractor/transformers_test.go
+++ b/internal/extractor/transformers_test.go
@@ -134,6 +134,139 @@ func TestCloseAdditionalProperties_PreservesFieldNamedProperties(t *testing.T) {
 	}
 }
 
+func TestCloseAdditionalProperties_PreservesValueKeywords(t *testing.T) {
+	wantDefault := map[string]any{
+		"properties": float64(1),
+		"nested": map[string]any{
+			"properties": map[string]any{
+				"name": "default",
+			},
+		},
+	}
+	wantEnum := []any{
+		map[string]any{
+			"properties": float64(1),
+			"nested": map[string]any{
+				"properties": map[string]any{
+					"name": "enum-a",
+				},
+			},
+		},
+		map[string]any{
+			"properties": float64(2),
+			"nested": map[string]any{
+				"properties": map[string]any{
+					"name": "enum-b",
+				},
+			},
+		},
+	}
+	wantExample := map[string]any{
+		"properties": float64(3),
+		"nested": map[string]any{
+			"properties": map[string]any{
+				"name": "example",
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		transform     func(any)
+		wantRootClose bool
+	}{
+		{
+			name:          "close root",
+			transform:     closeAdditionalProperties,
+			wantRootClose: true,
+		},
+		{
+			name:      "close children only",
+			transform: closeAdditionalPropertiesChildren,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			schema := map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"spec": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"cfg": map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"properties": map[string]any{"type": "integer"},
+									"nested": map[string]any{
+										"type": "object",
+										"properties": map[string]any{
+											"name": map[string]any{"type": "string"},
+										},
+									},
+								},
+								"default": map[string]any{
+									"properties": float64(1),
+									"nested": map[string]any{
+										"properties": map[string]any{
+											"name": "default",
+										},
+									},
+								},
+								"enum": []any{
+									map[string]any{
+										"properties": float64(1),
+										"nested": map[string]any{
+											"properties": map[string]any{
+												"name": "enum-a",
+											},
+										},
+									},
+									map[string]any{
+										"properties": float64(2),
+										"nested": map[string]any{
+											"properties": map[string]any{
+												"name": "enum-b",
+											},
+										},
+									},
+								},
+								"example": map[string]any{
+									"properties": float64(3),
+									"nested": map[string]any{
+										"properties": map[string]any{
+											"name": "example",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			tt.transform(schema)
+
+			_, rootHasAP := schema["additionalProperties"]
+			g.Expect(rootHasAP).To(Equal(tt.wantRootClose))
+
+			spec := schema["properties"].(map[string]any)["spec"].(map[string]any)
+			g.Expect(spec["additionalProperties"]).To(BeFalse(), "real object schema must be closed")
+
+			cfg := spec["properties"].(map[string]any)["cfg"].(map[string]any)
+			g.Expect(cfg["additionalProperties"]).To(BeFalse(), "real object schema with value keywords must be closed")
+
+			nestedSchema := cfg["properties"].(map[string]any)["nested"].(map[string]any)
+			g.Expect(nestedSchema["additionalProperties"]).To(BeFalse(), "nested real object schema must be closed")
+
+			g.Expect(cfg["default"]).To(Equal(wantDefault), "default value must stay untouched")
+			g.Expect(cfg["enum"]).To(Equal(wantEnum), "enum values must stay untouched")
+			g.Expect(cfg["example"]).To(Equal(wantExample), "example value must stay untouched")
+		})
+	}
+}
+
 // A structural object that also carries oneOf/anyOf branches (Cilium's
 // CiliumNetworkPolicy spec pattern): the object itself is closed, but the
 // branch subschemas — which list only a subset of properties to anchor a


### PR DESCRIPTION
`closeAdditionalProperties` treated any map containing a properties key as an object schema, including the properties map itself. A CRD field literally named properties (e.g. ClusterProfileStatus in kubernetes-sigs/cluster-inventory-api) made the check misfire and injected `additionalProperties:false` into the map as a bogus sibling of the real field schemas, breaking validate for that kind.

Recurse into the values of name-to-schema maps (properties, patternProperties, $defs, definitions) directly so the maps are never inspected as schema nodes. Apply the same to `closeAdditionalPropertiesChildren`, which shared the pattern.