### PR TITLE
Ignore $schema and $id in structural schemas

### DIFF
--- a/internal/validator/admission.go
+++ b/internal/validator/admission.go
@@ -88,6 +88,12 @@ func hasAdmissionValidation(node any) bool {
 
 func newStructuralSchema(raw map[string]any) (*apiextschema.Structural, error) {
 	structuralRaw := rewriteForKubernetesStructural(raw).(map[string]any)
+	// $schema and $id are JSON Schema document metadata with no admission or
+	// CEL semantics, but they round-trip into JSONSchemaProps fields that
+	// NewStructural rejects. Third-party catalogs commonly set $schema, so
+	// drop both from the structural copy instead of failing the build.
+	delete(structuralRaw, "$schema")
+	delete(structuralRaw, "$id")
 	body, err := json.Marshal(structuralRaw)
 	if err != nil {
 		return nil, fmt.Errorf("marshal schema: %w", err)

--- a/internal/validator/cel_test.go
+++ b/internal/validator/cel_test.go
@@ -182,6 +182,41 @@ func TestNewCELValidator_RulePassesWhenSatisfied(t *testing.T) {
 	g.Expect(v.Validate(context.Background(), doc)).To(BeEmpty())
 }
 
+func TestNewStructuralSchema_IgnoresSchemaMetadataKeys(t *testing.T) {
+	g := NewWithT(t)
+	// Third-party catalogs commonly carry root $schema/$id; NewStructural
+	// rejects both, so the structural build must drop them instead of
+	// failing every schema that also has x-kubernetes-* extensions.
+	schema := schemaFromJSON(t, `{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id": "https://example.com/widget_v1.json",
+		"type": "object",
+		"properties": {
+			"spec": {
+				"type": "object",
+				"properties": { "foo": { "type": "string" } },
+				"x-kubernetes-validations": [
+					{ "rule": "self.foo == 'ok'", "message": "spec.foo must be ok" }
+				]
+			}
+		}
+	}`)
+
+	v, err := newCELValidator(schema)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(v).ToNot(BeNil())
+
+	doc := map[string]any{"spec": map[string]any{"foo": "bad"}}
+	errs := v.Validate(context.Background(), doc)
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0].Msg).To(ContainSubstring("spec.foo must be ok"))
+
+	// The loader reuses the raw map for JSON Schema compilation; the
+	// structural rewrite must not strip keys from the caller's copy.
+	g.Expect(schema).To(HaveKey("$schema"))
+	g.Expect(schema).To(HaveKey("$id"))
+}
+
 func TestNewCELValidator_DefaultsBeforeCELAllowsUnguardedGatewayFields(t *testing.T) {
 	g := NewWithT(t)
 	schema := schemaFromJSON(t, `{


### PR DESCRIPTION
Schemas carrying a root $schema or $id round-trip into JSONSchemaProps fields that apiextensions NewStructural rejects, so any schema that also uses x-kubernetes-* extensions failed its admission/CEL build and every document of that kind was reported invalid:

  structural schema: OpenAPIV3Schema 'schema' is not supported

Both keys are JSON Schema document metadata with no admission or CEL semantics, and third-party catalogs commonly set $schema. Drop them from the structural copy; the compiled JSON Schema path still honors them.


Assisted-by: Claude Code/claude-fable-5