### PR TITLE
Set User-Agent header on outbound HTTP requests

### DIFF
--- a/cmd/flux-schema/explain.go
+++ b/cmd/flux-schema/explain.go
@@ -131,6 +131,7 @@ func buildExplainerOptions() (explainer.Options, error) {
 		APIVersion:            explainArgs.apiVersion,
 		OutputFormat:          explainArgs.output.String(),
 		Recursive:             explainArgs.recursive,
+		UserAgent:             userAgent(),
 		HTTPTimeout:           rootArgs.timeout,
 		InsecureSkipTLSVerify: explainArgs.insecureSkipTLSVerify,
 	}, nil

--- a/cmd/flux-schema/explain_test.go
+++ b/cmd/flux-schema/explain_test.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -109,6 +111,42 @@ func TestExplainCmd_Recursive(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(out).To(ContainSubstring("  metadata\t<ObjectMeta>\n    name\t<string>\n"))
 	g.Expect(out).To(ContainSubstring("  spec\t<PodSpec>\n    containers\t<[]Container> -required-\n      image\t<string>\n      imagePullPolicy\t<string>\n      enum: Always, IfNotPresent, Never\n"))
+}
+
+func TestExplainCmd_HTTPUserAgent(t *testing.T) {
+	g := NewWithT(t)
+
+	var userAgents []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgents = append(userAgents, r.Header.Get("User-Agent"))
+		switch r.URL.Path {
+		case "/catalog/example.com/widget_v1.json":
+			_, _ = w.Write([]byte(`{
+				"description": "Widget is a test resource.",
+				"properties": {
+					"apiVersion": {"type": "string"},
+					"kind": {"type": "string"},
+					"spec": {"type": "object", "description": "Widget spec."}
+				},
+				"type": "object"
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	out, err := executeCommand([]string{
+		"explain", "widgets",
+		"--api-version", "example.com/v1",
+		"--schema-location", srv.URL + "/catalog/{{.Group}}/{{.Kind}}_{{.Version}}.json",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("KIND:       Widget\n"))
+	g.Expect(userAgents).ToNot(BeEmpty())
+	for _, ua := range userAgents {
+		g.Expect(ua).To(Equal("flux-schema/0.0.0-dev.0"))
+	}
 }
 
 func TestExplainCmd_FieldIndexMetadataFallback(t *testing.T) {

--- a/cmd/flux-schema/extract_k8s.go
+++ b/cmd/flux-schema/extract_k8s.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/fluxcd/flux-schema/internal/extractor"
 	"github.com/fluxcd/flux-schema/internal/flags"
+	"github.com/fluxcd/flux-schema/internal/useragent"
 )
 
 const defaultK8sSwaggerURL = "https://raw.githubusercontent.com/kubernetes/kubernetes/%s/api/openapi-spec/swagger.json"
@@ -122,6 +123,7 @@ func k8sExtractWithVersionFallback(version string) func([]byte) ([]extractor.Sch
 func newDefaultK8sHTTPClient() *retryablehttp.Client {
 	c := retryablehttp.NewClient()
 	c.Logger = nil
+	useragent.Wrap(c, userAgent())
 	return c
 }
 

--- a/cmd/flux-schema/extract_k8s_test.go
+++ b/cmd/flux-schema/extract_k8s_test.go
@@ -473,7 +473,9 @@ func TestExtractK8sCmd_VersionFetch(t *testing.T) {
 	// Exercises the --version path via a monkey-patched URL template.
 	g := NewWithT(t)
 
+	var gotUserAgent string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserAgent = r.Header.Get("User-Agent")
 		g.Expect(r.URL.Path).To(Equal("/v1.35.0/swagger.json"))
 		_, _ = w.Write([]byte(minimalSwagger))
 	}))
@@ -484,6 +486,7 @@ func TestExtractK8sCmd_VersionFetch(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(source).To(Equal(srv.URL + "/v1.35.0/swagger.json"))
 	g.Expect(data).To(ContainSubstring("Widget"))
+	g.Expect(gotUserAgent).To(Equal("flux-schema/0.0.0-dev.0"))
 }
 
 func TestK8sExtractWithVersionFallback(t *testing.T) {

--- a/cmd/flux-schema/main.go
+++ b/cmd/flux-schema/main.go
@@ -42,6 +42,10 @@ func init() {
 	rootCmd.SetOut(os.Stdout)
 }
 
+func userAgent() string {
+	return "flux-schema/" + VERSION
+}
+
 // errSilent signals a non-zero exit without printing the usual "✗ ..." line.
 // Used by commands that have already emitted a self-describing summary
 // (e.g. `validate` prints its own "Summary: ... Invalid: N" line); restating

--- a/cmd/flux-schema/validate.go
+++ b/cmd/flux-schema/validate.go
@@ -451,6 +451,7 @@ func buildValidatorOptions(inputs []string) (validator.Options, error) {
 		SkipJSONPaths:         validateArgs.skipJSONPaths,
 		SkipFiles:             validateArgs.skipFiles,
 		SkipCELRules:          validateArgs.skipCELRules,
+		UserAgent:             userAgent(),
 		HTTPTimeout:           rootArgs.timeout,
 		Workers:               validateArgs.concurrent,
 		InsecureSkipTLSVerify: validateArgs.insecureSkipTLSVerify,

--- a/cmd/flux-schema/validate_test.go
+++ b/cmd/flux-schema/validate_test.go
@@ -485,7 +485,9 @@ func TestValidateCmd_InsecureSkipTLSVerify(t *testing.T) {
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var gotUserAgent string
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserAgent = r.Header.Get("User-Agent")
 		_, _ = w.Write(schemaBody)
 	}))
 	t.Cleanup(srv.Close)
@@ -506,6 +508,7 @@ func TestValidateCmd_InsecureSkipTLSVerify(t *testing.T) {
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(out).To(ContainSubstring("Valid: 1"))
+	g.Expect(gotUserAgent).To(Equal("flux-schema/0.0.0-dev.0"))
 }
 
 // TestValidateCmd_SkipJSONPath strips the SOPS metadata block from the

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -28,6 +28,7 @@ import (
 	kubeversion "k8s.io/apimachinery/pkg/version"
 
 	"github.com/fluxcd/flux-schema/internal/tmpl"
+	"github.com/fluxcd/flux-schema/internal/useragent"
 )
 
 const (
@@ -101,13 +102,16 @@ var versionCandidates = []string{
 var errResourceNotFound = errors.New("couldn't find resource")
 
 type Options struct {
-	SchemaLocations       []string
-	MetadataLocations     []string
-	IndexLocations        []string
-	APIVersion            string
-	OutputFormat          string
-	Recursive             bool
-	HTTPClient            *retryablehttp.Client
+	SchemaLocations   []string
+	MetadataLocations []string
+	IndexLocations    []string
+	APIVersion        string
+	OutputFormat      string
+	Recursive         bool
+	HTTPClient        *retryablehttp.Client
+	// UserAgent is the value for the User-Agent header on schema fetches;
+	// empty leaves the client untouched.
+	UserAgent             string
 	HTTPTimeout           time.Duration
 	InsecureSkipTLSVerify bool
 }
@@ -258,6 +262,9 @@ func New(opts Options) (*Explainer, error) {
 		if opts.InsecureSkipTLSVerify {
 			client.HTTPClient = &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
 		}
+	}
+	if opts.UserAgent != "" {
+		useragent.Wrap(client, opts.UserAgent)
 	}
 	opts.SchemaLocations = locations
 	return &Explainer{opts: opts, templates: compiled, client: client, byteCache: map[string]byteCacheEntry{}}, nil

--- a/internal/explain/explain_test.go
+++ b/internal/explain/explain_test.go
@@ -114,6 +114,7 @@ func TestEcosystemIndexResolveAndComplete(t *testing.T) {
 
 	var helmReleaseRequests int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g.Expect(r.Header.Get("User-Agent")).To(Equal("flux-schema/internal-explain"))
 		switch r.URL.Path {
 		case "/index.json":
 			_, _ = fmt.Fprint(w, `{"v":3,"projects":[{"groups":[{"g":"helm.toolkit.fluxcd.io","kinds":[["helmrelease",["v2"],1,"HelmRelease",{"n":["hr"]}]]},{"g":"source.extensions.fluxcd.io","kinds":[["artifactgenerator",["v1beta1"],1,"ArtifactGenerator",{"n":["ag"]}]]}]}]}`)
@@ -150,6 +151,7 @@ func TestEcosystemIndexResolveAndComplete(t *testing.T) {
 	ex, err := New(Options{
 		SchemaLocations: []string{srv.URL + "/catalog/{{.Group}}/{{.Kind}}_{{.Version}}.json"},
 		IndexLocations:  []string{srv.URL + "/index.json"},
+		UserAgent:       "flux-schema/internal-explain",
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package useragent provides HTTP transport helpers for setting User-Agent.
+package useragent
+
+import (
+	"net/http"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+type transport struct {
+	agent string
+	next  http.RoundTripper
+}
+
+// Transport returns a RoundTripper that sets User-Agent on a cloned request
+// before delegating to next. When next is nil, http.DefaultTransport is used.
+func Transport(agent string, next http.RoundTripper) http.RoundTripper {
+	if next == nil {
+		next = http.DefaultTransport
+	}
+	return transport{agent: agent, next: next}
+}
+
+func (t transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	if cloned.Header == nil {
+		cloned.Header = make(http.Header)
+	}
+	cloned.Header.Set("User-Agent", t.agent)
+	return t.next.RoundTrip(cloned)
+}
+
+// Wrap configures c to set User-Agent on outbound requests.
+func Wrap(c *retryablehttp.Client, agent string) {
+	if c.HTTPClient == nil {
+		c.HTTPClient = &http.Client{}
+	}
+	c.HTTPClient.Transport = Transport(agent, c.HTTPClient.Transport)
+}

--- a/internal/useragent/useragent_test.go
+++ b/internal/useragent/useragent_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package useragent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/go-retryablehttp"
+	. "github.com/onsi/gomega"
+)
+
+func TestTransportSetsUserAgentWithNilNext(t *testing.T) {
+	g := NewWithT(t)
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Transport: Transport("flux-schema/test", nil)}
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	req.Header.Set("User-Agent", "original")
+
+	resp, err := client.Do(req)
+	g.Expect(err).ToNot(HaveOccurred())
+	defer resp.Body.Close()
+
+	g.Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+	g.Expect(got).To(Equal("flux-schema/test"))
+	g.Expect(req.Header.Get("User-Agent")).To(Equal("original"))
+}
+
+func TestWrapRetryableHTTPClient(t *testing.T) {
+	g := NewWithT(t)
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := retryablehttp.NewClient()
+	client.Logger = nil
+	client.RetryMax = 0
+	Wrap(client, "flux-schema/retryable")
+
+	req, err := retryablehttp.NewRequest(http.MethodGet, srv.URL, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	resp, err := client.Do(req)
+	g.Expect(err).ToNot(HaveOccurred())
+	defer resp.Body.Close()
+
+	g.Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+	g.Expect(got).To(Equal("flux-schema/retryable"))
+}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/fluxcd/flux-schema/internal/tmpl"
+	"github.com/fluxcd/flux-schema/internal/useragent"
 	"github.com/fluxcd/flux-schema/internal/yamldoc"
 )
 
@@ -100,13 +101,16 @@ func (r Result) Identifier() string {
 // StdinSource. It is the caller's responsibility to pass a non-nil reader
 // (typically os.Stdin) when that sentinel is used.
 type Options struct {
-	SchemaLocations       []string
-	SkipMissingSchemas    bool
-	SkipKinds             []string
-	SkipJSONPaths         []string
-	SkipFiles             []string
-	SkipCELRules          bool
-	HTTPClient            *retryablehttp.Client
+	SchemaLocations    []string
+	SkipMissingSchemas bool
+	SkipKinds          []string
+	SkipJSONPaths      []string
+	SkipFiles          []string
+	SkipCELRules       bool
+	HTTPClient         *retryablehttp.Client
+	// UserAgent is the value for the User-Agent header on schema fetches;
+	// empty leaves the client untouched.
+	UserAgent             string
 	HTTPTimeout           time.Duration
 	Workers               int
 	InsecureSkipTLSVerify bool
@@ -286,6 +290,9 @@ func New(opts Options) (*Validator, error) {
 			applyInsecureTLS(c)
 		}
 		opts.HTTPClient = c
+	}
+	if opts.UserAgent != "" {
+		useragent.Wrap(opts.HTTPClient, opts.UserAgent)
 	}
 
 	skipKinds := make([]skipKindMatcher, 0, len(opts.SkipKinds))

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -1250,6 +1250,7 @@ func TestValidateBytes_MissingApiVersionAndKind_Skipped(t *testing.T) {
 func TestValidateSources_ConcurrencyCacheDedup(t *testing.T) {
 	g := NewWithT(t)
 	var requestCount atomic.Int32
+	var gotUserAgent string
 	// Build a valid schema to return on every request.
 	schemaBody, err := json.Marshal(map[string]any{
 		"type":     "object",
@@ -1265,6 +1266,7 @@ func TestValidateSources_ConcurrencyCacheDedup(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount.Add(1)
+		gotUserAgent = r.Header.Get("User-Agent")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(schemaBody)
 	}))
@@ -1277,6 +1279,7 @@ func TestValidateSources_ConcurrencyCacheDedup(t *testing.T) {
 	v, err := New(Options{
 		SchemaLocations: []string{srv.URL + "/{{ .Kind }}_{{ .Version }}.json"},
 		HTTPClient:      client,
+		UserAgent:       "flux-schema/internal-validator",
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -1309,6 +1312,7 @@ spec: {}
 	g.Expect(count).To(Equal(50))
 	// Exactly one HTTP fetch thanks to the sync.Map + sync.Once cache.
 	g.Expect(requestCount.Load()).To(Equal(int32(1)))
+	g.Expect(gotUserAgent).To(Equal("flux-schema/internal-validator"))
 }
 
 // TestValidateSources_SourceLoadError exercises the produceFromPath →


### PR DESCRIPTION
All HTTP fetches now send User-Agent `flux-schema/<version>` instead of `Go-http-client/2.0`.