### PR TITLE
Extract and use missing `x-kubernetes-*` fields for full validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ refreshed automatically from upstream stable releases.
 - **Strict schema validation** — every field of every Kubernetes built-in
   kind and custom resource is checked. Unknown fields, wrong types, and
   missing required properties are all reported as schema violations.
+- **Kubernetes admission semantics** — embedded resources and list map/set
+  topology are validated from `x-kubernetes-*` schema extensions.
 - **CEL evaluation** — `x-kubernetes-validations` rules evaluated with the
   same engine as Kubernetes API server.
 - **Strict YAML decoding** — duplicate keys are rejected matching Flux

--- a/docs/custom-schema-catalog.md
+++ b/docs/custom-schema-catalog.md
@@ -208,6 +208,11 @@ constraints the Kubernetes API server enforces:
 - Objects with `properties` are closed with `additionalProperties: false`,
   except under nodes marked `x-kubernetes-preserve-unknown-fields: true`,
   which stay open so free-form maps validate correctly.
+- Kubernetes admission validation extensions are preserved when they affect
+  manifest validation: `x-kubernetes-embedded-resource`,
+  `x-kubernetes-list-type`, `x-kubernetes-list-map-keys`,
+  `x-kubernetes-map-type`, `x-kubernetes-preserve-unknown-fields`, and
+  `x-kubernetes-validations`. Merge/patch-only extensions are stripped.
 - Integer-or-string fields are rewritten to
   `oneOf: [{type: string}, {type: integer}]`. Both the legacy
   `format: int-or-string` and the structural

--- a/docs/manifests-validation.md
+++ b/docs/manifests-validation.md
@@ -220,6 +220,10 @@ report is versioned by a published [JSON Schema](report-v1beta1.json).
 - Schemas produced by `flux schema extract crd` close objects with
   `additionalProperties: false`, so undocumented fields under `spec` fail
   validation.
+- Kubernetes admission extensions are enforced for embedded resources and list
+  topology: `x-kubernetes-embedded-resource` validates nested `apiVersion`,
+  `kind`, and `metadata`, while `x-kubernetes-list-type: map|set` rejects
+  duplicate list entries using `x-kubernetes-list-map-keys` for map lists.
 - String formats `duration`, `date`, `datetime`/`date-time`, and `time` are
   validated matching Kubernetes OpenAPI conventions.
 

--- a/internal/extractor/kubernetes_test.go
+++ b/internal/extractor/kubernetes_test.go
@@ -768,7 +768,7 @@ func TestExtractKubernetes_MissingRefIsError(t *testing.T) {
 	g.Expect(broken["description"]).To(ContainSubstring("unresolved $ref"))
 }
 
-func TestExtractKubernetes_StripsVendorExtensions(t *testing.T) {
+func TestExtractKubernetes_PreservesValidationVendorExtensions(t *testing.T) {
 	g := NewWithT(t)
 	doc := map[string]any{
 		"definitions": map[string]any{
@@ -788,6 +788,14 @@ func TestExtractKubernetes_StripsVendorExtensions(t *testing.T) {
 							map[string]any{"rule": "self >= 0", "message": "must be non-negative"},
 						},
 					},
+					"embedded": map[string]any{
+						"type":                           "object",
+						"x-kubernetes-embedded-resource": true,
+					},
+					"settings": map[string]any{
+						"type":                  "object",
+						"x-kubernetes-map-type": "atomic",
+					},
 				},
 				"required": []any{"count"},
 				"x-kubernetes-group-version-kind": []any{
@@ -801,16 +809,19 @@ func TestExtractKubernetes_StripsVendorExtensions(t *testing.T) {
 
 	g.Expect(out[0].JSON).ToNot(HaveKey("x-kubernetes-group-version-kind"))
 
-	list := out[0].JSON["properties"].(map[string]any)["list"].(map[string]any)
-	g.Expect(list).ToNot(HaveKey("x-kubernetes-list-type"))
-	g.Expect(list).ToNot(HaveKey("x-kubernetes-list-map-keys"))
+	props := out[0].JSON["properties"].(map[string]any)
+	list := props["list"].(map[string]any)
+	g.Expect(list["x-kubernetes-list-type"]).To(Equal("map"))
+	g.Expect(list["x-kubernetes-list-map-keys"]).To(Equal([]any{"name"}))
 	g.Expect(list).ToNot(HaveKey("x-kubernetes-patch-strategy"))
 	g.Expect(list).ToNot(HaveKey("x-kubernetes-patch-merge-key"))
 
-	// CEL validations are retained so the API server's rules survive in the
-	// extracted schema.
-	count := out[0].JSON["properties"].(map[string]any)["count"].(map[string]any)
+	count := props["count"].(map[string]any)
 	g.Expect(count).To(HaveKey("x-kubernetes-validations"))
+	embedded := props["embedded"].(map[string]any)
+	g.Expect(embedded["x-kubernetes-embedded-resource"]).To(BeTrue())
+	settings := props["settings"].(map[string]any)
+	g.Expect(settings["x-kubernetes-map-type"]).To(Equal("atomic"))
 }
 
 func TestExtractKubernetes_PreservesDescriptions(t *testing.T) {

--- a/internal/extractor/transformers.go
+++ b/internal/extractor/transformers.go
@@ -507,9 +507,8 @@ func closeAdditionalPropertiesNameMap(k string, v any) bool {
 // --- vendor extension stripping ---
 
 // stripVendorExtensions removes x-kubernetes-* keys from the tree except those
-// that carry validation semantics: x-kubernetes-preserve-unknown-fields (keeps
-// subtrees open for server-side unknown fields) and x-kubernetes-validations
-// (CEL rules enforced by the API server).
+// that carry API server validation semantics. Merge/patch-only hints are still
+// dropped because they do not affect admission validation.
 func stripVendorExtensions(node any) {
 	switch n := node.(type) {
 	case map[string]any:
@@ -534,7 +533,11 @@ func stripVendorExtensions(node any) {
 
 func keepVendorExtension(k string) bool {
 	switch k {
-	case "x-kubernetes-preserve-unknown-fields",
+	case "x-kubernetes-embedded-resource",
+		"x-kubernetes-list-map-keys",
+		"x-kubernetes-list-type",
+		"x-kubernetes-map-type",
+		"x-kubernetes-preserve-unknown-fields",
 		"x-kubernetes-validations":
 		return true
 	}

--- a/internal/validator/admission.go
+++ b/internal/validator/admission.go
@@ -1,0 +1,187 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"encoding/json"
+	"fmt"
+
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting"
+	structurallisttype "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/listtype"
+	schemaobjectmeta "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// admissionValidator runs Kubernetes structural-schema admission checks that
+// are expressed through x-kubernetes-* extensions and are not JSON Schema
+// keywords. It mirrors kube-apiserver's custom resource strategy: embedded
+// resource metadata validation, then list map/set uniqueness validation.
+type admissionValidator struct {
+	structural *apiextschema.Structural
+	hasDefault bool
+}
+
+func newAdmissionValidatorFromStructural(structural *apiextschema.Structural) *admissionValidator {
+	if structural == nil {
+		return nil
+	}
+	return &admissionValidator{
+		structural: structural,
+		hasDefault: structuralHasDefaults(structural),
+	}
+}
+
+func (v *admissionValidator) Validate(obj map[string]any) []ValidationError {
+	if v == nil || v.structural == nil {
+		return nil
+	}
+
+	validatedObj := any(obj)
+	if v.hasDefault || hasJSONNull(obj) {
+		// Match kube-apiserver CREATE ordering: prune non-defaultable nulls and
+		// apply structural defaults before extension-backed admission checks.
+		validatedObj = runtime.DeepCopyJSON(obj)
+		defaulting.PruneNonNullableNullsWithoutDefaults(validatedObj, v.structural)
+		if v.hasDefault {
+			defaulting.Default(validatedObj, v.structural)
+		}
+	}
+
+	validatedMap, ok := validatedObj.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	errs := schemaobjectmeta.Validate(nil, validatedMap, v.structural, false)
+	errs = append(errs, structurallisttype.ValidateListSetsAndMaps(nil, v.structural, validatedMap)...)
+	return fieldErrorsToValidationErrors(errs)
+}
+
+func hasAdmissionValidation(node any) bool {
+	switch n := node.(type) {
+	case map[string]any:
+		if v, ok := n["x-kubernetes-embedded-resource"].(bool); ok && v {
+			return true
+		}
+		if v, ok := n["x-kubernetes-list-type"].(string); ok && (v == "map" || v == "set") {
+			return true
+		}
+		for _, v := range n {
+			if hasAdmissionValidation(v) {
+				return true
+			}
+		}
+	case []any:
+		for _, v := range n {
+			if hasAdmissionValidation(v) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func newStructuralSchema(raw map[string]any) (*apiextschema.Structural, error) {
+	structuralRaw := rewriteForKubernetesStructural(raw).(map[string]any)
+	body, err := json.Marshal(structuralRaw)
+	if err != nil {
+		return nil, fmt.Errorf("marshal schema: %w", err)
+	}
+	var v1Props apiextensionsv1.JSONSchemaProps
+	if err := json.Unmarshal(body, &v1Props); err != nil {
+		return nil, fmt.Errorf("decode JSONSchemaProps: %w", err)
+	}
+
+	var internalProps apiextensions.JSONSchemaProps
+	if err := apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(&v1Props, &internalProps, nil); err != nil {
+		return nil, fmt.Errorf("convert JSONSchemaProps: %w", err)
+	}
+
+	structural, err := apiextschema.NewStructural(&internalProps)
+	if err != nil {
+		return nil, fmt.Errorf("structural schema: %w", err)
+	}
+	return structural, nil
+}
+
+func rewriteForKubernetesStructural(node any) any {
+	return collapseNullableTypes(rewriteIntOrStringOneOfForCEL(node))
+}
+
+// collapseNullableTypes converts JSON Schema type arrays into the Kubernetes
+// structural-schema representation. The extractor expresses optional nullable
+// fields as type: ["T", "null"]; apiextensions expects type: "T" plus
+// nullable: true for the structural copy used by admission and CEL validators.
+func collapseNullableTypes(node any) any {
+	switch n := node.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(n))
+		for k, v := range n {
+			out[k] = collapseNullableTypes(v)
+		}
+		if rawType, ok := out["type"].([]any); ok {
+			if t, nullable, ok := nonNullJSONSchemaType(rawType); ok {
+				if t == "" {
+					delete(out, "type")
+				} else {
+					out["type"] = t
+				}
+				if nullable {
+					out["nullable"] = true
+				}
+			}
+		}
+		return out
+	case []any:
+		out := make([]any, len(n))
+		for i, v := range n {
+			out[i] = collapseNullableTypes(v)
+		}
+		return out
+	default:
+		return n
+	}
+}
+
+func nonNullJSONSchemaType(values []any) (string, bool, bool) {
+	types := make([]string, 0, len(values))
+	nullable := false
+	for _, value := range values {
+		s, ok := value.(string)
+		if !ok {
+			return "", false, false
+		}
+		if s == "null" {
+			nullable = true
+			continue
+		}
+		types = append(types, s)
+	}
+	switch len(types) {
+	case 0:
+		return "", nullable, true
+	case 1:
+		return types[0], nullable, true
+	default:
+		return "", false, false
+	}
+}
+
+func fieldErrorsToValidationErrors(errs field.ErrorList) []ValidationError {
+	if len(errs) == 0 {
+		return nil
+	}
+	out := make([]ValidationError, 0, len(errs))
+	for _, err := range errs {
+		out = append(out, ValidationError{
+			Path: fieldPathToJSONPointer(err.Field),
+			Msg:  err.ErrorBody(),
+		})
+	}
+	return out
+}

--- a/internal/validator/cel.go
+++ b/internal/validator/cel.go
@@ -5,13 +5,9 @@ package validator
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"math"
 	"strings"
 
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	apiextschemacel "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting"
@@ -45,42 +41,23 @@ type celValidator struct {
 //     per-document surfaceable problem — not a schema-load failure — so that
 //     schemas unrelated to CEL still validate normally.
 //
-// The "has rules?" pre-check matters: the catalog's native Kubernetes
-// schemas use type: ["string","null"] (the extractor's nullableOptional
-// transform) which apiextensionsv1.JSONSchemaProps cannot decode. Those
-// schemas don't carry CEL rules, so we must return (nil, nil) without
-// attempting the unmarshal — otherwise every Secret/ConfigMap/etc. would
-// surface a spurious build error.
+// The "has rules?" pre-check matters: schemas without CEL rules should not
+// pay the structural-schema conversion cost or surface CEL setup errors.
 func newCELValidator(raw map[string]any) (*celValidator, error) {
 	if raw == nil || !hasCELRules(raw) {
 		return nil, nil
 	}
 
-	// The JSON Schema path still needs the extracted oneOf form. Build the
-	// structural/CEL schema from a private copy that restores int-or-string to
-	// the representation Kubernetes' CEL type-checker understands.
-	celRaw := rewriteIntOrStringOneOfForCEL(raw).(map[string]any)
-
-	// The internal apiextensions.JSONSchemaProps has no JSON tags, so the
-	// versioned type is the only viable unmarshal target on the way to
-	// NewStructural.
-	body, err := json.Marshal(celRaw)
+	structural, err := newStructuralSchema(raw)
 	if err != nil {
-		return nil, fmt.Errorf("marshal schema: %w", err)
+		return nil, err
 	}
-	var v1Props apiextensionsv1.JSONSchemaProps
-	if err := json.Unmarshal(body, &v1Props); err != nil {
-		return nil, fmt.Errorf("decode JSONSchemaProps: %w", err)
-	}
+	return newCELValidatorFromStructural(structural), nil
+}
 
-	var internalProps apiextensions.JSONSchemaProps
-	if err := apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(&v1Props, &internalProps, nil); err != nil {
-		return nil, fmt.Errorf("convert JSONSchemaProps: %w", err)
-	}
-
-	structural, err := apiextschema.NewStructural(&internalProps)
-	if err != nil {
-		return nil, fmt.Errorf("structural schema: %w", err)
+func newCELValidatorFromStructural(structural *apiextschema.Structural) *celValidator {
+	if structural == nil {
+		return nil
 	}
 
 	// math.MaxUint64: flux-schema is a CI-time static validator running the
@@ -90,13 +67,13 @@ func newCELValidator(raw map[string]any) (*celValidator, error) {
 	// schemas, which describe a full custom resource.
 	v := apiextschemacel.NewValidator(structural, true, math.MaxUint64)
 	if v == nil {
-		return nil, nil
+		return nil
 	}
 	return &celValidator{
 		v:          v,
 		structural: structural,
 		hasDefault: structuralHasDefaults(structural),
-	}, nil
+	}
 }
 
 // Validate runs every compiled CEL rule over obj after applying the same
@@ -135,14 +112,7 @@ func (c *celValidator) Validate(ctx context.Context, obj map[string]any) []Valid
 	if len(errs) == 0 {
 		return nil
 	}
-	out := make([]ValidationError, 0, len(errs))
-	for _, e := range errs {
-		out = append(out, ValidationError{
-			Path: fieldPathToJSONPointer(e.Field),
-			Msg:  e.ErrorBody(),
-		})
-	}
-	return out
+	return fieldErrorsToValidationErrors(errs)
 }
 
 func structuralHasDefaults(s *apiextschema.Structural) bool {

--- a/internal/validator/cel_test.go
+++ b/internal/validator/cel_test.go
@@ -588,12 +588,11 @@ func TestNewCELValidator_ArrayTypeWithoutRulesShortCircuits(t *testing.T) {
 	g.Expect(v).To(BeNil())
 }
 
-func TestNewCELValidator_ArrayTypeWithRulesIsSoftBuildError(t *testing.T) {
+func TestNewCELValidator_ArrayTypeWithRulesBuilds(t *testing.T) {
 	g := NewWithT(t)
-	// Forward-compat guard: if a future schema source mixes nullableOptional
-	// (type: ["string","null"]) with x-kubernetes-validations rules, the
-	// JSONSchemaProps decode must surface as a build error rather than a
-	// panic — and crucially must NOT bubble up as a schema-load failure.
+	// nullableOptional produces type: ["string","null"]. The Kubernetes
+	// structural-schema builder collapses that back to the non-null type for CEL
+	// setup, while JSON Schema validation still owns nullability enforcement.
 	schema := schemaFromJSON(t, `{
 		"type": "object",
 		"properties": {
@@ -606,8 +605,9 @@ func TestNewCELValidator_ArrayTypeWithRulesIsSoftBuildError(t *testing.T) {
 		]
 	}`)
 	v, err := newCELValidator(schema)
-	g.Expect(err).To(HaveOccurred())
-	g.Expect(v).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(v).ToNot(BeNil())
+	g.Expect(v.Validate(context.Background(), docFromJSON(t, `{}`))).To(BeEmpty())
 }
 
 func TestFieldPathToJSONPointer(t *testing.T) {

--- a/internal/validator/loader.go
+++ b/internal/validator/loader.go
@@ -44,15 +44,17 @@ type SchemaLoader struct {
 }
 
 // loadResult is the populated outcome of a single loadAndCompile call.
-// celBuildErr is recorded as data, not an error return: it means "this
-// schema's CEL evaluator could not be built" (e.g. apiextensions/v1 cannot
-// decode the shape) and is surfaced per-document by validateDoc, never as a
-// schema-load failure. The hard schema-load error stays on the cache entry.
+// Admission/CEL build errors are recorded as data, not error returns: they
+// mean Kubernetes evaluators could not be built (e.g. apiextensions/v1 cannot
+// decode the shape) and are surfaced per-document by validateDoc, never as
+// schema-load failures. Hard schema-load errors stay on the cache entry.
 type loadResult struct {
-	schema      *jsonschema.Schema
-	cel         *celValidator
-	celBuildErr error
-	found       bool
+	schema            *jsonschema.Schema
+	admission         *admissionValidator
+	admissionBuildErr error
+	cel               *celValidator
+	celBuildErr       error
+	found             bool
 }
 
 type schemaCacheEntry struct {
@@ -62,16 +64,17 @@ type schemaCacheEntry struct {
 }
 
 // ResolvedSchema is the bundle of artifacts the loader produces for one
-// schema location: the compiled JSON Schema, plus an optional compiled CEL
-// evaluator. Either of the CEL fields may be set independently — the schema
-// may have rules that compiled fine (CEL set, CELBuildErr nil), or rules
-// that failed to set up (CEL nil, CELBuildErr non-nil), or no rules at all
-// (both nil).
+// schema location: the compiled JSON Schema plus optional Kubernetes admission
+// and CEL evaluators. Build errors are recorded as data so they can be surfaced
+// per document without blocking plain JSON Schema validation for unrelated
+// schemas.
 type ResolvedSchema struct {
-	JSON        *jsonschema.Schema
-	CEL         *celValidator
-	CELBuildErr error
-	Location    string
+	JSON              *jsonschema.Schema
+	Admission         *admissionValidator
+	AdmissionBuildErr error
+	CEL               *celValidator
+	CELBuildErr       error
+	Location          string
 }
 
 // NewSchemaLoader returns a loader that will try templates in order and
@@ -109,10 +112,12 @@ func (l *SchemaLoader) Resolve(ctx context.Context, vars tmpl.SchemaVars) (resol
 		}
 		if entry.found {
 			return &ResolvedSchema{
-				JSON:        entry.schema,
-				CEL:         entry.cel,
-				CELBuildErr: entry.celBuildErr,
-				Location:    rendered,
+				JSON:              entry.schema,
+				Admission:         entry.admission,
+				AdmissionBuildErr: entry.admissionBuildErr,
+				CEL:               entry.cel,
+				CELBuildErr:       entry.celBuildErr,
+				Location:          rendered,
 			}, true, nil
 		}
 	}
@@ -127,16 +132,16 @@ func (l *SchemaLoader) cacheEntry(location string) *schemaCacheEntry {
 	return entry.(*schemaCacheEntry)
 }
 
-// loadAndCompile fetches location and compiles its contents as a JSON
-// Schema, then builds a CEL evaluator from the same document. The returned
-// loadResult has found=false when the location responded with "not found",
-// so the caller can fall through to the next template.
+// loadAndCompile fetches location and compiles its contents as a JSON Schema,
+// then builds Kubernetes admission and CEL evaluators from the same document.
+// The returned loadResult has found=false when the location responded with
+// "not found", so the caller can fall through to the next template.
 //
-// CEL build is intentionally performed AFTER compileMu is released:
+// Admission/CEL builds are intentionally performed AFTER compileMu is released:
 // compileMu only guards compiler.AddResource/Compile, and holding it across
-// CEL construction would serialize unrelated schemas' CEL builds. A CEL
-// build failure is recorded on the result (celBuildErr) rather than
-// returned, because it must not block JSON Schema validation.
+// Kubernetes evaluator construction would serialize unrelated schemas. Build
+// failures are recorded on the result rather than returned, because they must
+// not block JSON Schema validation.
 func (l *SchemaLoader) loadAndCompile(ctx context.Context, location string) (loadResult, error) {
 	var r loadResult
 	body, found, err := l.loadBytes(ctx, location)
@@ -161,7 +166,26 @@ func (l *SchemaLoader) loadAndCompile(ctx context.Context, location string) (loa
 	r.found = true
 
 	if rootMap, ok := doc.(map[string]any); ok {
-		r.cel, r.celBuildErr = newCELValidator(rootMap)
+		hasAdmission := hasAdmissionValidation(rootMap)
+		hasCEL := hasCELRules(rootMap)
+		if hasAdmission || hasCEL {
+			structural, buildErr := newStructuralSchema(rootMap)
+			if buildErr != nil {
+				if hasAdmission {
+					r.admissionBuildErr = buildErr
+				}
+				if hasCEL {
+					r.celBuildErr = buildErr
+				}
+			} else {
+				if hasAdmission {
+					r.admission = newAdmissionValidatorFromStructural(structural)
+				}
+				if hasCEL {
+					r.cel = newCELValidatorFromStructural(structural)
+				}
+			}
+		}
 	}
 	return r, nil
 }
@@ -169,7 +193,7 @@ func (l *SchemaLoader) loadAndCompile(ctx context.Context, location string) (loa
 // compileJSONSchema serializes access to the shared jsonschema.Compiler.
 // jsonschema.Compiler is not safe for concurrent use; the per-entry sync.Once
 // only dedupes work per location, so cross-location calls still need this
-// mutex. Kept narrow so it doesn't serialize unrelated work (e.g. CEL build).
+// mutex. Kept narrow so it does not serialize unrelated evaluator builds.
 func (l *SchemaLoader) compileJSONSchema(baseURI string, doc any) (*jsonschema.Schema, error) {
 	l.compileMu.Lock()
 	defer l.compileMu.Unlock()

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -579,7 +579,8 @@ func (v *Validator) streamReader(ctx context.Context, source string, r io.Reader
 
 // validateDoc runs the full per-document pipeline: strict YAML decode,
 // apiVersion/kind extraction, name-or-generateName admission check, schema
-// resolution, and JSON Schema validation.
+// resolution, JSON Schema validation, Kubernetes extension-backed admission
+// checks, and CEL evaluation.
 //
 // Returns emit=false when the document contains only comments or whitespace
 // (YAML decodes to nil); such content-free documents are dropped entirely
@@ -711,10 +712,27 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 		return settle(StatusInvalid, ReasonSchemaViolation)
 	}
 
-	// CEL x-kubernetes-validations evaluation runs only after JSON Schema +
-	// metadata pass. Most CEL rules presume a well-shaped object, so adding
-	// CEL noise on top of a JSON Schema failure rarely helps; the user can
-	// fix the structural problems and re-run.
+	if resolved.AdmissionBuildErr != nil {
+		// Admission extensions define Kubernetes schema topology, not optional
+		// policy. Surface build errors unconditionally so a schema that claims
+		// list/map/resource semantics cannot validate differently from the API
+		// server.
+		r.Errors = []ValidationError{{
+			Msg: resolved.AdmissionBuildErr.Error(),
+		}}
+		return settle(StatusInvalid, ReasonSchemaViolation)
+	}
+	if resolved.Admission != nil {
+		if admissionErrs := resolved.Admission.Validate(doc); len(admissionErrs) > 0 {
+			r.Errors = admissionErrs
+			return settle(StatusInvalid, ReasonSchemaViolation)
+		}
+	}
+
+	// CEL x-kubernetes-validations evaluation runs only after JSON Schema,
+	// metadata, and Kubernetes admission-extension checks pass. Most CEL rules
+	// presume a well-shaped object, so adding CEL noise on top of structural
+	// failures rarely helps; the user can fix those problems and re-run.
 	if !v.opts.SkipCELRules {
 		if resolved.CELBuildErr != nil {
 			r.Errors = []ValidationError{{

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -56,6 +56,161 @@ func writeWidgetSchema(t *testing.T, dir string) {
 	}
 }
 
+func writeAdmissionWidgetSchema(t *testing.T, dir string) {
+	t.Helper()
+	schema := map[string]any{
+		"type":     "object",
+		"required": []any{"apiVersion", "kind", "spec"},
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"type": "string"},
+			"kind":       map[string]any{"type": "string"},
+			"metadata":   map[string]any{"type": "object"},
+			"spec": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]any{
+					"embedded": map[string]any{
+						"type":                                 "object",
+						"x-kubernetes-embedded-resource":       true,
+						"x-kubernetes-preserve-unknown-fields": true,
+					},
+					"issuers": map[string]any{
+						"type":                       "array",
+						"x-kubernetes-list-type":     "map",
+						"x-kubernetes-list-map-keys": []any{"issuerURL"},
+						"items": map[string]any{
+							"type":                 "object",
+							"additionalProperties": false,
+							"required":             []any{"issuerURL"},
+							"properties": map[string]any{
+								"issuerURL": map[string]any{"type": "string"},
+								"name":      map[string]any{"type": "string"},
+							},
+						},
+					},
+					"tags": map[string]any{
+						"type":                   "array",
+						"x-kubernetes-list-type": "set",
+						"items":                  map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+	}
+	b, err := json.MarshalIndent(schema, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	path := filepath.Join(dir, "admissionwidget-example-v1.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+}
+
+func writeBrokenAdmissionSchema(t *testing.T, dir string) {
+	t.Helper()
+	schema := map[string]any{
+		"type":     "object",
+		"required": []any{"apiVersion", "kind", "spec"},
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"type": "string"},
+			"kind":       map[string]any{"type": "string"},
+			"metadata":   map[string]any{"type": "object"},
+			"spec": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]any{
+					"count": map[string]any{
+						"type":             "number",
+						"exclusiveMinimum": 0,
+					},
+					"tags": map[string]any{
+						"type":                   "array",
+						"x-kubernetes-list-type": "set",
+						"items":                  map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+	}
+	b, err := json.MarshalIndent(schema, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	path := filepath.Join(dir, "brokenadmissionwidget-example-v1.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+}
+
+func writeExtractedNativeServiceSchema(t *testing.T, dir string) {
+	t.Helper()
+	swagger := map[string]any{
+		"swagger": "2.0",
+		"definitions": map[string]any{
+			"io.k8s.api.core.v1.Service": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"metadata": map[string]any{
+						"type":                                 "object",
+						"x-kubernetes-preserve-unknown-fields": true,
+					},
+					"spec": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"ports": map[string]any{
+								"type":                       "array",
+								"x-kubernetes-list-type":     "map",
+								"x-kubernetes-list-map-keys": []any{"port"},
+								"items": map[string]any{
+									"$ref": "#/definitions/io.k8s.api.core.v1.ServicePort",
+								},
+							},
+						},
+					},
+				},
+				"required": []any{"metadata", "spec"},
+				"x-kubernetes-group-version-kind": []any{
+					map[string]any{"group": "", "version": "v1", "kind": "Service"},
+				},
+			},
+			"io.k8s.api.core.v1.ServicePort": map[string]any{
+				"type":     "object",
+				"required": []any{"port"},
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+					"port": map[string]any{"type": "integer", "format": "int32"},
+					"targetPort": map[string]any{
+						"$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+					},
+				},
+			},
+			"io.k8s.apimachinery.pkg.util.intstr.IntOrString": map[string]any{
+				"format": "int-or-string",
+			},
+		},
+	}
+	raw, err := json.Marshal(swagger)
+	if err != nil {
+		t.Fatalf("marshal swagger: %v", err)
+	}
+	schemas, errs := extractor.ExtractKubernetes(raw)
+	if len(errs) > 0 {
+		t.Fatalf("extract kubernetes: %v", errs)
+	}
+	if len(schemas) != 1 {
+		t.Fatalf("extract kubernetes: got %d schemas, want 1", len(schemas))
+	}
+	b, err := json.MarshalIndent(schemas[0].JSON, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	path := filepath.Join(dir, "service-core-v1.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+}
+
 func writePluginConfigSchema(t *testing.T, dir string) {
 	t.Helper()
 	schema := map[string]any{
@@ -308,9 +463,152 @@ spec:
 	results = v.ValidateBytes(context.Background(), "httproute.yaml", invalid)
 	g.Expect(results).To(HaveLen(1))
 	g.Expect(results[0].Status).To(Equal(StatusInvalid))
-	g.Expect(results[0].Reason).To(Equal(ReasonCELViolation))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaViolation))
 	g.Expect(results[0].Errors).ToNot(BeEmpty())
-	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("sectionName must be specified"))
+	g.Expect(results[0].Errors[0].Path).To(Equal("/spec/parentRefs/1"))
+	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("Duplicate value"))
+}
+
+func TestValidateBytes_ListMapDuplicateKey(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeAdmissionWidgetSchema(t, dir)
+	v := newLocalValidator(t, dir, false)
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: AdmissionWidget
+metadata:
+  name: list-map
+spec:
+  issuers:
+    - issuerURL: https://issuer.example.com
+      name: first
+    - issuerURL: https://issuer.example.com
+      name: second
+`)
+	results := v.ValidateBytes(context.Background(), "admission.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaViolation))
+	g.Expect(results[0].Errors).ToNot(BeEmpty())
+	g.Expect(results[0].Errors[0].Path).To(Equal("/spec/issuers/1"))
+	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("Duplicate value"))
+	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("issuerURL"))
+}
+
+func TestValidateBytes_ListSetDuplicateValue(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeAdmissionWidgetSchema(t, dir)
+	v := newLocalValidator(t, dir, false)
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: AdmissionWidget
+metadata:
+  name: list-set
+spec:
+  tags:
+    - stable
+    - stable
+`)
+	results := v.ValidateBytes(context.Background(), "admission.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaViolation))
+	g.Expect(results[0].Errors).ToNot(BeEmpty())
+	g.Expect(results[0].Errors[0].Path).To(Equal("/spec/tags/1"))
+	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("Duplicate value"))
+	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("stable"))
+}
+
+func TestValidateBytes_ExtractedKubernetesAdmissionExtensions(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeExtractedNativeServiceSchema(t, dir)
+	v := newLocalValidator(t, dir, false)
+
+	valid := []byte(`apiVersion: v1
+kind: Service
+metadata:
+  name: native-service
+spec:
+  ports:
+    - port: 80
+      targetPort: null
+`)
+	results := v.ValidateBytes(context.Background(), "service.yaml", valid)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusValid), "errors: %+v", results[0].Errors)
+
+	invalid := []byte(`apiVersion: v1
+kind: Service
+metadata:
+  name: native-service
+spec:
+  ports:
+    - port: 80
+      targetPort: null
+    - port: 80
+      targetPort: 8080
+`)
+	results = v.ValidateBytes(context.Background(), "service.yaml", invalid)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaViolation))
+	g.Expect(results[0].Errors).ToNot(BeEmpty())
+	g.Expect(results[0].Errors[0].Path).To(Equal("/spec/ports/1"))
+	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("Duplicate value"))
+	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("port"))
+}
+
+func TestValidateBytes_AdmissionBuildError(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeBrokenAdmissionSchema(t, dir)
+	v := newLocalValidator(t, dir, false)
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: BrokenAdmissionWidget
+metadata:
+  name: broken-admission
+spec:
+  count: 1
+  tags:
+    - stable
+`)
+	results := v.ValidateBytes(context.Background(), "admission.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaViolation))
+	g.Expect(results[0].Errors).To(HaveLen(1))
+	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("decode JSONSchemaProps"))
+	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("exclusiveMinimum"))
+}
+
+func TestValidateBytes_EmbeddedResourceMetadata(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeAdmissionWidgetSchema(t, dir)
+	v := newLocalValidator(t, dir, false)
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: AdmissionWidget
+metadata:
+  name: embedded
+spec:
+  embedded:
+    apiVersion: 42
+    kind: ConfigMap
+    metadata:
+      name: embedded-config
+`)
+	results := v.ValidateBytes(context.Background(), "admission.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaViolation))
+	g.Expect(results[0].Errors).ToNot(BeEmpty())
+	g.Expect(results[0].Errors[0].Path).To(Equal("/spec/embedded/apiVersion"))
+	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("must be a string"))
 }
 
 const clusterQueueIntOrStringCRD = `


### PR DESCRIPTION
Preserves Kubernetes validation-relevant `x-kubernetes-*` extensions during schema extraction and uses Kubernetes apiextensions validators for embedded resources and list map/set uniqueness.