### PR TITLE
extract crd: Keep root metadata schema open

### DIFF
--- a/cmd/flux-schema/validate_test.go
+++ b/cmd/flux-schema/validate_test.go
@@ -1470,3 +1470,75 @@ func TestValidateCmd_CELRule_SkipJSONPath(t *testing.T) {
 	g.Expect(res.Reason).To(Equal(apiv1.ReportReason(validator.ReasonCELViolation)))
 	g.Expect(res.Violations[0].Message).ToNot(BeEmpty())
 }
+
+// metadataCRDYAML declares a metadata schema constraining only name, as
+// Crossplane-generated CRDs do. Extracted schemas must still accept the
+// implicit ObjectMeta fields such as namespace.
+const metadataCRDYAML = `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keyvaults.example.com
+spec:
+  group: example.com
+  scope: Namespaced
+  names:
+    kind: KeyVault
+    plural: keyvaults
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 11
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string
+`
+
+func TestValidateCmd_CRDMetadataSchema_AcceptsNamespace(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractCRDSchema(t, metadataCRDYAML)
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", `apiVersion: example.com/v1alpha1
+kind: KeyVault
+metadata:
+  name: testkv
+  namespace: stas
+  labels:
+    app: kv
+spec:
+  name: hello
+`)
+	path := writeManifest(t, manifestDir, "bad.yaml", `apiVersion: example.com/v1alpha1
+kind: KeyVault
+metadata:
+  name: name-too-long
+  namespace: stas
+spec:
+  name: hello
+`)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+	})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(out).ToNot(ContainSubstring("additional properties 'namespace' not allowed"))
+	g.Expect(out).To(ContainSubstring(path + " - KeyVault/stas/name-too-long is invalid: schema violation"))
+	g.Expect(out).To(MatchRegexp(`(?m)^  - /metadata/name: `))
+	g.Expect(out).To(ContainSubstring("Summary: 2 resources found in 2 files - Valid: 1, Invalid: 1, Skipped: 0"))
+}

--- a/docs/custom-schema-catalog.md
+++ b/docs/custom-schema-catalog.md
@@ -207,7 +207,10 @@ constraints the Kubernetes API server enforces:
 - Every `$ref` is inlined, so each schema has no cross-file dependencies.
 - Objects with `properties` are closed with `additionalProperties: false`,
   except under nodes marked `x-kubernetes-preserve-unknown-fields: true`,
-  which stay open so free-form maps validate correctly.
+  which stay open so free-form maps validate correctly. The root `metadata`
+  object of a CRD schema is also left open: the API server only honors
+  `name` and `generateName` constraints there and validates the remaining
+  `ObjectMeta` fields implicitly.
 - Kubernetes admission validation extensions are preserved when they affect
   manifest validation: `x-kubernetes-embedded-resource`,
   `x-kubernetes-list-type`, `x-kubernetes-list-map-keys`,

--- a/internal/extractor/crd.go
+++ b/internal/extractor/crd.go
@@ -129,6 +129,7 @@ func versionsFromCRD(crd map[string]any) ([]Schema, []error) {
 		deprecated, _ := vm["deprecated"].(bool)
 		deprecationWarning, _ := vm["deprecationWarning"].(string)
 		closeAdditionalPropertiesChildren(schema)
+		openRootMetadata(schema)
 		transformed, _ := replaceIntOrString(schema).(map[string]any)
 		injectExplainMetadata(transformed, kind, GVK{Group: group, Version: versionName, Kind: kind}, resource)
 

--- a/internal/extractor/crd_test.go
+++ b/internal/extractor/crd_test.go
@@ -4,6 +4,7 @@
 package extractor
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -386,4 +387,55 @@ func TestExtractCRDs_MissingSpec(t *testing.T) {
 	_, errs := ExtractCRDs([]byte("apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: x\n"))
 	g.Expect(errs).To(HaveLen(1))
 	g.Expect(errs[0].Error()).To(ContainSubstring("missing 'spec'"))
+}
+
+// metadataCRD mirrors a Crossplane-generated CRD that declares a metadata
+// schema constraining only name, which is all the API server allows.
+const metadataCRD = `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keyvaults.example.com
+spec:
+  group: example.com
+  scope: Namespaced
+  names:
+    kind: KeyVault
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 63
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string
+`
+
+func TestExtractCRDs_RootMetadataStaysOpen(t *testing.T) {
+	g := NewWithT(t)
+	crds, errs := ExtractCRDs([]byte(metadataCRD))
+	g.Expect(errs).To(BeEmpty())
+	g.Expect(crds).To(HaveLen(1))
+
+	props := crds[0].JSON["properties"].(map[string]any)
+	meta := props["metadata"].(map[string]any)
+	g.Expect(meta).ToNot(HaveKey("additionalProperties"), "root metadata must stay open")
+	name := meta["properties"].(map[string]any)["name"].(map[string]any)
+	g.Expect(fmt.Sprint(name["maxLength"])).To(Equal("63"), "name constraint must be preserved")
+
+	spec := props["spec"].(map[string]any)
+	g.Expect(spec["additionalProperties"]).To(BeFalse(), "sibling objects must still be closed")
 }

--- a/internal/extractor/transformers.go
+++ b/internal/extractor/transformers.go
@@ -504,6 +504,24 @@ func closeAdditionalPropertiesNameMap(k string, v any) bool {
 	return true
 }
 
+// openRootMetadata removes the additionalProperties:false that
+// closeAdditionalPropertiesChildren sets on the root "metadata" property of a
+// CRD schema. The API server only lets a CRD constrain metadata.name and
+// metadata.generateName and validates the rest of ObjectMeta (namespace,
+// labels, annotations, ...) implicitly, so a closed metadata object would
+// reject every namespaced resource whose CRD declares a metadata schema
+// (Crossplane-generated CRDs do this).
+func openRootMetadata(schema map[string]any) {
+	props, _ := schema[keyProperties].(map[string]any)
+	meta, _ := props["metadata"].(map[string]any)
+	if meta == nil {
+		return
+	}
+	if ap, ok := meta["additionalProperties"].(bool); ok && !ap {
+		delete(meta, "additionalProperties")
+	}
+}
+
 // --- vendor extension stripping ---
 
 // stripVendorExtensions removes x-kubernetes-* keys from the tree except those


### PR DESCRIPTION
The `extract crd` command closed` properties.metadata` with `additionalProperties:false` whenever a CRD declared a metadata schema. Validation with the resulting schema rejected `metadata.namespace`, labels and annotations on resources the API server accepts. CRDs generated by Crossplane Compositions and by Gatekeeper, Antrea and OVN-Kubernetes declare such a schema to constrain `metadata.name`.

The API server only honors `name` and `generateName` constraints under metadata and validates the rest of `ObjectMeta` implicitly. Mirror that in `extract crd` by reopening the root metadata object after closing, keeping the declared `name` and `generateName` constraints.

Schemas produced by `extract k8s` and `extract openshift` from a cluster's OpenAPI document are not affected: the API server replaces the CRD metadata schema with the full `ObjectMeta` definition before publishing it, so those schemas already accept every metadata field. Users of `extract crd` must re-extract their schemas to get the fix.

Fixes #94

Assisted-by: Claude Code/claude-fable-5-1