### PR TITLE
Add validate.sh script to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,12 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
 
 FROM alpine:3.23
 
-RUN apk --no-cache add ca-certificates \
+RUN apk --no-cache add bash ca-certificates \
   && update-ca-certificates
 
 COPY catalog/ /catalog/
 COPY --from=builder /usr/local/bin/flux-schema /usr/local/bin/
+COPY --chmod=0755 actions/validate/validate.sh /usr/local/bin/flux-schema-validate.sh
 
 USER 65534:65534
 


### PR DESCRIPTION
We use the image to create a GitLab CI/CD component with equivalent features as the GHA provided by this project. The GitLab component job is running on (an extension) of the flux-schema image. To include the script, where most of the action is implemented, we need to download it from a GitLab mirror of this project. This is something that I was hoping to avoid, which is the motivation for this PR.

This PR adds the `validate.sh` script to the image provided. Since bash is needed to run the script, I propose to also install the Alpine bash package. The image size is getting a slight increase by this change, but not dramatically. And I think it would be sad to include a script that cannot run.