### PR TITLE
action: Use the ecosystem catalog as fallback

### DIFF
--- a/actions/validate/README.md
+++ b/actions/validate/README.md
@@ -46,7 +46,8 @@ jobs:
 By default, the action looks for a `.fluxschema.yml` file at the repository
 root. When present, all validation options (schema locations, skipped kinds,
 SOPS field stripping, etc.) are read from it. When absent, the action falls
-back to a built-in set of defaults that targets the Flux Schema catalog.
+back to a built-in set of defaults that targets the ecosystem catalog at
+[schemas.fluxoperator.dev](https://schemas.fluxoperator.dev/).
 
 ### Using a config file
 
@@ -146,10 +147,10 @@ surface for tools and AI agents. It can be uploaded as a workflow artifact:
 
 ## Action Inputs
 
-| Name            | Description                                                                                                                   | Default           |
-|-----------------|-------------------------------------------------------------------------------------------------------------------------------|-------------------|
-| `path`          | Root directory to validate (relative to the repository root).                                                                 | `.`               |
-| `exclude`       | Newline-separated list of directories to exclude from validation and the bundle.                                              | `""`              |
-| `config`        | Path to Flux Schema CLI config file. When the file does not exist, sensible defaults targeting the built-in catalog are used. | `.fluxschema.yml` |
-| `helm-charts`   | Render Helm charts with `helm template` using their default values and validate the output. Requires `helm` on `PATH`.        | `"false"`         |
-| `output-bundle` | Path to a file where all manifests and rendered overlays are merged as a single YAML stream with provenance comments.         | `""`              |
+| Name            | Description                                                                                                                       | Default           |
+|-----------------|-----------------------------------------------------------------------------------------------------------------------------------|-------------------|
+| `path`          | Root directory to validate (relative to the repository root).                                                                     | `.`               |
+| `exclude`       | Newline-separated list of directories to exclude from validation and the bundle.                                                  | `""`              |
+| `config`        | Path to Flux Schema CLI config file. When the file does not exist, sensible defaults targeting the ecosystem catalog are used.    | `.fluxschema.yml` |
+| `helm-charts`   | Render Helm charts with `helm template` using their default values and validate the output. Requires `helm` on `PATH`.            | `"false"`         |
+| `output-bundle` | Path to a file where all manifests and rendered overlays are merged as a single YAML stream with provenance comments.             | `""`              |

--- a/actions/validate/action.yaml
+++ b/actions/validate/action.yaml
@@ -16,7 +16,7 @@ inputs:
   config:
     description: |
       Path to a flux-schema config file (relative to the repository root).
-      When the file does not exist, the default Flux Schema catalog will be used.
+      When the file does not exist, the ecosystem catalog (schemas.fluxoperator.dev) will be used.
     required: false
     default: ".fluxschema.yml"
   output-bundle:

--- a/actions/validate/validate.sh
+++ b/actions/validate/validate.sh
@@ -4,8 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This script validates Kubernetes manifests using the Flux Schema CLI.
-# It builds kustomize overlays and validating the output against the
-# default schema catalog or a user-provided config file.
+# It builds kustomize overlays and validates the output using a user-provided
+# config file, or the ecosystem catalog (schemas.fluxoperator.dev) when no
+# config file is found.
 # Arguments after '--' are passed verbatim to 'flux-schema validate' and
 # take precedence over the config file, so callers (e.g. AI agents) can
 # set validation options inline without writing a config file to disk.
@@ -66,11 +67,12 @@ kustomize_config="kustomization.yaml"
 helm_flags=("--include-crds")
 helm_config="Chart.yaml"
 
-# Default flags used when no config file is found. Strip SOPS-encrypted
-# fields before validation (Flux removes these at apply time), skip documents
-# whose schema is not in the catalog, and pin text output so the per-resource
-# summary tally is parsed reliably (a config or '--' override owns the format).
-default_flux_schema_flags=("--skip-json-path=/sops" "--skip-missing-schemas" "--verbose" "--output=text")
+# Default flags used when no config file is found. Use the ecosystem catalog,
+# strip SOPS-encrypted fields before validation (Flux removes these at apply
+# time), skip documents whose schema is not in the catalog, and pin text output
+# so the per-resource summary tally is parsed reliably (a config or '--'
+# override owns the format).
+default_flux_schema_flags=("--schema-location=ecosystem" "--skip-json-path=/sops" "--skip-missing-schemas" "--verbose" "--output=text")
 
 # Effective flags passed to flux-schema, populated by resolve_config.
 flux_schema_flags=()


### PR DESCRIPTION
Set the [ecosystem catalog](https://schemas.fluxoperator.dev/catalog/) as fallback when no config is present in the repo.