### PR TITLE
Add absent JSON path skip flag

### DIFF
--- a/api/v1beta1/config_types.go
+++ b/api/v1beta1/config_types.go
@@ -44,6 +44,11 @@ type ValidateConfig struct {
 	// +optional
 	SkipJSONPaths []string `json:"skipJSONPath,omitempty"`
 
+	// IgnoreJSONPathIfAbsent contains JSON Pointers whose required-property
+	// errors are ignored when the field is absent.
+	// +optional
+	IgnoreJSONPathIfAbsent []string `json:"ignoreJSONPathIfAbsent,omitempty"`
+
 	// SkipFiles contains basename glob patterns excluded from validation.
 	// +optional
 	SkipFiles []string `json:"skipFile,omitempty"`

--- a/api/v1beta1/config_types.go
+++ b/api/v1beta1/config_types.go
@@ -44,10 +44,10 @@ type ValidateConfig struct {
 	// +optional
 	SkipJSONPaths []string `json:"skipJSONPath,omitempty"`
 
-	// IgnoreJSONPathIfAbsent contains JSON Pointers whose required-property errors
-	// are ignored when the field is absent; CEL is skipped for matching documents.
+	// SkipJSONPathIfAbsent contains JSON Pointers whose required-property errors
+	// are skipped when the field is absent; CEL is skipped for matching documents.
 	// +optional
-	IgnoreJSONPathIfAbsent []string `json:"ignoreJSONPathIfAbsent,omitempty"`
+	SkipJSONPathIfAbsent []string `json:"skipJSONPathIfAbsent,omitempty"`
 
 	// SkipFiles contains basename glob patterns excluded from validation.
 	// +optional

--- a/api/v1beta1/config_types.go
+++ b/api/v1beta1/config_types.go
@@ -44,8 +44,8 @@ type ValidateConfig struct {
 	// +optional
 	SkipJSONPaths []string `json:"skipJSONPath,omitempty"`
 
-	// IgnoreJSONPathIfAbsent contains JSON Pointers whose required-property
-	// errors are ignored when the field is absent.
+	// IgnoreJSONPathIfAbsent contains JSON Pointers whose required-property errors
+	// are ignored when the field is absent; CEL is skipped for matching documents.
 	// +optional
 	IgnoreJSONPathIfAbsent []string `json:"ignoreJSONPathIfAbsent,omitempty"`
 

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -290,6 +290,11 @@ func (in *ValidateConfig) DeepCopyInto(out *ValidateConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.IgnoreJSONPathIfAbsent != nil {
+		in, out := &in.IgnoreJSONPathIfAbsent, &out.IgnoreJSONPathIfAbsent
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.SkipFiles != nil {
 		in, out := &in.SkipFiles, &out.SkipFiles
 		*out = make([]string, len(*in))

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -290,8 +290,8 @@ func (in *ValidateConfig) DeepCopyInto(out *ValidateConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.IgnoreJSONPathIfAbsent != nil {
-		in, out := &in.IgnoreJSONPathIfAbsent, &out.IgnoreJSONPathIfAbsent
+	if in.SkipJSONPathIfAbsent != nil {
+		in, out := &in.SkipJSONPathIfAbsent, &out.SkipJSONPathIfAbsent
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/catalog/latest/schema.plugin.fluxcd.io/config_v1beta1.json
+++ b/catalog/latest/schema.plugin.fluxcd.io/config_v1beta1.json
@@ -58,13 +58,6 @@
           "description": "FailFast exits after the first invalid document.",
           "type": "boolean"
         },
-        "ignoreJSONPathIfAbsent": {
-          "description": "IgnoreJSONPathIfAbsent contains JSON Pointers whose required-property errors\nare ignored when the field is absent; CEL is skipped for matching documents.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "insecureSkipTLSVerify": {
           "description": "InsecureSkipTLSVerify disables TLS certificate verification for HTTPS schemas.",
           "type": "boolean"
@@ -98,6 +91,13 @@
         },
         "skipJSONPath": {
           "description": "SkipJSONPaths contains JSON Pointers stripped before validation.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "skipJSONPathIfAbsent": {
+          "description": "SkipJSONPathIfAbsent contains JSON Pointers whose required-property errors\nare skipped when the field is absent; CEL is skipped for matching documents.",
           "items": {
             "type": "string"
           },

--- a/catalog/latest/schema.plugin.fluxcd.io/config_v1beta1.json
+++ b/catalog/latest/schema.plugin.fluxcd.io/config_v1beta1.json
@@ -59,7 +59,7 @@
           "type": "boolean"
         },
         "ignoreJSONPathIfAbsent": {
-          "description": "IgnoreJSONPathIfAbsent contains JSON Pointers whose required-property\nerrors are ignored when the field is absent.",
+          "description": "IgnoreJSONPathIfAbsent contains JSON Pointers whose required-property errors\nare ignored when the field is absent; CEL is skipped for matching documents.",
           "items": {
             "type": "string"
           },

--- a/catalog/latest/schema.plugin.fluxcd.io/config_v1beta1.json
+++ b/catalog/latest/schema.plugin.fluxcd.io/config_v1beta1.json
@@ -58,6 +58,13 @@
           "description": "FailFast exits after the first invalid document.",
           "type": "boolean"
         },
+        "ignoreJSONPathIfAbsent": {
+          "description": "IgnoreJSONPathIfAbsent contains JSON Pointers whose required-property\nerrors are ignored when the field is absent.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "insecureSkipTLSVerify": {
           "description": "InsecureSkipTLSVerify disables TLS certificate verification for HTTPS schemas.",
           "type": "boolean"

--- a/cmd/flux-schema/config.go
+++ b/cmd/flux-schema/config.go
@@ -121,8 +121,8 @@ func applyValidateConfig(cmd *cobra.Command, cfg *apiv1.ValidateConfig, args *va
 	if cfg.SkipJSONPaths != nil && !flags.Changed("skip-json-path") {
 		args.skipJSONPaths = cfg.SkipJSONPaths
 	}
-	if cfg.IgnoreJSONPathIfAbsent != nil && !flags.Changed("ignore-json-path-if-absent") {
-		args.ignoreJSONPathIfAbsent = cfg.IgnoreJSONPathIfAbsent
+	if cfg.SkipJSONPathIfAbsent != nil && !flags.Changed("skip-json-path-if-absent") {
+		args.skipJSONPathIfAbsent = cfg.SkipJSONPathIfAbsent
 	}
 	if cfg.SkipFiles != nil && !flags.Changed("skip-file") {
 		args.skipFiles = cfg.SkipFiles

--- a/cmd/flux-schema/config.go
+++ b/cmd/flux-schema/config.go
@@ -121,6 +121,9 @@ func applyValidateConfig(cmd *cobra.Command, cfg *apiv1.ValidateConfig, args *va
 	if cfg.SkipJSONPaths != nil && !flags.Changed("skip-json-path") {
 		args.skipJSONPaths = cfg.SkipJSONPaths
 	}
+	if cfg.IgnoreJSONPathIfAbsent != nil && !flags.Changed("ignore-json-path-if-absent") {
+		args.ignoreJSONPathIfAbsent = cfg.IgnoreJSONPathIfAbsent
+	}
 	if cfg.SkipFiles != nil && !flags.Changed("skip-file") {
 		args.skipFiles = cfg.SkipFiles
 	}

--- a/cmd/flux-schema/validate.go
+++ b/cmd/flux-schema/validate.go
@@ -52,9 +52,9 @@ var validateCmd = &cobra.Command{
   flux-schema validate ./manifests \
     --skip-json-path v1/Secret:/sops
 
-  # Ignore required-field errors for values defaulted by admission hooks
+  # Skip required-field errors for values defaulted by admission hooks
   flux-schema validate ./manifests \
-    --ignore-json-path-if-absent Widget:/spec/replicas
+    --skip-json-path-if-absent Widget:/spec/replicas
 
   # Skip files and directories by basename glob
   # default skips dotfiles and dot-directories e.g. '.git'
@@ -68,19 +68,19 @@ var validateCmd = &cobra.Command{
 }
 
 type validateFlags struct {
-	schemaLocations        []string
-	skipMissingSchemas     bool
-	skipKinds              []string
-	skipJSONPaths          []string
-	ignoreJSONPathIfAbsent []string
-	skipFiles              []string
-	skipCELRules           bool
-	verbose                bool
-	failFast               bool
-	concurrent             int
-	insecureSkipTLSVerify  bool
-	configFile             string
-	output                 flags.Output
+	schemaLocations       []string
+	skipMissingSchemas    bool
+	skipKinds             []string
+	skipJSONPaths         []string
+	skipJSONPathIfAbsent  []string
+	skipFiles             []string
+	skipCELRules          bool
+	verbose               bool
+	failFast              bool
+	concurrent            int
+	insecureSkipTLSVerify bool
+	configFile            string
+	output                flags.Output
 }
 
 var validateArgs = validateFlags{
@@ -97,8 +97,8 @@ func init() {
 		"skip documents matching kind or apiVersion/kind e.g. 'v1/Secret' (repeatable)")
 	validateCmd.Flags().StringArrayVar(&validateArgs.skipJSONPaths, "skip-json-path", nil,
 		"strip a JSON Pointer field, optionally scoped e.g. 'v1/Secret:/sops' (repeatable)")
-	validateCmd.Flags().StringArrayVar(&validateArgs.ignoreJSONPathIfAbsent, "ignore-json-path-if-absent", nil,
-		"ignore a missing required JSON Pointer field, optionally scoped e.g. 'Widget:/spec/replicas' (repeatable)")
+	validateCmd.Flags().StringArrayVar(&validateArgs.skipJSONPathIfAbsent, "skip-json-path-if-absent", nil,
+		"skip a missing required JSON Pointer field, optionally scoped e.g. 'Widget:/spec/replicas' (repeatable)")
 	validateCmd.Flags().StringArrayVar(&validateArgs.skipFiles, "skip-file", nil,
 		"glob pattern matched against files and dirs "+
 			"defaults to skipping dotfiles and dot-dirs (repeatable)")
@@ -452,17 +452,17 @@ func buildValidatorOptions(inputs []string) (validator.Options, error) {
 		return validator.Options{}, fmt.Errorf("--concurrent must be >= 1, got %d", validateArgs.concurrent)
 	}
 	opts := validator.Options{
-		SchemaLocations:        locations,
-		SkipMissingSchemas:     validateArgs.skipMissingSchemas,
-		SkipKinds:              validateArgs.skipKinds,
-		SkipJSONPaths:          validateArgs.skipJSONPaths,
-		IgnoreJSONPathIfAbsent: validateArgs.ignoreJSONPathIfAbsent,
-		SkipFiles:              validateArgs.skipFiles,
-		SkipCELRules:           validateArgs.skipCELRules,
-		UserAgent:              userAgent(),
-		HTTPTimeout:            rootArgs.timeout,
-		Workers:                validateArgs.concurrent,
-		InsecureSkipTLSVerify:  validateArgs.insecureSkipTLSVerify,
+		SchemaLocations:       locations,
+		SkipMissingSchemas:    validateArgs.skipMissingSchemas,
+		SkipKinds:             validateArgs.skipKinds,
+		SkipJSONPaths:         validateArgs.skipJSONPaths,
+		SkipJSONPathIfAbsent:  validateArgs.skipJSONPathIfAbsent,
+		SkipFiles:             validateArgs.skipFiles,
+		SkipCELRules:          validateArgs.skipCELRules,
+		UserAgent:             userAgent(),
+		HTTPTimeout:           rootArgs.timeout,
+		Workers:               validateArgs.concurrent,
+		InsecureSkipTLSVerify: validateArgs.insecureSkipTLSVerify,
 	}
 	if slices.Contains(inputs, stdinLabel) {
 		opts.Stdin = stdinReader

--- a/cmd/flux-schema/validate.go
+++ b/cmd/flux-schema/validate.go
@@ -52,6 +52,10 @@ var validateCmd = &cobra.Command{
   flux-schema validate ./manifests \
     --skip-json-path v1/Secret:/sops
 
+  # Ignore required-field errors for values defaulted by admission hooks
+  flux-schema validate ./manifests \
+    --ignore-json-path-if-absent Widget:/spec/replicas
+
   # Skip files and directories by basename glob
   # default skips dotfiles and dot-directories e.g. '.git'
   flux-schema validate ./manifests \
@@ -64,18 +68,19 @@ var validateCmd = &cobra.Command{
 }
 
 type validateFlags struct {
-	schemaLocations       []string
-	skipMissingSchemas    bool
-	skipKinds             []string
-	skipJSONPaths         []string
-	skipFiles             []string
-	skipCELRules          bool
-	verbose               bool
-	failFast              bool
-	concurrent            int
-	insecureSkipTLSVerify bool
-	configFile            string
-	output                flags.Output
+	schemaLocations        []string
+	skipMissingSchemas     bool
+	skipKinds              []string
+	skipJSONPaths          []string
+	ignoreJSONPathIfAbsent []string
+	skipFiles              []string
+	skipCELRules           bool
+	verbose                bool
+	failFast               bool
+	concurrent             int
+	insecureSkipTLSVerify  bool
+	configFile             string
+	output                 flags.Output
 }
 
 var validateArgs = validateFlags{
@@ -92,6 +97,8 @@ func init() {
 		"skip documents matching kind or apiVersion/kind e.g. 'v1/Secret' (repeatable)")
 	validateCmd.Flags().StringArrayVar(&validateArgs.skipJSONPaths, "skip-json-path", nil,
 		"strip a JSON Pointer field, optionally scoped e.g. 'v1/Secret:/sops' (repeatable)")
+	validateCmd.Flags().StringArrayVar(&validateArgs.ignoreJSONPathIfAbsent, "ignore-json-path-if-absent", nil,
+		"ignore a missing required JSON Pointer field, optionally scoped e.g. 'Widget:/spec/replicas' (repeatable)")
 	validateCmd.Flags().StringArrayVar(&validateArgs.skipFiles, "skip-file", nil,
 		"glob pattern matched against files and dirs "+
 			"defaults to skipping dotfiles and dot-dirs (repeatable)")
@@ -445,16 +452,17 @@ func buildValidatorOptions(inputs []string) (validator.Options, error) {
 		return validator.Options{}, fmt.Errorf("--concurrent must be >= 1, got %d", validateArgs.concurrent)
 	}
 	opts := validator.Options{
-		SchemaLocations:       locations,
-		SkipMissingSchemas:    validateArgs.skipMissingSchemas,
-		SkipKinds:             validateArgs.skipKinds,
-		SkipJSONPaths:         validateArgs.skipJSONPaths,
-		SkipFiles:             validateArgs.skipFiles,
-		SkipCELRules:          validateArgs.skipCELRules,
-		UserAgent:             userAgent(),
-		HTTPTimeout:           rootArgs.timeout,
-		Workers:               validateArgs.concurrent,
-		InsecureSkipTLSVerify: validateArgs.insecureSkipTLSVerify,
+		SchemaLocations:        locations,
+		SkipMissingSchemas:     validateArgs.skipMissingSchemas,
+		SkipKinds:              validateArgs.skipKinds,
+		SkipJSONPaths:          validateArgs.skipJSONPaths,
+		IgnoreJSONPathIfAbsent: validateArgs.ignoreJSONPathIfAbsent,
+		SkipFiles:              validateArgs.skipFiles,
+		SkipCELRules:           validateArgs.skipCELRules,
+		UserAgent:              userAgent(),
+		HTTPTimeout:            rootArgs.timeout,
+		Workers:                validateArgs.concurrent,
+		InsecureSkipTLSVerify:  validateArgs.insecureSkipTLSVerify,
 	}
 	if slices.Contains(inputs, stdinLabel) {
 		opts.Stdin = stdinReader

--- a/cmd/flux-schema/validate_test.go
+++ b/cmd/flux-schema/validate_test.go
@@ -53,6 +53,31 @@ func writeManifest(t *testing.T, dir, name, body string) string {
 	return path
 }
 
+func writeRequiredWidgetSchema(t *testing.T, dir string) {
+	t.Helper()
+	g := NewWithT(t)
+	schema := map[string]any{
+		"type":     "object",
+		"required": []any{"apiVersion", "kind", "spec"},
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"type": "string"},
+			"kind":       map[string]any{"type": "string"},
+			"metadata":   map[string]any{"type": "object"},
+			"spec": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"required":             []any{"name"},
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+				},
+			},
+		},
+	}
+	b, err := json.MarshalIndent(schema, "", "  ")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(os.WriteFile(filepath.Join(dir, "widget-example-v1.json"), b, 0o644)).To(Succeed())
+}
+
 const validWidget = `apiVersion: example.com/v1
 kind: Widget
 metadata:
@@ -553,6 +578,41 @@ func TestValidateCmd_SkipJSONPath_Invalid(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("skip JSON path pattern")))
 }
 
+func TestValidateCmd_IgnoreJSONPathIfAbsent(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := t.TempDir()
+	writeRequiredWidgetSchema(t, schemaDir)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "defaulted.yaml", `apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: defaulted-widget
+  namespace: default
+spec: {}
+`)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--ignore-json-path-if-absent", "Widget:/spec/name",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("Summary: 1 resource found in 1 file - Valid: 1, Invalid: 0, Skipped: 0"))
+}
+
+func TestValidateCmd_IgnoreJSONPathIfAbsent_Invalid(t *testing.T) {
+	g := NewWithT(t)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+
+	_, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(t.TempDir(), "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--ignore-json-path-if-absent", "no-leading-slash",
+	})
+	g.Expect(err).To(MatchError(ContainSubstring("ignore JSON path if absent pattern")))
+}
+
 func TestValidateCmd_SkipKind_Invalid(t *testing.T) {
 	g := NewWithT(t)
 	manifestDir := t.TempDir()
@@ -650,6 +710,66 @@ validate:
 		"--schema-location", "./testdata/validate/schemas/{{ .Group }}/{{ .Kind }}_{{ .Version }}.json",
 		"--config", cfg,
 		"--skip-json-path", "Secret:/does-not-exist",
+	})
+	g.Expect(err).To(HaveOccurred())
+}
+
+// Config file's ignore-json-path-if-absent entries are picked up when the
+// flag is absent.
+func TestValidateCmd_Config_IgnoreJSONPathIfAbsent(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := t.TempDir()
+	writeRequiredWidgetSchema(t, schemaDir)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "defaulted.yaml", `apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: defaulted-widget
+  namespace: default
+spec: {}
+`)
+
+	cfg := writeManifest(t, t.TempDir(), ".fluxschema.yml", `apiVersion: schema.plugin.fluxcd.io/v1beta1
+kind: Config
+validate:
+  ignoreJSONPathIfAbsent:
+    - Widget:/spec/name
+`)
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--config", cfg,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("Valid: 1, Invalid: 0, Skipped: 0"))
+}
+
+// CLI --ignore-json-path-if-absent replaces (does not merge with) the config's
+// list.
+func TestValidateCmd_Config_CLIOverridesIgnoreJSONPathIfAbsent(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := t.TempDir()
+	writeRequiredWidgetSchema(t, schemaDir)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "defaulted.yaml", `apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: defaulted-widget
+  namespace: default
+spec: {}
+`)
+
+	cfg := writeManifest(t, t.TempDir(), ".fluxschema.yml", `apiVersion: schema.plugin.fluxcd.io/v1beta1
+kind: Config
+validate:
+  ignoreJSONPathIfAbsent:
+    - Widget:/spec/name
+`)
+	_, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+		"--config", cfg,
+		"--ignore-json-path-if-absent", "Widget:/spec/doesNotExist",
 	})
 	g.Expect(err).To(HaveOccurred())
 }
@@ -1019,6 +1139,8 @@ validate:
     - Widget
   skipJSONPath:
     - Secret:/sops
+  ignoreJSONPathIfAbsent:
+    - Widget:/spec/name
   skipFile:
     - '.*'
   skipCELRules: true

--- a/cmd/flux-schema/validate_test.go
+++ b/cmd/flux-schema/validate_test.go
@@ -578,7 +578,7 @@ func TestValidateCmd_SkipJSONPath_Invalid(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("skip JSON path pattern")))
 }
 
-func TestValidateCmd_IgnoreJSONPathIfAbsent(t *testing.T) {
+func TestValidateCmd_SkipJSONPathIfAbsent(t *testing.T) {
 	g := NewWithT(t)
 	schemaDir := t.TempDir()
 	writeRequiredWidgetSchema(t, schemaDir)
@@ -594,13 +594,13 @@ spec: {}
 	out, err := executeCommand([]string{
 		"validate", manifestDir,
 		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
-		"--ignore-json-path-if-absent", "Widget:/spec/name",
+		"--skip-json-path-if-absent", "Widget:/spec/name",
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(out).To(ContainSubstring("Summary: 1 resource found in 1 file - Valid: 1, Invalid: 0, Skipped: 0"))
 }
 
-func TestValidateCmd_IgnoreJSONPathIfAbsent_Invalid(t *testing.T) {
+func TestValidateCmd_SkipJSONPathIfAbsent_Invalid(t *testing.T) {
 	g := NewWithT(t)
 	manifestDir := t.TempDir()
 	writeManifest(t, manifestDir, "ok.yaml", validWidget)
@@ -608,9 +608,9 @@ func TestValidateCmd_IgnoreJSONPathIfAbsent_Invalid(t *testing.T) {
 	_, err := executeCommand([]string{
 		"validate", manifestDir,
 		"--schema-location", filepath.Join(t.TempDir(), "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
-		"--ignore-json-path-if-absent", "no-leading-slash",
+		"--skip-json-path-if-absent", "no-leading-slash",
 	})
-	g.Expect(err).To(MatchError(ContainSubstring("ignore JSON path if absent pattern")))
+	g.Expect(err).To(MatchError(ContainSubstring("skip JSON path if absent pattern")))
 }
 
 func TestValidateCmd_SkipKind_Invalid(t *testing.T) {
@@ -714,9 +714,9 @@ validate:
 	g.Expect(err).To(HaveOccurred())
 }
 
-// Config file's ignore-json-path-if-absent entries are picked up when the
+// Config file's skip-json-path-if-absent entries are picked up when the
 // flag is absent.
-func TestValidateCmd_Config_IgnoreJSONPathIfAbsent(t *testing.T) {
+func TestValidateCmd_Config_SkipJSONPathIfAbsent(t *testing.T) {
 	g := NewWithT(t)
 	schemaDir := t.TempDir()
 	writeRequiredWidgetSchema(t, schemaDir)
@@ -732,7 +732,7 @@ spec: {}
 	cfg := writeManifest(t, t.TempDir(), ".fluxschema.yml", `apiVersion: schema.plugin.fluxcd.io/v1beta1
 kind: Config
 validate:
-  ignoreJSONPathIfAbsent:
+  skipJSONPathIfAbsent:
     - Widget:/spec/name
 `)
 	out, err := executeCommand([]string{
@@ -744,9 +744,9 @@ validate:
 	g.Expect(out).To(ContainSubstring("Valid: 1, Invalid: 0, Skipped: 0"))
 }
 
-// CLI --ignore-json-path-if-absent replaces (does not merge with) the config's
+// CLI --skip-json-path-if-absent replaces (does not merge with) the config's
 // list.
-func TestValidateCmd_Config_CLIOverridesIgnoreJSONPathIfAbsent(t *testing.T) {
+func TestValidateCmd_Config_CLIOverridesSkipJSONPathIfAbsent(t *testing.T) {
 	g := NewWithT(t)
 	schemaDir := t.TempDir()
 	writeRequiredWidgetSchema(t, schemaDir)
@@ -762,14 +762,14 @@ spec: {}
 	cfg := writeManifest(t, t.TempDir(), ".fluxschema.yml", `apiVersion: schema.plugin.fluxcd.io/v1beta1
 kind: Config
 validate:
-  ignoreJSONPathIfAbsent:
+  skipJSONPathIfAbsent:
     - Widget:/spec/name
 `)
 	_, err := executeCommand([]string{
 		"validate", manifestDir,
 		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
 		"--config", cfg,
-		"--ignore-json-path-if-absent", "Widget:/spec/doesNotExist",
+		"--skip-json-path-if-absent", "Widget:/spec/doesNotExist",
 	})
 	g.Expect(err).To(HaveOccurred())
 }
@@ -1139,7 +1139,7 @@ validate:
     - Widget
   skipJSONPath:
     - Secret:/sops
-  ignoreJSONPathIfAbsent:
+  skipJSONPathIfAbsent:
     - Widget:/spec/name
   skipFile:
     - '.*'

--- a/docs/config-v1beta1.json
+++ b/docs/config-v1beta1.json
@@ -58,13 +58,6 @@
           "description": "FailFast exits after the first invalid document.",
           "type": "boolean"
         },
-        "ignoreJSONPathIfAbsent": {
-          "description": "IgnoreJSONPathIfAbsent contains JSON Pointers whose required-property errors\nare ignored when the field is absent; CEL is skipped for matching documents.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "insecureSkipTLSVerify": {
           "description": "InsecureSkipTLSVerify disables TLS certificate verification for HTTPS schemas.",
           "type": "boolean"
@@ -98,6 +91,13 @@
         },
         "skipJSONPath": {
           "description": "SkipJSONPaths contains JSON Pointers stripped before validation.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "skipJSONPathIfAbsent": {
+          "description": "SkipJSONPathIfAbsent contains JSON Pointers whose required-property errors\nare skipped when the field is absent; CEL is skipped for matching documents.",
           "items": {
             "type": "string"
           },

--- a/docs/config-v1beta1.json
+++ b/docs/config-v1beta1.json
@@ -59,7 +59,7 @@
           "type": "boolean"
         },
         "ignoreJSONPathIfAbsent": {
-          "description": "IgnoreJSONPathIfAbsent contains JSON Pointers whose required-property\nerrors are ignored when the field is absent.",
+          "description": "IgnoreJSONPathIfAbsent contains JSON Pointers whose required-property errors\nare ignored when the field is absent; CEL is skipped for matching documents.",
           "items": {
             "type": "string"
           },

--- a/docs/config-v1beta1.json
+++ b/docs/config-v1beta1.json
@@ -58,6 +58,13 @@
           "description": "FailFast exits after the first invalid document.",
           "type": "boolean"
         },
+        "ignoreJSONPathIfAbsent": {
+          "description": "IgnoreJSONPathIfAbsent contains JSON Pointers whose required-property\nerrors are ignored when the field is absent.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "insecureSkipTLSVerify": {
           "description": "InsecureSkipTLSVerify disables TLS certificate verification for HTTPS schemas.",
           "type": "boolean"

--- a/docs/config.md
+++ b/docs/config.md
@@ -73,7 +73,7 @@ The `validate` section configures defaults for the `flux schema validate` flags.
 | `skipMissingSchemas`    | Skip documents for which no schema can be found.                                                                                                                          |
 | `skipKind[]`            | Kind or apiVersion/kind patterns excluded from validation.                                                                                                                |
 | `skipJSONPath[]`        | JSON Pointers stripped before validation.                                                                                                                                 |
-| `ignoreJSONPathIfAbsent[]` | JSON Pointers whose required-field errors are ignored when the field is absent. Present values are still validated.                                                     |
+| `ignoreJSONPathIfAbsent[]` | JSON Pointers whose required-field errors are ignored when the field is absent. CEL is skipped for matching documents with absent paths; present values are still validated. |
 | `skipFile[]`            | Basename glob patterns excluded from validation.                                                                                                                          |
 | `skipCELRules`          | Disable evaluation of `x-kubernetes-validations` CEL rules.                                                                                                               |
 | `verbose`               | Print a line for every document, including valid and skipped.                                                                                                             |

--- a/docs/config.md
+++ b/docs/config.md
@@ -21,6 +21,8 @@ validate:
     - source.toolkit.fluxcd.io/v1/ExternalArtifact
   skipJSONPath:
     - Secret:/sops
+  ignoreJSONPathIfAbsent:
+    - Widget:/spec/replicas
   skipFile:
     - '.*'
     - kustomization.yaml
@@ -71,6 +73,7 @@ The `validate` section configures defaults for the `flux schema validate` flags.
 | `skipMissingSchemas`    | Skip documents for which no schema can be found.                                                                                                                          |
 | `skipKind[]`            | Kind or apiVersion/kind patterns excluded from validation.                                                                                                                |
 | `skipJSONPath[]`        | JSON Pointers stripped before validation.                                                                                                                                 |
+| `ignoreJSONPathIfAbsent[]` | JSON Pointers whose required-field errors are ignored when the field is absent. Present values are still validated.                                                     |
 | `skipFile[]`            | Basename glob patterns excluded from validation.                                                                                                                          |
 | `skipCELRules`          | Disable evaluation of `x-kubernetes-validations` CEL rules.                                                                                                               |
 | `verbose`               | Print a line for every document, including valid and skipped.                                                                                                             |

--- a/docs/config.md
+++ b/docs/config.md
@@ -21,7 +21,7 @@ validate:
     - source.toolkit.fluxcd.io/v1/ExternalArtifact
   skipJSONPath:
     - Secret:/sops
-  ignoreJSONPathIfAbsent:
+  skipJSONPathIfAbsent:
     - Widget:/spec/replicas
   skipFile:
     - '.*'
@@ -73,7 +73,7 @@ The `validate` section configures defaults for the `flux schema validate` flags.
 | `skipMissingSchemas`    | Skip documents for which no schema can be found.                                                                                                                          |
 | `skipKind[]`            | Kind or apiVersion/kind patterns excluded from validation.                                                                                                                |
 | `skipJSONPath[]`        | JSON Pointers stripped before validation.                                                                                                                                 |
-| `ignoreJSONPathIfAbsent[]` | JSON Pointers whose required-field errors are ignored when the field is absent. CEL is skipped for matching documents with absent paths; present values are still validated. |
+| `skipJSONPathIfAbsent[]` | JSON Pointers whose required-field errors are skipped when the field is absent. CEL is skipped for matching documents with absent paths; present values are still validated. |
 | `skipFile[]`            | Basename glob patterns excluded from validation.                                                                                                                          |
 | `skipCELRules`          | Disable evaluation of `x-kubernetes-validations` CEL rules.                                                                                                               |
 | `verbose`               | Print a line for every document, including valid and skipped.                                                                                                             |

--- a/docs/manifests-validation.md
+++ b/docs/manifests-validation.md
@@ -28,7 +28,7 @@ A non-zero exit code is returned when any document is invalid or errored.
 | `--skip-missing-schemas`     | Skip documents for which no schema can be found.                                                         |
 | `--skip-kind`                | Skip documents matching `kind` or `apiVersion/kind` (repeatable).                                        |
 | `--skip-json-path`           | Strip a JSON Pointer field before validation, optionally scoped: `[apiVersion/kind:]/path` (repeatable). |
-| `--ignore-json-path-if-absent` | Ignore missing required-field errors for a JSON Pointer field, optionally scoped: `[apiVersion/kind:]/path` (repeatable). |
+| `--skip-json-path-if-absent` | Skip missing required-field errors for a JSON Pointer field, optionally scoped: `[apiVersion/kind:]/path` (repeatable). |
 | `--skip-file`                | Glob pattern matched against files and dirs; defaults to skipping dotfiles and dot-dirs (repeatable).    |
 | `--skip-cel-rules`           | Skip evaluation of `x-kubernetes-validations` CEL rules.                                                 |
 | `--fail-fast`                | Exit after the first invalid document.                                                                   |
@@ -105,14 +105,14 @@ flux schema validate ./manifests \
 ```
 
 If admission hooks such as Kyverno or `MutatingAdmissionPolicy` add default
-values before API server validation, use `--ignore-json-path-if-absent` for
+values before API server validation, use `--skip-json-path-if-absent` for
 required fields that may be omitted from Git. Only the missing-field error is
-ignored; if the field is present, its value is still validated against the
+skipped; if the field is present, its value is still validated against the
 schema and CEL rules:
 
 ```shell
 flux schema validate ./manifests \
-  --ignore-json-path-if-absent 'Widget:/spec/replicas'
+  --skip-json-path-if-absent 'Widget:/spec/replicas'
 ```
 
 When a matching path is absent, CEL evaluation is skipped for that document
@@ -282,7 +282,7 @@ validate:
     - source.toolkit.fluxcd.io/v1/ExternalArtifact
   skipJSONPath:
     - Secret:/sops
-  ignoreJSONPathIfAbsent:
+  skipJSONPathIfAbsent:
     - Widget:/spec/replicas
   skipFile:
     - '.*'

--- a/docs/manifests-validation.md
+++ b/docs/manifests-validation.md
@@ -28,6 +28,7 @@ A non-zero exit code is returned when any document is invalid or errored.
 | `--skip-missing-schemas`     | Skip documents for which no schema can be found.                                                         |
 | `--skip-kind`                | Skip documents matching `kind` or `apiVersion/kind` (repeatable).                                        |
 | `--skip-json-path`           | Strip a JSON Pointer field before validation, optionally scoped: `[apiVersion/kind:]/path` (repeatable). |
+| `--ignore-json-path-if-absent` | Ignore missing required-field errors for a JSON Pointer field, optionally scoped: `[apiVersion/kind:]/path` (repeatable). |
 | `--skip-file`                | Glob pattern matched against files and dirs; defaults to skipping dotfiles and dot-dirs (repeatable).    |
 | `--skip-cel-rules`           | Skip evaluation of `x-kubernetes-validations` CEL rules.                                                 |
 | `--fail-fast`                | Exit after the first invalid document.                                                                   |
@@ -101,6 +102,17 @@ fields from validation so the rest of the document is still checked:
 flux schema validate ./manifests \
   --skip-json-path 'v1/Secret:/sops' \
   --skip-json-path 'Deployment:/sops'
+```
+
+If admission hooks such as Kyverno or `MutatingAdmissionPolicy` add default
+values before API server validation, use `--ignore-json-path-if-absent` for
+required fields that may be omitted from Git. Only the missing-field error is
+ignored; if the field is present, its value is still validated against the
+schema:
+
+```shell
+flux schema validate ./manifests \
+  --ignore-json-path-if-absent 'Widget:/spec/replicas'
 ```
 
 ## Output
@@ -266,6 +278,8 @@ validate:
     - source.toolkit.fluxcd.io/v1/ExternalArtifact
   skipJSONPath:
     - Secret:/sops
+  ignoreJSONPathIfAbsent:
+    - Widget:/spec/replicas
   skipFile:
     - '.*'
     - kustomization.yaml

--- a/docs/manifests-validation.md
+++ b/docs/manifests-validation.md
@@ -108,16 +108,16 @@ If admission hooks such as Kyverno or `MutatingAdmissionPolicy` add default
 values before API server validation, use `--ignore-json-path-if-absent` for
 required fields that may be omitted from Git. Only the missing-field error is
 ignored; if the field is present, its value is still validated against the
-schema:
+schema and CEL rules:
 
 ```shell
 flux schema validate ./manifests \
   --ignore-json-path-if-absent 'Widget:/spec/replicas'
 ```
 
-CEL rules still evaluate the manifest as written. If a CEL rule assumes an
-admission-defaulted field exists, validation may still fail on the absent field;
-use `--skip-cel-rules` for those schemas.
+When a matching path is absent, CEL evaluation is skipped for that document
+because Flux Schema cannot apply out-of-band admission defaults before running
+CEL.
 
 ## Output
 

--- a/docs/manifests-validation.md
+++ b/docs/manifests-validation.md
@@ -115,6 +115,10 @@ flux schema validate ./manifests \
   --ignore-json-path-if-absent 'Widget:/spec/replicas'
 ```
 
+CEL rules still evaluate the manifest as written. If a CEL rule assumes an
+admission-defaulted field exists, validation may still fail on the absent field;
+use `--skip-cel-rules` for those schemas.
+
 ## Output
 
 Default output (`-o text`) prints one line per document with its validation result,

--- a/internal/validator/doc.go
+++ b/internal/validator/doc.go
@@ -41,9 +41,10 @@
 //     layer is skipped for Flux plugin API groups. Violations merge under
 //     ReasonSchemaViolation.
 //  7. CEL x-kubernetes-validations — runs only after steps 1-6 pass and
-//     unless Options.SkipCELRules is set. Rule compile errors and runtime
-//     violations both surface as ReasonCELViolation; oldSelf is unbound
-//     (static validator, no transition state).
+//     unless Options.SkipCELRules is set or IgnoreJSONPathIfAbsent matched an
+//     absent path on the document. Rule compile errors and runtime violations
+//     both surface as ReasonCELViolation; oldSelf is unbound (static
+//     validator, no transition state).
 //
 // Schemas produced by the extractor close objects with
 // additionalProperties: false, so undocumented spec fields fail.

--- a/internal/validator/doc.go
+++ b/internal/validator/doc.go
@@ -34,10 +34,12 @@
 //  5. SkipJSONPaths — matching pointers are deleted from the document
 //     before schema validation.
 //  6. JSON Schema + ObjectMeta — the compiled schema runs against the
-//     document; DNS-1123 and qualified-name rules are layered on metadata
-//     since Kubernetes schemas leave it effectively unconstrained. The
-//     metadata layer is skipped for Flux plugin API groups. Violations merge
-//     under ReasonSchemaViolation.
+//     document. IgnoreJSONPathIfAbsent suppresses matching required-property
+//     errors for absent fields only; present values are still checked by the
+//     schema. DNS-1123 and qualified-name rules are layered on metadata since
+//     Kubernetes schemas leave it effectively unconstrained. The metadata
+//     layer is skipped for Flux plugin API groups. Violations merge under
+//     ReasonSchemaViolation.
 //  7. CEL x-kubernetes-validations — runs only after steps 1-6 pass and
 //     unless Options.SkipCELRules is set. Rule compile errors and runtime
 //     violations both surface as ReasonCELViolation; oldSelf is unbound

--- a/internal/validator/doc.go
+++ b/internal/validator/doc.go
@@ -34,14 +34,14 @@
 //  5. SkipJSONPaths — matching pointers are deleted from the document
 //     before schema validation.
 //  6. JSON Schema + ObjectMeta — the compiled schema runs against the
-//     document. IgnoreJSONPathIfAbsent suppresses matching required-property
+//     document. SkipJSONPathIfAbsent suppresses matching required-property
 //     errors for absent fields only; present values are still checked by the
 //     schema. DNS-1123 and qualified-name rules are layered on metadata since
 //     Kubernetes schemas leave it effectively unconstrained. The metadata
 //     layer is skipped for Flux plugin API groups. Violations merge under
 //     ReasonSchemaViolation.
 //  7. CEL x-kubernetes-validations — runs only after steps 1-6 pass and
-//     unless Options.SkipCELRules is set or IgnoreJSONPathIfAbsent matched an
+//     unless Options.SkipCELRules is set or SkipJSONPathIfAbsent matched an
 //     absent path on the document. Rule compile errors and runtime violations
 //     both surface as ReasonCELViolation; oldSelf is unbound (static
 //     validator, no transition state).

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"text/template"
@@ -289,6 +290,29 @@ func (m skipPathMatcher) stripPath(doc map[string]any) {
 		}
 		parent = next
 	}
+}
+
+func (m skipPathMatcher) pathExists(doc map[string]any) bool {
+	var node any = doc
+	for _, seg := range m.segments {
+		switch n := node.(type) {
+		case map[string]any:
+			next, ok := n[seg]
+			if !ok {
+				return false
+			}
+			node = next
+		case []any:
+			i, err := strconv.Atoi(seg)
+			if err != nil || i < 0 || i >= len(n) {
+				return false
+			}
+			node = n[i]
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // New returns a Validator configured from opts. Each location template is
@@ -781,7 +805,7 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 	// metadata, and Kubernetes admission-extension checks pass. Most CEL rules
 	// presume a well-shaped object, so adding CEL noise on top of structural
 	// failures rarely helps; the user can fix those problems and re-run.
-	if !v.opts.SkipCELRules {
+	if !v.opts.SkipCELRules && !hasIgnoredAbsentPath(v.ignoreAbsentPaths, r.APIVersion, r.Kind, doc) {
 		if resolved.CELBuildErr != nil {
 			r.Errors = []ValidationError{{
 				Msg: resolved.CELBuildErr.Error(),
@@ -1048,6 +1072,15 @@ func keepRequiredFields(parentSegments []string, missing []string,
 func matchesIgnoredAbsentPath(matchers []skipPathMatcher, apiVersion, kind string, segments []string) bool {
 	for _, m := range matchers {
 		if m.matchesPath(apiVersion, kind, segments) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasIgnoredAbsentPath(matchers []skipPathMatcher, apiVersion, kind string, doc map[string]any) bool {
+	for _, m := range matchers {
+		if m.matches(apiVersion, kind) && !m.pathExists(doc) {
 			return true
 		}
 	}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -1015,13 +1015,15 @@ func pruneSkippedAbsentRequired(err *jsonschema.ValidationError, matchers []skip
 	clone := *err
 	if len(err.Causes) > 0 {
 		prunedCauses := 0
+		prunedIndexes := make([]int, 0, len(err.Causes))
 		clone.Causes = make([]*jsonschema.ValidationError, 0, len(err.Causes))
-		for _, cause := range err.Causes {
+		for i, cause := range err.Causes {
 			pruned := pruneSkippedAbsentRequired(cause, matchers, apiVersion, kind)
 			if pruned != nil {
 				clone.Causes = append(clone.Causes, pruned)
 			} else {
 				prunedCauses++
+				prunedIndexes = append(prunedIndexes, i)
 			}
 		}
 		switch err.ErrorKind.(type) {
@@ -1032,6 +1034,11 @@ func pruneSkippedAbsentRequired(err *jsonschema.ValidationError, matchers []skip
 		case *jsonschemakind.OneOf:
 			if prunedCauses == 1 {
 				return nil
+			}
+			if prunedCauses > 1 {
+				clone.Causes = nil
+				clone.ErrorKind = &jsonschemakind.OneOf{Subschemas: prunedIndexes[:2]}
+				return &clone
 			}
 		}
 		if len(clone.Causes) == 0 {

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -776,6 +776,10 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 	if err := resolved.JSON.Validate(doc); err != nil {
 		errs = flattenErrors(err, v.skipAbsentPaths, r.APIVersion, r.Kind)
 	}
+	hasAbsentSkippedPath := hasSkippedAbsentPath(v.skipAbsentPaths, r.APIVersion, r.Kind, doc)
+	if len(errs) == 0 && hasAbsentSkippedPath {
+		errs = append(errs, skippedAbsentOneOfErrors(resolved.JSON, doc, nil, v.skipAbsentPaths, r.APIVersion, r.Kind)...)
+	}
 	if !skipMetadata {
 		errs = append(errs, validateMetadata(doc)...)
 	}
@@ -805,7 +809,7 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 	// metadata, and Kubernetes admission-extension checks pass. Most CEL rules
 	// presume a well-shaped object, so adding CEL noise on top of structural
 	// failures rarely helps; the user can fix those problems and re-run.
-	if !v.opts.SkipCELRules && !hasSkippedAbsentPath(v.skipAbsentPaths, r.APIVersion, r.Kind, doc) {
+	if !v.opts.SkipCELRules && !hasAbsentSkippedPath {
 		if resolved.CELBuildErr != nil {
 			r.Errors = []ValidationError{{
 				Msg: resolved.CELBuildErr.Error(),
@@ -978,16 +982,22 @@ func applyInsecureTLS(c *retryablehttp.Client) {
 // flattenErrors walks a ValidationError tree and returns one entry per leaf
 // error, with the JSON Pointer path to the failing field.
 func flattenErrors(err error, skipAbsentPaths []skipPathMatcher, apiVersion, kind string) []ValidationError {
+	return flattenErrorsAt(err, skipAbsentPaths, apiVersion, kind, nil)
+}
+
+func flattenErrorsAt(err error, skipAbsentPaths []skipPathMatcher, apiVersion, kind string, baseSegments []string) []ValidationError {
 	var verr *jsonschema.ValidationError
 	ok := errors.As(err, &verr)
 	if !ok {
 		return []ValidationError{{Msg: err.Error()}}
 	}
 	if len(skipAbsentPaths) > 0 {
-		verr = pruneSkippedAbsentRequired(verr, skipAbsentPaths, apiVersion, kind)
+		verr = pruneSkippedAbsentRequired(verr, skipAbsentPaths, apiVersion, kind, baseSegments)
 		if verr == nil {
 			return nil
 		}
+	} else if len(baseSegments) > 0 {
+		verr = cloneValidationErrorAtBase(verr, baseSegments)
 	}
 	basic := verr.BasicOutput()
 	var out []ValidationError
@@ -1008,17 +1018,20 @@ func flattenErrors(err error, skipAbsentPaths []skipPathMatcher, apiVersion, kin
 	return out
 }
 
-func pruneSkippedAbsentRequired(err *jsonschema.ValidationError, matchers []skipPathMatcher, apiVersion, kind string) *jsonschema.ValidationError {
+func pruneSkippedAbsentRequired(err *jsonschema.ValidationError, matchers []skipPathMatcher,
+	apiVersion, kind string, baseSegments []string,
+) *jsonschema.ValidationError {
 	if err == nil {
 		return nil
 	}
 	clone := *err
+	clone.InstanceLocation = appendInstanceLocation(baseSegments, err.InstanceLocation)
 	if len(err.Causes) > 0 {
 		prunedCauses := 0
 		prunedIndexes := make([]int, 0, len(err.Causes))
 		clone.Causes = make([]*jsonschema.ValidationError, 0, len(err.Causes))
 		for i, cause := range err.Causes {
-			pruned := pruneSkippedAbsentRequired(cause, matchers, apiVersion, kind)
+			pruned := pruneSkippedAbsentRequired(cause, matchers, apiVersion, kind, baseSegments)
 			if pruned != nil {
 				clone.Causes = append(clone.Causes, pruned)
 			} else {
@@ -1049,7 +1062,7 @@ func pruneSkippedAbsentRequired(err *jsonschema.ValidationError, matchers []skip
 	if !ok || len(required.Missing) == 0 {
 		return &clone
 	}
-	kept := keepRequiredFields(err.InstanceLocation, required.Missing, matchers, apiVersion, kind)
+	kept := keepRequiredFields(clone.InstanceLocation, required.Missing, matchers, apiVersion, kind)
 	if len(kept) == 0 {
 		return nil
 	}
@@ -1057,6 +1070,21 @@ func pruneSkippedAbsentRequired(err *jsonschema.ValidationError, matchers []skip
 		copied := *required
 		copied.Missing = kept
 		clone.ErrorKind = &copied
+	}
+	return &clone
+}
+
+func cloneValidationErrorAtBase(err *jsonschema.ValidationError, baseSegments []string) *jsonschema.ValidationError {
+	if err == nil {
+		return nil
+	}
+	clone := *err
+	clone.InstanceLocation = appendInstanceLocation(baseSegments, err.InstanceLocation)
+	if len(err.Causes) > 0 {
+		clone.Causes = make([]*jsonschema.ValidationError, 0, len(err.Causes))
+		for _, cause := range err.Causes {
+			clone.Causes = append(clone.Causes, cloneValidationErrorAtBase(cause, baseSegments))
+		}
 	}
 	return &clone
 }
@@ -1074,6 +1102,179 @@ func keepRequiredFields(parentSegments []string, missing []string,
 		}
 	}
 	return kept
+}
+
+func skippedAbsentOneOfErrors(schema *jsonschema.Schema, value any, segments []string,
+	matchers []skipPathMatcher, apiVersion, kind string,
+) []ValidationError {
+	return collectSkippedAbsentOneOfErrors(schema, value, segments, matchers, apiVersion, kind, map[schemaVisit]bool{})
+}
+
+type schemaVisit struct {
+	schema *jsonschema.Schema
+	path   string
+}
+
+func collectSkippedAbsentOneOfErrors(schema *jsonschema.Schema, value any, segments []string,
+	matchers []skipPathMatcher, apiVersion, kind string, visits map[schemaVisit]bool,
+) []ValidationError {
+	if schema == nil {
+		return nil
+	}
+	key := schemaVisit{schema: schema, path: jsonPointerFromSegments(segments)}
+	if visits[key] {
+		return nil
+	}
+	visits[key] = true
+	defer delete(visits, key)
+
+	var out []ValidationError
+	if schema.Ref != nil && schemaMatchesWithSkippedAbsentRequired(schema.Ref, value, segments, matchers, apiVersion, kind) {
+		out = append(out, collectSkippedAbsentOneOfErrors(schema.Ref, value, segments, matchers, apiVersion, kind, visits)...)
+	}
+	for _, branch := range schema.AllOf {
+		if schemaMatchesWithSkippedAbsentRequired(branch, value, segments, matchers, apiVersion, kind) {
+			out = append(out, collectSkippedAbsentOneOfErrors(branch, value, segments, matchers, apiVersion, kind, visits)...)
+		}
+	}
+	for _, branch := range schema.AnyOf {
+		if schemaMatchesWithSkippedAbsentRequired(branch, value, segments, matchers, apiVersion, kind) {
+			out = append(out, collectSkippedAbsentOneOfErrors(branch, value, segments, matchers, apiVersion, kind, visits)...)
+		}
+	}
+	if len(schema.OneOf) > 0 {
+		var matched []int
+		for i, branch := range schema.OneOf {
+			if schemaMatchesWithSkippedAbsentRequired(branch, value, segments, matchers, apiVersion, kind) {
+				matched = append(matched, i)
+				if len(matched) == 2 {
+					out = append(out, validationErrorFromKind(segments, &jsonschemakind.OneOf{Subschemas: matched}))
+					break
+				}
+			}
+		}
+		if len(matched) == 1 {
+			branch := schema.OneOf[matched[0]]
+			out = append(out, collectSkippedAbsentOneOfErrors(branch, value, segments, matchers, apiVersion, kind, visits)...)
+		}
+	}
+	if schema.If != nil {
+		switch {
+		case schemaMatchesWithSkippedAbsentRequired(schema.If, value, segments, matchers, apiVersion, kind) && schema.Then != nil:
+			out = append(out, collectSkippedAbsentOneOfErrors(schema.Then, value, segments, matchers, apiVersion, kind, visits)...)
+		case schema.Else != nil:
+			out = append(out, collectSkippedAbsentOneOfErrors(schema.Else, value, segments, matchers, apiVersion, kind, visits)...)
+		}
+	}
+
+	switch typed := value.(type) {
+	case map[string]any:
+		out = append(out, collectObjectSkippedAbsentOneOfErrors(schema, typed, segments, matchers, apiVersion, kind, visits)...)
+	case []any:
+		out = append(out, collectArraySkippedAbsentOneOfErrors(schema, typed, segments, matchers, apiVersion, kind, visits)...)
+	}
+	return out
+}
+
+func collectObjectSkippedAbsentOneOfErrors(schema *jsonschema.Schema, object map[string]any, segments []string,
+	matchers []skipPathMatcher, apiVersion, kind string, visits map[schemaVisit]bool,
+) []ValidationError {
+	var out []ValidationError
+	for prop, value := range object {
+		evaluated := false
+		propSegments := appendInstanceLocation(segments, []string{prop})
+		if propSchema, ok := schema.Properties[prop]; ok {
+			evaluated = true
+			out = append(out, collectSkippedAbsentOneOfErrors(propSchema, value, propSegments, matchers, apiVersion, kind, visits)...)
+		}
+		for regex, propSchema := range schema.PatternProperties {
+			if regex.MatchString(prop) {
+				evaluated = true
+				out = append(out, collectSkippedAbsentOneOfErrors(propSchema, value, propSegments, matchers, apiVersion, kind, visits)...)
+			}
+		}
+		if !evaluated {
+			if propSchema, ok := schema.AdditionalProperties.(*jsonschema.Schema); ok {
+				out = append(out, collectSkippedAbsentOneOfErrors(propSchema, value, propSegments, matchers, apiVersion, kind, visits)...)
+			}
+		}
+	}
+	return out
+}
+
+func collectArraySkippedAbsentOneOfErrors(schema *jsonschema.Schema, array []any, segments []string,
+	matchers []skipPathMatcher, apiVersion, kind string, visits map[schemaVisit]bool,
+) []ValidationError {
+	var out []ValidationError
+	for i, value := range array {
+		itemSegments := appendInstanceLocation(segments, []string{strconv.Itoa(i)})
+		switch items := schema.Items.(type) {
+		case *jsonschema.Schema:
+			out = append(out, collectSkippedAbsentOneOfErrors(items, value, itemSegments, matchers, apiVersion, kind, visits)...)
+		case []*jsonschema.Schema:
+			if i < len(items) {
+				out = append(out, collectSkippedAbsentOneOfErrors(items[i], value, itemSegments, matchers, apiVersion, kind, visits)...)
+			} else if propSchema, ok := schema.AdditionalItems.(*jsonschema.Schema); ok {
+				out = append(out, collectSkippedAbsentOneOfErrors(propSchema, value, itemSegments, matchers, apiVersion, kind, visits)...)
+			}
+		}
+		if i < len(schema.PrefixItems) {
+			out = append(out, collectSkippedAbsentOneOfErrors(schema.PrefixItems[i], value, itemSegments, matchers, apiVersion, kind, visits)...)
+		} else if schema.Items2020 != nil {
+			out = append(out, collectSkippedAbsentOneOfErrors(schema.Items2020, value, itemSegments, matchers, apiVersion, kind, visits)...)
+		}
+		if schema.Contains != nil && schemaMatchesWithSkippedAbsentRequired(schema.Contains, value, itemSegments, matchers, apiVersion, kind) {
+			out = append(out, collectSkippedAbsentOneOfErrors(schema.Contains, value, itemSegments, matchers, apiVersion, kind, visits)...)
+		}
+	}
+	return out
+}
+
+func schemaMatchesWithSkippedAbsentRequired(schema *jsonschema.Schema, value any, segments []string,
+	matchers []skipPathMatcher, apiVersion, kind string,
+) bool {
+	if schema == nil {
+		return true
+	}
+	err := schema.Validate(value)
+	if err == nil {
+		return true
+	}
+	return len(flattenErrorsAt(err, matchers, apiVersion, kind, segments)) == 0
+}
+
+func validationErrorFromKind(segments []string, errorKind jsonschema.ErrorKind) ValidationError {
+	verr := &jsonschema.ValidationError{
+		InstanceLocation: segments,
+		ErrorKind:        errorKind,
+	}
+	out := verr.BasicOutput()
+	return ValidationError{
+		Path: out.InstanceLocation,
+		Msg:  out.Error.String(),
+	}
+}
+
+func appendInstanceLocation(base, path []string) []string {
+	if len(base) == 0 {
+		return slices.Clone(path)
+	}
+	out := make([]string, 0, len(base)+len(path))
+	out = append(out, base...)
+	out = append(out, path...)
+	return out
+}
+
+func jsonPointerFromSegments(segments []string) string {
+	if len(segments) == 0 {
+		return ""
+	}
+	var out strings.Builder
+	for _, segment := range segments {
+		out.WriteByte('/')
+		out.WriteString(escapeJSONPointer(segment))
+	}
+	return out.String()
 }
 
 func matchesSkippedAbsentPath(matchers []skipPathMatcher, apiVersion, kind string, segments []string) bool {

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -959,6 +959,12 @@ func flattenErrors(err error, ignoreAbsentPaths []skipPathMatcher, apiVersion, k
 	if !ok {
 		return []ValidationError{{Msg: err.Error()}}
 	}
+	if len(ignoreAbsentPaths) > 0 {
+		verr = pruneIgnoredAbsentRequired(verr, ignoreAbsentPaths, apiVersion, kind)
+		if verr == nil {
+			return nil
+		}
+	}
 	basic := verr.BasicOutput()
 	var out []ValidationError
 	seenLeaf := false
@@ -967,51 +973,76 @@ func flattenErrors(err error, ignoreAbsentPaths []skipPathMatcher, apiVersion, k
 			continue
 		}
 		seenLeaf = true
-		if required, ok := unit.Error.Kind.(*jsonschemakind.Required); ok && len(ignoreAbsentPaths) > 0 {
-			out = appendRequiredErrors(out, unit.InstanceLocation, unit.Error.String(), required.Missing,
-				ignoreAbsentPaths, apiVersion, kind)
-			continue
-		}
 		out = append(out, ValidationError{
 			Path: unit.InstanceLocation,
 			Msg:  unit.Error.String(),
 		})
 	}
 	if len(out) == 0 && !seenLeaf {
-		out = append(out, ValidationError{Msg: err.Error()})
+		out = append(out, ValidationError{Msg: verr.Error()})
 	}
 	return out
 }
 
-func appendRequiredErrors(out []ValidationError, parentPath, originalMsg string, missing []string,
-	ignoreAbsentPaths []skipPathMatcher, apiVersion, kind string,
-) []ValidationError {
-	if len(missing) == 0 {
-		return append(out, ValidationError{Path: parentPath, Msg: originalMsg})
+func pruneIgnoredAbsentRequired(err *jsonschema.ValidationError, matchers []skipPathMatcher, apiVersion, kind string) *jsonschema.ValidationError {
+	if err == nil {
+		return nil
 	}
-	parentSegments, err := parseJSONPointerSegments(parentPath)
-	if err != nil {
-		return append(out, ValidationError{Path: parentPath, Msg: originalMsg})
+	clone := *err
+	if len(err.Causes) > 0 {
+		prunedCauses := 0
+		clone.Causes = make([]*jsonschema.ValidationError, 0, len(err.Causes))
+		for _, cause := range err.Causes {
+			pruned := pruneIgnoredAbsentRequired(cause, matchers, apiVersion, kind)
+			if pruned != nil {
+				clone.Causes = append(clone.Causes, pruned)
+			} else {
+				prunedCauses++
+			}
+		}
+		switch err.ErrorKind.(type) {
+		case *jsonschemakind.AnyOf:
+			if prunedCauses > 0 {
+				return nil
+			}
+		case *jsonschemakind.OneOf:
+			if prunedCauses == 1 {
+				return nil
+			}
+		}
+		if len(clone.Causes) == 0 {
+			return nil
+		}
 	}
+	required, ok := err.ErrorKind.(*jsonschemakind.Required)
+	if !ok || len(required.Missing) == 0 {
+		return &clone
+	}
+	kept := keepRequiredFields(err.InstanceLocation, required.Missing, matchers, apiVersion, kind)
+	if len(kept) == 0 {
+		return nil
+	}
+	if len(kept) < len(required.Missing) {
+		copied := *required
+		copied.Missing = kept
+		clone.ErrorKind = &copied
+	}
+	return &clone
+}
+
+func keepRequiredFields(parentSegments []string, missing []string,
+	matchers []skipPathMatcher, apiVersion, kind string,
+) []string {
 	kept := make([]string, 0, len(missing))
 	for _, prop := range missing {
-		if !matchesIgnoredAbsentPath(ignoreAbsentPaths, apiVersion, kind, append(parentSegments, prop)) {
+		fieldSegments := make([]string, len(parentSegments), len(parentSegments)+1)
+		copy(fieldSegments, parentSegments)
+		fieldSegments = append(fieldSegments, prop)
+		if !matchesIgnoredAbsentPath(matchers, apiVersion, kind, fieldSegments) {
 			kept = append(kept, prop)
 		}
 	}
-	if len(kept) == 0 {
-		return out
-	}
-	if len(kept) == len(missing) {
-		return append(out, ValidationError{Path: parentPath, Msg: originalMsg})
-	}
-	for _, prop := range kept {
-		out = append(out, ValidationError{
-			Path: parentPath,
-			Msg:  "missing property " + quoteSchemaString(prop),
-		})
-	}
-	return out
+	return kept
 }
 
 func matchesIgnoredAbsentPath(matchers []skipPathMatcher, apiVersion, kind string, segments []string) bool {
@@ -1021,11 +1052,4 @@ func matchesIgnoredAbsentPath(matchers []skipPathMatcher, apiVersion, kind strin
 		}
 	}
 	return false
-}
-
-func quoteSchemaString(s string) string {
-	q := fmt.Sprintf("%q", s)
-	q = strings.ReplaceAll(q, `\"`, `"`)
-	q = strings.ReplaceAll(q, `'`, `\'`)
-	return "'" + q[1:len(q)-1] + "'"
 }

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/santhosh-tekuri/jsonschema/v6"
+	jsonschemakind "github.com/santhosh-tekuri/jsonschema/v6/kind"
 	utiljson "k8s.io/apimachinery/pkg/util/json"
 	"sigs.k8s.io/yaml"
 
@@ -105,9 +106,12 @@ type Options struct {
 	SkipMissingSchemas bool
 	SkipKinds          []string
 	SkipJSONPaths      []string
-	SkipFiles          []string
-	SkipCELRules       bool
-	HTTPClient         *retryablehttp.Client
+	// IgnoreJSONPathIfAbsent suppresses JSON Schema required-property errors
+	// for matching fields. Present values are still validated normally.
+	IgnoreJSONPathIfAbsent []string
+	SkipFiles              []string
+	SkipCELRules           bool
+	HTTPClient             *retryablehttp.Client
 	// UserAgent is the value for the User-Agent header on schema fetches;
 	// empty leaves the client untouched.
 	UserAgent             string
@@ -125,11 +129,12 @@ var DefaultSkipFiles = []string{".*"}
 // Validator resolves and applies JSON Schemas to Kubernetes manifests.
 // It is safe for concurrent use by multiple goroutines.
 type Validator struct {
-	opts      Options
-	loader    *SchemaLoader
-	skipKinds []skipKindMatcher
-	skipPaths []skipPathMatcher
-	skipFiles []string
+	opts              Options
+	loader            *SchemaLoader
+	skipKinds         []skipKindMatcher
+	skipPaths         []skipPathMatcher
+	ignoreAbsentPaths []skipPathMatcher
+	skipFiles         []string
 }
 
 // skipKindMatcher matches a document by Kind, optionally scoped to an
@@ -189,9 +194,17 @@ type skipPathMatcher struct {
 // from the pointer half, which follows RFC 6901; '~1' decodes to '/' and '~0'
 // to '~'. Pointer descent through arrays is a silent no-op (map keys only).
 func parseSkipJSONPath(s string) (skipPathMatcher, error) {
+	return parseJSONPathMatcher(s, "skip JSON path")
+}
+
+func parseIgnoreJSONPathIfAbsent(s string) (skipPathMatcher, error) {
+	return parseJSONPathMatcher(s, "ignore JSON path if absent")
+}
+
+func parseJSONPathMatcher(s, label string) (skipPathMatcher, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
-		return skipPathMatcher{}, errors.New("skip JSON path pattern must not be empty")
+		return skipPathMatcher{}, fmt.Errorf("%s pattern must not be empty", label)
 	}
 	var selector, pointer string
 	switch {
@@ -201,29 +214,43 @@ func parseSkipJSONPath(s string) (skipPathMatcher, error) {
 	default:
 		left, right, hasSelector := strings.Cut(s, ":")
 		if !hasSelector {
-			return skipPathMatcher{}, fmt.Errorf("skip JSON path pattern %q: pointer must start with '/'", s)
+			return skipPathMatcher{}, fmt.Errorf("%s pattern %q: pointer must start with '/'", label, s)
 		}
 		selector, pointer = left, right
 	}
 	if !strings.HasPrefix(pointer, "/") {
-		return skipPathMatcher{}, fmt.Errorf("skip JSON path pattern %q: pointer must start with '/'", s)
+		return skipPathMatcher{}, fmt.Errorf("%s pattern %q: pointer must start with '/'", label, s)
 	}
 	if pointer == "/" {
-		return skipPathMatcher{}, fmt.Errorf("skip JSON path pattern %q: pointer must target a property", s)
+		return skipPathMatcher{}, fmt.Errorf("%s pattern %q: pointer must target a property", label, s)
 	}
 	var apiVersion, kind string
 	if selector != "" {
 		m, err := parseSkipKind(selector)
 		if err != nil {
-			return skipPathMatcher{}, fmt.Errorf("skip JSON path pattern %q: %w", s, err)
+			return skipPathMatcher{}, fmt.Errorf("%s pattern %q: %w", label, s, err)
 		}
 		apiVersion, kind = m.apiVersion, m.kind
+	}
+	segments, err := parseJSONPointerSegments(pointer)
+	if err != nil {
+		return skipPathMatcher{}, fmt.Errorf("%s pattern %q: %w", label, s, err)
+	}
+	return skipPathMatcher{apiVersion: apiVersion, kind: kind, segments: segments}, nil
+}
+
+func parseJSONPointerSegments(pointer string) ([]string, error) {
+	if pointer == "" {
+		return nil, nil
+	}
+	if !strings.HasPrefix(pointer, "/") {
+		return nil, errors.New("pointer must start with '/'")
 	}
 	rawSegments := strings.Split(strings.TrimPrefix(pointer, "/"), "/")
 	segments := make([]string, len(rawSegments))
 	for i, seg := range rawSegments {
 		if seg == "" {
-			return skipPathMatcher{}, fmt.Errorf("skip JSON path pattern %q: empty segment in pointer", s)
+			return nil, errors.New("empty segment in pointer")
 		}
 		// RFC 6901: decode '~1' before '~0' so '~01' decodes to literal '~1'
 		// rather than collapsing into '/'.
@@ -231,7 +258,7 @@ func parseSkipJSONPath(s string) (skipPathMatcher, error) {
 		seg = strings.ReplaceAll(seg, "~0", "~")
 		segments[i] = seg
 	}
-	return skipPathMatcher{apiVersion: apiVersion, kind: kind, segments: segments}, nil
+	return segments, nil
 }
 
 func (m skipPathMatcher) matches(apiVersion, kind string) bool {
@@ -239,6 +266,10 @@ func (m skipPathMatcher) matches(apiVersion, kind string) bool {
 		return false
 	}
 	return m.apiVersion == "" || m.apiVersion == apiVersion
+}
+
+func (m skipPathMatcher) matchesPath(apiVersion, kind string, segments []string) bool {
+	return m.matches(apiVersion, kind) && slices.Equal(m.segments, segments)
 }
 
 // stripPath deletes the field referenced by m.segments from doc when present.
@@ -313,6 +344,15 @@ func New(opts Options) (*Validator, error) {
 		skipPaths = append(skipPaths, m)
 	}
 
+	ignoreAbsentPaths := make([]skipPathMatcher, 0, len(opts.IgnoreJSONPathIfAbsent))
+	for _, s := range opts.IgnoreJSONPathIfAbsent {
+		m, err := parseIgnoreJSONPathIfAbsent(s)
+		if err != nil {
+			return nil, err
+		}
+		ignoreAbsentPaths = append(ignoreAbsentPaths, m)
+	}
+
 	skipFiles := opts.SkipFiles
 	if skipFiles == nil {
 		// Clone so DefaultSkipFiles can never be mutated through a
@@ -329,11 +369,12 @@ func New(opts Options) (*Validator, error) {
 	}
 
 	return &Validator{
-		opts:      opts,
-		loader:    NewSchemaLoader(templates, opts.HTTPClient, opts.HTTPTimeout),
-		skipKinds: skipKinds,
-		skipPaths: skipPaths,
-		skipFiles: skipFiles,
+		opts:              opts,
+		loader:            NewSchemaLoader(templates, opts.HTTPClient, opts.HTTPTimeout),
+		skipKinds:         skipKinds,
+		skipPaths:         skipPaths,
+		ignoreAbsentPaths: ignoreAbsentPaths,
+		skipFiles:         skipFiles,
 	}, nil
 }
 
@@ -709,7 +750,7 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 
 	var errs []ValidationError
 	if err := resolved.JSON.Validate(doc); err != nil {
-		errs = flattenErrors(err)
+		errs = flattenErrors(err, v.ignoreAbsentPaths, r.APIVersion, r.Kind)
 	}
 	if !skipMetadata {
 		errs = append(errs, validateMetadata(doc)...)
@@ -912,7 +953,7 @@ func applyInsecureTLS(c *retryablehttp.Client) {
 
 // flattenErrors walks a ValidationError tree and returns one entry per leaf
 // error, with the JSON Pointer path to the failing field.
-func flattenErrors(err error) []ValidationError {
+func flattenErrors(err error, ignoreAbsentPaths []skipPathMatcher, apiVersion, kind string) []ValidationError {
 	var verr *jsonschema.ValidationError
 	ok := errors.As(err, &verr)
 	if !ok {
@@ -920,8 +961,15 @@ func flattenErrors(err error) []ValidationError {
 	}
 	basic := verr.BasicOutput()
 	var out []ValidationError
+	seenLeaf := false
 	for _, unit := range basic.Errors {
 		if unit.Error == nil {
+			continue
+		}
+		seenLeaf = true
+		if required, ok := unit.Error.Kind.(*jsonschemakind.Required); ok && len(ignoreAbsentPaths) > 0 {
+			out = appendRequiredErrors(out, unit.InstanceLocation, unit.Error.String(), required.Missing,
+				ignoreAbsentPaths, apiVersion, kind)
 			continue
 		}
 		out = append(out, ValidationError{
@@ -929,8 +977,55 @@ func flattenErrors(err error) []ValidationError {
 			Msg:  unit.Error.String(),
 		})
 	}
-	if len(out) == 0 {
+	if len(out) == 0 && !seenLeaf {
 		out = append(out, ValidationError{Msg: err.Error()})
 	}
 	return out
+}
+
+func appendRequiredErrors(out []ValidationError, parentPath, originalMsg string, missing []string,
+	ignoreAbsentPaths []skipPathMatcher, apiVersion, kind string,
+) []ValidationError {
+	if len(missing) == 0 {
+		return append(out, ValidationError{Path: parentPath, Msg: originalMsg})
+	}
+	parentSegments, err := parseJSONPointerSegments(parentPath)
+	if err != nil {
+		return append(out, ValidationError{Path: parentPath, Msg: originalMsg})
+	}
+	kept := make([]string, 0, len(missing))
+	for _, prop := range missing {
+		if !matchesIgnoredAbsentPath(ignoreAbsentPaths, apiVersion, kind, append(parentSegments, prop)) {
+			kept = append(kept, prop)
+		}
+	}
+	if len(kept) == 0 {
+		return out
+	}
+	if len(kept) == len(missing) {
+		return append(out, ValidationError{Path: parentPath, Msg: originalMsg})
+	}
+	for _, prop := range kept {
+		out = append(out, ValidationError{
+			Path: parentPath,
+			Msg:  "missing property " + quoteSchemaString(prop),
+		})
+	}
+	return out
+}
+
+func matchesIgnoredAbsentPath(matchers []skipPathMatcher, apiVersion, kind string, segments []string) bool {
+	for _, m := range matchers {
+		if m.matchesPath(apiVersion, kind, segments) {
+			return true
+		}
+	}
+	return false
+}
+
+func quoteSchemaString(s string) string {
+	q := fmt.Sprintf("%q", s)
+	q = strings.ReplaceAll(q, `\"`, `"`)
+	q = strings.ReplaceAll(q, `'`, `\'`)
+	return "'" + q[1:len(q)-1] + "'"
 }

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -107,12 +107,12 @@ type Options struct {
 	SkipMissingSchemas bool
 	SkipKinds          []string
 	SkipJSONPaths      []string
-	// IgnoreJSONPathIfAbsent suppresses JSON Schema required-property errors
+	// SkipJSONPathIfAbsent suppresses JSON Schema required-property errors
 	// for matching fields. Present values are still validated normally.
-	IgnoreJSONPathIfAbsent []string
-	SkipFiles              []string
-	SkipCELRules           bool
-	HTTPClient             *retryablehttp.Client
+	SkipJSONPathIfAbsent []string
+	SkipFiles            []string
+	SkipCELRules         bool
+	HTTPClient           *retryablehttp.Client
 	// UserAgent is the value for the User-Agent header on schema fetches;
 	// empty leaves the client untouched.
 	UserAgent             string
@@ -130,12 +130,12 @@ var DefaultSkipFiles = []string{".*"}
 // Validator resolves and applies JSON Schemas to Kubernetes manifests.
 // It is safe for concurrent use by multiple goroutines.
 type Validator struct {
-	opts              Options
-	loader            *SchemaLoader
-	skipKinds         []skipKindMatcher
-	skipPaths         []skipPathMatcher
-	ignoreAbsentPaths []skipPathMatcher
-	skipFiles         []string
+	opts            Options
+	loader          *SchemaLoader
+	skipKinds       []skipKindMatcher
+	skipPaths       []skipPathMatcher
+	skipAbsentPaths []skipPathMatcher
+	skipFiles       []string
 }
 
 // skipKindMatcher matches a document by Kind, optionally scoped to an
@@ -198,8 +198,8 @@ func parseSkipJSONPath(s string) (skipPathMatcher, error) {
 	return parseJSONPathMatcher(s, "skip JSON path")
 }
 
-func parseIgnoreJSONPathIfAbsent(s string) (skipPathMatcher, error) {
-	return parseJSONPathMatcher(s, "ignore JSON path if absent")
+func parseSkipJSONPathIfAbsent(s string) (skipPathMatcher, error) {
+	return parseJSONPathMatcher(s, "skip JSON path if absent")
 }
 
 func parseJSONPathMatcher(s, label string) (skipPathMatcher, error) {
@@ -368,13 +368,13 @@ func New(opts Options) (*Validator, error) {
 		skipPaths = append(skipPaths, m)
 	}
 
-	ignoreAbsentPaths := make([]skipPathMatcher, 0, len(opts.IgnoreJSONPathIfAbsent))
-	for _, s := range opts.IgnoreJSONPathIfAbsent {
-		m, err := parseIgnoreJSONPathIfAbsent(s)
+	skipAbsentPaths := make([]skipPathMatcher, 0, len(opts.SkipJSONPathIfAbsent))
+	for _, s := range opts.SkipJSONPathIfAbsent {
+		m, err := parseSkipJSONPathIfAbsent(s)
 		if err != nil {
 			return nil, err
 		}
-		ignoreAbsentPaths = append(ignoreAbsentPaths, m)
+		skipAbsentPaths = append(skipAbsentPaths, m)
 	}
 
 	skipFiles := opts.SkipFiles
@@ -393,12 +393,12 @@ func New(opts Options) (*Validator, error) {
 	}
 
 	return &Validator{
-		opts:              opts,
-		loader:            NewSchemaLoader(templates, opts.HTTPClient, opts.HTTPTimeout),
-		skipKinds:         skipKinds,
-		skipPaths:         skipPaths,
-		ignoreAbsentPaths: ignoreAbsentPaths,
-		skipFiles:         skipFiles,
+		opts:            opts,
+		loader:          NewSchemaLoader(templates, opts.HTTPClient, opts.HTTPTimeout),
+		skipKinds:       skipKinds,
+		skipPaths:       skipPaths,
+		skipAbsentPaths: skipAbsentPaths,
+		skipFiles:       skipFiles,
 	}, nil
 }
 
@@ -774,7 +774,7 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 
 	var errs []ValidationError
 	if err := resolved.JSON.Validate(doc); err != nil {
-		errs = flattenErrors(err, v.ignoreAbsentPaths, r.APIVersion, r.Kind)
+		errs = flattenErrors(err, v.skipAbsentPaths, r.APIVersion, r.Kind)
 	}
 	if !skipMetadata {
 		errs = append(errs, validateMetadata(doc)...)
@@ -805,7 +805,7 @@ func (v *Validator) validateDoc(ctx context.Context, source string, idx int, raw
 	// metadata, and Kubernetes admission-extension checks pass. Most CEL rules
 	// presume a well-shaped object, so adding CEL noise on top of structural
 	// failures rarely helps; the user can fix those problems and re-run.
-	if !v.opts.SkipCELRules && !hasIgnoredAbsentPath(v.ignoreAbsentPaths, r.APIVersion, r.Kind, doc) {
+	if !v.opts.SkipCELRules && !hasSkippedAbsentPath(v.skipAbsentPaths, r.APIVersion, r.Kind, doc) {
 		if resolved.CELBuildErr != nil {
 			r.Errors = []ValidationError{{
 				Msg: resolved.CELBuildErr.Error(),
@@ -977,14 +977,14 @@ func applyInsecureTLS(c *retryablehttp.Client) {
 
 // flattenErrors walks a ValidationError tree and returns one entry per leaf
 // error, with the JSON Pointer path to the failing field.
-func flattenErrors(err error, ignoreAbsentPaths []skipPathMatcher, apiVersion, kind string) []ValidationError {
+func flattenErrors(err error, skipAbsentPaths []skipPathMatcher, apiVersion, kind string) []ValidationError {
 	var verr *jsonschema.ValidationError
 	ok := errors.As(err, &verr)
 	if !ok {
 		return []ValidationError{{Msg: err.Error()}}
 	}
-	if len(ignoreAbsentPaths) > 0 {
-		verr = pruneIgnoredAbsentRequired(verr, ignoreAbsentPaths, apiVersion, kind)
+	if len(skipAbsentPaths) > 0 {
+		verr = pruneSkippedAbsentRequired(verr, skipAbsentPaths, apiVersion, kind)
 		if verr == nil {
 			return nil
 		}
@@ -1008,7 +1008,7 @@ func flattenErrors(err error, ignoreAbsentPaths []skipPathMatcher, apiVersion, k
 	return out
 }
 
-func pruneIgnoredAbsentRequired(err *jsonschema.ValidationError, matchers []skipPathMatcher, apiVersion, kind string) *jsonschema.ValidationError {
+func pruneSkippedAbsentRequired(err *jsonschema.ValidationError, matchers []skipPathMatcher, apiVersion, kind string) *jsonschema.ValidationError {
 	if err == nil {
 		return nil
 	}
@@ -1017,7 +1017,7 @@ func pruneIgnoredAbsentRequired(err *jsonschema.ValidationError, matchers []skip
 		prunedCauses := 0
 		clone.Causes = make([]*jsonschema.ValidationError, 0, len(err.Causes))
 		for _, cause := range err.Causes {
-			pruned := pruneIgnoredAbsentRequired(cause, matchers, apiVersion, kind)
+			pruned := pruneSkippedAbsentRequired(cause, matchers, apiVersion, kind)
 			if pruned != nil {
 				clone.Causes = append(clone.Causes, pruned)
 			} else {
@@ -1062,14 +1062,14 @@ func keepRequiredFields(parentSegments []string, missing []string,
 		fieldSegments := make([]string, len(parentSegments), len(parentSegments)+1)
 		copy(fieldSegments, parentSegments)
 		fieldSegments = append(fieldSegments, prop)
-		if !matchesIgnoredAbsentPath(matchers, apiVersion, kind, fieldSegments) {
+		if !matchesSkippedAbsentPath(matchers, apiVersion, kind, fieldSegments) {
 			kept = append(kept, prop)
 		}
 	}
 	return kept
 }
 
-func matchesIgnoredAbsentPath(matchers []skipPathMatcher, apiVersion, kind string, segments []string) bool {
+func matchesSkippedAbsentPath(matchers []skipPathMatcher, apiVersion, kind string, segments []string) bool {
 	for _, m := range matchers {
 		if m.matchesPath(apiVersion, kind, segments) {
 			return true
@@ -1078,7 +1078,7 @@ func matchesIgnoredAbsentPath(matchers []skipPathMatcher, apiVersion, kind strin
 	return false
 }
 
-func hasIgnoredAbsentPath(matchers []skipPathMatcher, apiVersion, kind string, doc map[string]any) bool {
+func hasSkippedAbsentPath(matchers []skipPathMatcher, apiVersion, kind string, doc map[string]any) bool {
 	for _, m := range matchers {
 		if m.matches(apiVersion, kind) && !m.pathExists(doc) {
 			return true

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -2148,6 +2148,146 @@ spec: {}
 	}))
 }
 
+func TestValidateBytes_IgnoreJSONPathIfAbsent_PrunesAllOfParent(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	schema := map[string]any{
+		"type":     "object",
+		"required": []any{"apiVersion", "kind", "spec"},
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"type": "string"},
+			"kind":       map[string]any{"type": "string"},
+			"metadata":   map[string]any{"type": "object"},
+			"spec": map[string]any{
+				"allOf": []any{
+					map[string]any{
+						"type":     "object",
+						"required": []any{"name"},
+						"properties": map[string]any{
+							"name": map[string]any{"type": "string"},
+						},
+					},
+				},
+			},
+		},
+	}
+	b, err := json.MarshalIndent(schema, "", "  ")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(os.WriteFile(filepath.Join(dir, "widget-example-v1.json"), b, 0o644)).To(Succeed())
+	v, err := New(Options{
+		SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		IgnoreJSONPathIfAbsent: []string{"Widget:/spec/name"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec: {}
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusValid))
+	g.Expect(results[0].Errors).To(BeEmpty())
+}
+
+func TestValidateBytes_IgnoreJSONPathIfAbsent_PrunesPassingCompositeBranch(t *testing.T) {
+	for _, keyword := range []string{"anyOf", "oneOf"} {
+		t.Run(keyword, func(t *testing.T) {
+			g := NewWithT(t)
+			dir := t.TempDir()
+			schema := map[string]any{
+				"type":     "object",
+				"required": []any{"apiVersion", "kind", "spec"},
+				"properties": map[string]any{
+					"apiVersion": map[string]any{"type": "string"},
+					"kind":       map[string]any{"type": "string"},
+					"metadata":   map[string]any{"type": "object"},
+					"spec": map[string]any{
+						keyword: []any{
+							map[string]any{
+								"type":     "object",
+								"required": []any{"name"},
+								"properties": map[string]any{
+									"name": map[string]any{"type": "string"},
+								},
+							},
+							map[string]any{
+								"type": "string",
+							},
+						},
+					},
+				},
+			}
+			b, err := json.MarshalIndent(schema, "", "  ")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(os.WriteFile(filepath.Join(dir, "widget-example-v1.json"), b, 0o644)).To(Succeed())
+			v, err := New(Options{
+				SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+				IgnoreJSONPathIfAbsent: []string{"Widget:/spec/name"},
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec: {}
+`)
+			results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+			g.Expect(results).To(HaveLen(1))
+			g.Expect(results[0].Status).To(Equal(StatusValid))
+			g.Expect(results[0].Errors).To(BeEmpty())
+		})
+	}
+}
+
+func TestValidateBytes_IgnoreJSONPathIfAbsent_PrunesRefParent(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	schema := map[string]any{
+		"type":     "object",
+		"required": []any{"apiVersion", "kind", "spec"},
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"type": "string"},
+			"kind":       map[string]any{"type": "string"},
+			"metadata":   map[string]any{"type": "object"},
+			"spec": map[string]any{
+				"$ref": "#/$defs/spec",
+			},
+		},
+		"$defs": map[string]any{
+			"spec": map[string]any{
+				"type":     "object",
+				"required": []any{"name"},
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+				},
+			},
+		},
+	}
+	b, err := json.MarshalIndent(schema, "", "  ")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(os.WriteFile(filepath.Join(dir, "widget-example-v1.json"), b, 0o644)).To(Succeed())
+	v, err := New(Options{
+		SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		IgnoreJSONPathIfAbsent: []string{"Widget:/spec/name"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec: {}
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusValid))
+	g.Expect(results[0].Errors).To(BeEmpty())
+}
+
 func TestNew_RejectsBadIgnoreJSONPathIfAbsent(t *testing.T) {
 	g := NewWithT(t)
 	_, err := New(Options{

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -2027,6 +2027,136 @@ spec:
 	g.Expect(results[0].Status).To(Equal(StatusValid))
 }
 
+func TestValidateBytes_IgnoreJSONPathIfAbsent_AllowsMissingRequiredField(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchema(t, dir)
+	v, err := New(Options{
+		SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		IgnoreJSONPathIfAbsent: []string{"Widget:/spec/name"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec:
+  interval: 30m
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusValid))
+	g.Expect(results[0].Errors).To(BeEmpty())
+}
+
+func TestValidateBytes_IgnoreJSONPathIfAbsent_ValidatesPresentValue(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchema(t, dir)
+	v, err := New(Options{
+		SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		IgnoreJSONPathIfAbsent: []string{"Widget:/spec/name"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec:
+  name: 42
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaViolation))
+	g.Expect(results[0].Errors).To(ContainElement(ValidationError{
+		Path: "/spec/name",
+		Msg:  "got number, want string",
+	}))
+}
+
+func TestValidateBytes_IgnoreJSONPathIfAbsent_KindScopeBlocksUnrelatedDocs(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchema(t, dir)
+	v, err := New(Options{
+		SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		IgnoreJSONPathIfAbsent: []string{"Secret:/spec/name"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec:
+  interval: 30m
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Errors).To(ContainElement(ValidationError{
+		Path: "/spec",
+		Msg:  "missing property 'name'",
+	}))
+}
+
+func TestValidateBytes_IgnoreJSONPathIfAbsent_KeepsOtherMissingFields(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	schema := map[string]any{
+		"type":     "object",
+		"required": []any{"apiVersion", "kind", "spec"},
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"type": "string"},
+			"kind":       map[string]any{"type": "string"},
+			"metadata":   map[string]any{"type": "object"},
+			"spec": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"required":             []any{"name", "interval"},
+				"properties": map[string]any{
+					"name":     map[string]any{"type": "string"},
+					"interval": map[string]any{"type": "string", "format": "duration"},
+				},
+			},
+		},
+	}
+	b, err := json.MarshalIndent(schema, "", "  ")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(os.WriteFile(filepath.Join(dir, "widget-example-v1.json"), b, 0o644)).To(Succeed())
+	v, err := New(Options{
+		SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		IgnoreJSONPathIfAbsent: []string{"Widget:/spec/name"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec: {}
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Errors).To(ConsistOf(ValidationError{
+		Path: "/spec",
+		Msg:  "missing property 'interval'",
+	}))
+}
+
+func TestNew_RejectsBadIgnoreJSONPathIfAbsent(t *testing.T) {
+	g := NewWithT(t)
+	_, err := New(Options{
+		SchemaLocations:        []string{"./{{ .Kind }}.json"},
+		IgnoreJSONPathIfAbsent: []string{"no-leading-slash"},
+	})
+	g.Expect(err).To(MatchError(ContainSubstring("ignore JSON path if absent pattern")))
+}
+
 func TestNew_RejectsBadSkipJSONPath(t *testing.T) {
 	g := NewWithT(t)
 	_, err := New(Options{

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -390,7 +390,7 @@ spec:
 	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("port must be positive"))
 }
 
-func TestValidateBytes_IgnoreJSONPathIfAbsent_SkipsCELWhenPathAbsent(t *testing.T) {
+func TestValidateBytes_SkipJSONPathIfAbsent_SkipsCELWhenPathAbsent(t *testing.T) {
 	g := NewWithT(t)
 	dir := t.TempDir()
 	writeWidgetSchemaWithOptionalIntCEL(t, dir)
@@ -409,8 +409,8 @@ spec: {}
 	g.Expect(baseResults[0].Errors[0].Msg).To(ContainSubstring("no such key: port"))
 
 	v, err := New(Options{
-		SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
-		IgnoreJSONPathIfAbsent: []string{"Widget:/spec/port"},
+		SchemaLocations:      []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipJSONPathIfAbsent: []string{"Widget:/spec/port"},
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
@@ -419,13 +419,13 @@ spec: {}
 	g.Expect(results[0].Errors).To(BeEmpty())
 }
 
-func TestValidateBytes_IgnoreJSONPathIfAbsent_RunsCELWhenPathPresent(t *testing.T) {
+func TestValidateBytes_SkipJSONPathIfAbsent_RunsCELWhenPathPresent(t *testing.T) {
 	g := NewWithT(t)
 	dir := t.TempDir()
 	writeWidgetSchemaWithOptionalIntCEL(t, dir)
 	v, err := New(Options{
-		SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
-		IgnoreJSONPathIfAbsent: []string{"Widget:/spec/port"},
+		SchemaLocations:      []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipJSONPathIfAbsent: []string{"Widget:/spec/port"},
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -2111,13 +2111,13 @@ spec:
 	g.Expect(results[0].Status).To(Equal(StatusValid))
 }
 
-func TestValidateBytes_IgnoreJSONPathIfAbsent_AllowsMissingRequiredField(t *testing.T) {
+func TestValidateBytes_SkipJSONPathIfAbsent_AllowsMissingRequiredField(t *testing.T) {
 	g := NewWithT(t)
 	dir := t.TempDir()
 	writeWidgetSchema(t, dir)
 	v, err := New(Options{
-		SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
-		IgnoreJSONPathIfAbsent: []string{"Widget:/spec/name"},
+		SchemaLocations:      []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipJSONPathIfAbsent: []string{"Widget:/spec/name"},
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -2134,13 +2134,13 @@ spec:
 	g.Expect(results[0].Errors).To(BeEmpty())
 }
 
-func TestValidateBytes_IgnoreJSONPathIfAbsent_ValidatesPresentValue(t *testing.T) {
+func TestValidateBytes_SkipJSONPathIfAbsent_ValidatesPresentValue(t *testing.T) {
 	g := NewWithT(t)
 	dir := t.TempDir()
 	writeWidgetSchema(t, dir)
 	v, err := New(Options{
-		SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
-		IgnoreJSONPathIfAbsent: []string{"Widget:/spec/name"},
+		SchemaLocations:      []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipJSONPathIfAbsent: []string{"Widget:/spec/name"},
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -2161,13 +2161,13 @@ spec:
 	}))
 }
 
-func TestValidateBytes_IgnoreJSONPathIfAbsent_KindScopeBlocksUnrelatedDocs(t *testing.T) {
+func TestValidateBytes_SkipJSONPathIfAbsent_KindScopeBlocksUnrelatedDocs(t *testing.T) {
 	g := NewWithT(t)
 	dir := t.TempDir()
 	writeWidgetSchema(t, dir)
 	v, err := New(Options{
-		SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
-		IgnoreJSONPathIfAbsent: []string{"Secret:/spec/name"},
+		SchemaLocations:      []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipJSONPathIfAbsent: []string{"Secret:/spec/name"},
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -2187,7 +2187,7 @@ spec:
 	}))
 }
 
-func TestValidateBytes_IgnoreJSONPathIfAbsent_KeepsOtherMissingFields(t *testing.T) {
+func TestValidateBytes_SkipJSONPathIfAbsent_KeepsOtherMissingFields(t *testing.T) {
 	g := NewWithT(t)
 	dir := t.TempDir()
 	schema := map[string]any{
@@ -2212,8 +2212,8 @@ func TestValidateBytes_IgnoreJSONPathIfAbsent_KeepsOtherMissingFields(t *testing
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(os.WriteFile(filepath.Join(dir, "widget-example-v1.json"), b, 0o644)).To(Succeed())
 	v, err := New(Options{
-		SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
-		IgnoreJSONPathIfAbsent: []string{"Widget:/spec/name"},
+		SchemaLocations:      []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipJSONPathIfAbsent: []string{"Widget:/spec/name"},
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -2232,7 +2232,7 @@ spec: {}
 	}))
 }
 
-func TestValidateBytes_IgnoreJSONPathIfAbsent_PrunesAllOfParent(t *testing.T) {
+func TestValidateBytes_SkipJSONPathIfAbsent_PrunesAllOfParent(t *testing.T) {
 	g := NewWithT(t)
 	dir := t.TempDir()
 	schema := map[string]any{
@@ -2259,8 +2259,8 @@ func TestValidateBytes_IgnoreJSONPathIfAbsent_PrunesAllOfParent(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(os.WriteFile(filepath.Join(dir, "widget-example-v1.json"), b, 0o644)).To(Succeed())
 	v, err := New(Options{
-		SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
-		IgnoreJSONPathIfAbsent: []string{"Widget:/spec/name"},
+		SchemaLocations:      []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipJSONPathIfAbsent: []string{"Widget:/spec/name"},
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -2276,7 +2276,7 @@ spec: {}
 	g.Expect(results[0].Errors).To(BeEmpty())
 }
 
-func TestValidateBytes_IgnoreJSONPathIfAbsent_PrunesPassingCompositeBranch(t *testing.T) {
+func TestValidateBytes_SkipJSONPathIfAbsent_PrunesPassingCompositeBranch(t *testing.T) {
 	for _, keyword := range []string{"anyOf", "oneOf"} {
 		t.Run(keyword, func(t *testing.T) {
 			g := NewWithT(t)
@@ -2308,8 +2308,8 @@ func TestValidateBytes_IgnoreJSONPathIfAbsent_PrunesPassingCompositeBranch(t *te
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(os.WriteFile(filepath.Join(dir, "widget-example-v1.json"), b, 0o644)).To(Succeed())
 			v, err := New(Options{
-				SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
-				IgnoreJSONPathIfAbsent: []string{"Widget:/spec/name"},
+				SchemaLocations:      []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+				SkipJSONPathIfAbsent: []string{"Widget:/spec/name"},
 			})
 			g.Expect(err).ToNot(HaveOccurred())
 
@@ -2327,7 +2327,7 @@ spec: {}
 	}
 }
 
-func TestValidateBytes_IgnoreJSONPathIfAbsent_PrunesRefParent(t *testing.T) {
+func TestValidateBytes_SkipJSONPathIfAbsent_PrunesRefParent(t *testing.T) {
 	g := NewWithT(t)
 	dir := t.TempDir()
 	schema := map[string]any{
@@ -2355,8 +2355,8 @@ func TestValidateBytes_IgnoreJSONPathIfAbsent_PrunesRefParent(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(os.WriteFile(filepath.Join(dir, "widget-example-v1.json"), b, 0o644)).To(Succeed())
 	v, err := New(Options{
-		SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
-		IgnoreJSONPathIfAbsent: []string{"Widget:/spec/name"},
+		SchemaLocations:      []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipJSONPathIfAbsent: []string{"Widget:/spec/name"},
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -2372,13 +2372,13 @@ spec: {}
 	g.Expect(results[0].Errors).To(BeEmpty())
 }
 
-func TestNew_RejectsBadIgnoreJSONPathIfAbsent(t *testing.T) {
+func TestNew_RejectsBadSkipJSONPathIfAbsent(t *testing.T) {
 	g := NewWithT(t)
 	_, err := New(Options{
-		SchemaLocations:        []string{"./{{ .Kind }}.json"},
-		IgnoreJSONPathIfAbsent: []string{"no-leading-slash"},
+		SchemaLocations:      []string{"./{{ .Kind }}.json"},
+		SkipJSONPathIfAbsent: []string{"no-leading-slash"},
 	})
-	g.Expect(err).To(MatchError(ContainSubstring("ignore JSON path if absent pattern")))
+	g.Expect(err).To(MatchError(ContainSubstring("skip JSON path if absent pattern")))
 }
 
 func TestNew_RejectsBadSkipJSONPath(t *testing.T) {

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -2384,6 +2384,64 @@ spec: {}
 	}))
 }
 
+func TestValidateBytes_SkipJSONPathIfAbsent_OneOfValidBranchBecomesAmbiguous(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	schema := map[string]any{
+		"type":     "object",
+		"required": []any{"apiVersion", "kind", "spec"},
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"type": "string"},
+			"kind":       map[string]any{"type": "string"},
+			"metadata":   map[string]any{"type": "object"},
+			"spec": map[string]any{
+				"oneOf": []any{
+					map[string]any{
+						"type":     "object",
+						"required": []any{"mode"},
+						"properties": map[string]any{
+							"mode": map[string]any{
+								"type":  "string",
+								"const": "auto",
+							},
+						},
+					},
+					map[string]any{
+						"type":     "object",
+						"required": []any{"replicas"},
+						"properties": map[string]any{
+							"replicas": map[string]any{"type": "integer"},
+						},
+					},
+				},
+			},
+		},
+	}
+	b, err := json.MarshalIndent(schema, "", "  ")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(os.WriteFile(filepath.Join(dir, "widget-example-v1.json"), b, 0o644)).To(Succeed())
+	v, err := New(Options{
+		SchemaLocations:      []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipJSONPathIfAbsent: []string{"Widget:/spec/replicas"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec:
+  mode: auto
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Errors).To(ConsistOf(ValidationError{
+		Path: "/spec",
+		Msg:  "'oneOf' failed, subschemas 0, 1 matched",
+	}))
+}
+
 func TestValidateBytes_SkipJSONPathIfAbsent_PrunesRefParent(t *testing.T) {
 	g := NewWithT(t)
 	dir := t.TempDir()

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -310,6 +310,37 @@ func writeWidgetSchemaWithIntCEL(t *testing.T, dir string) {
 	}
 }
 
+func writeWidgetSchemaWithOptionalIntCEL(t *testing.T, dir string) {
+	t.Helper()
+	schema := map[string]any{
+		"type":     "object",
+		"required": []any{"apiVersion", "kind", "spec"},
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"type": "string"},
+			"kind":       map[string]any{"type": "string"},
+			"metadata":   map[string]any{"type": "object"},
+			"spec": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]any{
+					"port": map[string]any{"type": "integer", "format": "int32"},
+				},
+				"x-kubernetes-validations": []any{
+					map[string]any{"rule": "self.port > 0", "message": "port must be positive"},
+				},
+			},
+		},
+	}
+	b, err := json.MarshalIndent(schema, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	path := filepath.Join(dir, "widget-example-v1.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+}
+
 // Regression: a CEL rule that references an integer field used to fail with
 // "invalid data, expected int, got float64" because sigs.k8s.io/yaml decoded
 // JSON numbers via stdlib encoding/json (float64 by default for any).
@@ -356,6 +387,59 @@ spec:
 	g.Expect(results[0].Status).To(Equal(StatusInvalid))
 	g.Expect(results[0].Reason).To(Equal(ReasonCELViolation))
 	g.Expect(results[0].Errors).ToNot(BeEmpty())
+	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("port must be positive"))
+}
+
+func TestValidateBytes_IgnoreJSONPathIfAbsent_SkipsCELWhenPathAbsent(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchemaWithOptionalIntCEL(t, dir)
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec: {}
+`)
+
+	base := newLocalValidator(t, dir, false)
+	baseResults := base.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(baseResults).To(HaveLen(1))
+	g.Expect(baseResults[0].Status).To(Equal(StatusInvalid))
+	g.Expect(baseResults[0].Reason).To(Equal(ReasonCELViolation))
+	g.Expect(baseResults[0].Errors[0].Msg).To(ContainSubstring("no such key: port"))
+
+	v, err := New(Options{
+		SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		IgnoreJSONPathIfAbsent: []string{"Widget:/spec/port"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusValid))
+	g.Expect(results[0].Errors).To(BeEmpty())
+}
+
+func TestValidateBytes_IgnoreJSONPathIfAbsent_RunsCELWhenPathPresent(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchemaWithOptionalIntCEL(t, dir)
+	v, err := New(Options{
+		SchemaLocations:        []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		IgnoreJSONPathIfAbsent: []string{"Widget:/spec/port"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec:
+  port: 0
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Reason).To(Equal(ReasonCELViolation))
 	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("port must be positive"))
 }
 

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -2327,6 +2327,63 @@ spec: {}
 	}
 }
 
+func TestValidateBytes_SkipJSONPathIfAbsent_OneOfMultiplePrunedBranchesFails(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	schema := map[string]any{
+		"type":     "object",
+		"required": []any{"apiVersion", "kind", "spec"},
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"type": "string"},
+			"kind":       map[string]any{"type": "string"},
+			"metadata":   map[string]any{"type": "object"},
+			"spec": map[string]any{
+				"oneOf": []any{
+					map[string]any{
+						"type":     "object",
+						"required": []any{"alpha"},
+						"properties": map[string]any{
+							"alpha": map[string]any{"type": "string"},
+						},
+					},
+					map[string]any{
+						"type":     "object",
+						"required": []any{"beta"},
+						"properties": map[string]any{
+							"beta": map[string]any{"type": "string"},
+						},
+					},
+				},
+			},
+		},
+	}
+	b, err := json.MarshalIndent(schema, "", "  ")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(os.WriteFile(filepath.Join(dir, "widget-example-v1.json"), b, 0o644)).To(Succeed())
+	v, err := New(Options{
+		SchemaLocations: []string{filepath.Join(dir, "{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json")},
+		SkipJSONPathIfAbsent: []string{
+			"Widget:/spec/alpha",
+			"Widget:/spec/beta",
+		},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+spec: {}
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Errors).To(ConsistOf(ValidationError{
+		Path: "/spec",
+		Msg:  "'oneOf' failed, subschemas 0, 1 matched",
+	}))
+}
+
 func TestValidateBytes_SkipJSONPathIfAbsent_PrunesRefParent(t *testing.T) {
 	g := NewWithT(t)
 	dir := t.TempDir()


### PR DESCRIPTION
Adds `--skip-json-path-if-absent` and `skipJSONPathIfAbsent` for validation cases where admission hooks default required fields before API server validation. The option skips only missing required-field errors for matching JSON Pointer paths; present values still validate against the schema, and CEL is skipped only for matching documents with absent paths.

Closes: #95