### PR TITLE
Inject implicit ObjectMeta fields into the schema for validation

### DIFF
--- a/cmd/flux-schema/validate_test.go
+++ b/cmd/flux-schema/validate_test.go
@@ -96,6 +96,39 @@ spec:
   name: 42
 `
 
+const crdWithRootMetadataNameOnly = `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  scope: Namespaced
+  names:
+    kind: Widget
+    plural: widgets
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 63
+            spec:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+`
+
 func TestValidateCmd_ValidManifest_QuietNoOutput(t *testing.T) {
 	g := NewWithT(t)
 	schemaDir := extractWidgetSchema(t)
@@ -109,6 +142,50 @@ func TestValidateCmd_ValidManifest_QuietNoOutput(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(out).ToNot(ContainSubstring("is valid"))
 	g.Expect(out).To(ContainSubstring("Summary: 1 resource found in 1 file - Valid: 1, Invalid: 0, Skipped: 0"))
+}
+
+func TestValidateCmd_CRDImplicitObjectMetaFields(t *testing.T) {
+	g := NewWithT(t)
+	schemaDir := extractCRDSchema(t, crdWithRootMetadataNameOnly)
+	schemaFiles, err := filepath.Glob(filepath.Join(schemaDir, "*.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(schemaFiles).To(HaveLen(1))
+	schemaData, err := os.ReadFile(schemaFiles[0])
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(schemaData)).ToNot(ContainSubstring(`"namespace"`), "extract crd output must stay compact")
+
+	manifestDir := t.TempDir()
+	writeManifest(t, manifestDir, "ok.yaml", validWidget)
+	longName := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	longNamePath := writeManifest(t, manifestDir, "long-name.yaml", `apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: `+longName+`
+  namespace: default
+spec:
+  name: hello
+`)
+	typoPath := writeManifest(t, manifestDir, "typo.yaml", `apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: typo-widget
+  namespace: default
+  namepaceX: default
+spec:
+  name: hello
+`)
+
+	out, err := executeCommand([]string{
+		"validate", manifestDir,
+		"--schema-location", filepath.Join(schemaDir, "{{.Kind}}-{{.GroupPrefix}}-{{.Version}}.json"),
+	})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(out).ToNot(ContainSubstring("additional properties 'namespace' not allowed"))
+	g.Expect(out).To(ContainSubstring(longNamePath + " - Widget/default/" + longName + " is invalid: schema violation"))
+	g.Expect(out).To(MatchRegexp(`(?m)^  - /metadata/name: `))
+	g.Expect(out).To(ContainSubstring(typoPath + " - Widget/default/typo-widget is invalid: schema violation"))
+	g.Expect(out).To(ContainSubstring("additional properties 'namepaceX' not allowed"))
+	g.Expect(out).To(ContainSubstring("Summary: 3 resources found in 3 files - Valid: 1, Invalid: 2, Skipped: 0"))
 }
 
 func TestValidateCmd_InvalidManifest_PrintsViolationAndFails(t *testing.T) {

--- a/docs/manifests-validation.md
+++ b/docs/manifests-validation.md
@@ -89,7 +89,9 @@ During validation, resource-root `metadata` is treated as Kubernetes
 `metadata.properties`, Flux Schema completes the loaded schema in memory so
 standard fields like `namespace`, `labels`, and `annotations` do not fail as
 additional properties. Existing schema constraints on fields such as
-`metadata.name` and `metadata.generateName` are preserved.
+`metadata.name` and `metadata.generateName` are preserved. CEL rules still use
+Kubernetes' structural schema view of root metadata, where only `name` and
+`generateName` are implicitly visible.
 
 ## Skipping documents and fields
 

--- a/docs/manifests-validation.md
+++ b/docs/manifests-validation.md
@@ -84,6 +84,13 @@ projects and rebuilt daily from upstream releases.
 See [custom catalogs](custom-schema-catalog.md) for guidance on building and hosting
 your own schema catalog.
 
+During validation, resource-root `metadata` is treated as Kubernetes
+`ObjectMeta`. If a compact CRD schema declares only part of
+`metadata.properties`, Flux Schema completes the loaded schema in memory so
+standard fields like `namespace`, `labels`, and `annotations` do not fail as
+additional properties. Existing schema constraints on fields such as
+`metadata.name` and `metadata.generateName` are preserved.
+
 ## Skipping documents and fields
 
 Manifests can be piped in and certain documents skipped with `--skip-kind`:

--- a/internal/validator/doc.go
+++ b/internal/validator/doc.go
@@ -34,12 +34,13 @@
 //  5. SkipJSONPaths — matching pointers are deleted from the document
 //     before schema validation.
 //  6. JSON Schema + ObjectMeta — the compiled schema runs against the
-//     document. SkipJSONPathIfAbsent suppresses matching required-property
-//     errors for absent fields only; present values are still checked by the
-//     schema. DNS-1123 and qualified-name rules are layered on metadata since
-//     Kubernetes schemas leave it effectively unconstrained. The metadata
-//     layer is skipped for Flux plugin API groups. Violations merge under
-//     ReasonSchemaViolation.
+//     document. Loaded schemas are completed in memory with implicit root
+//     ObjectMeta fields when they partially define metadata. SkipJSONPathIfAbsent
+//     suppresses matching required-property errors for absent fields only;
+//     present values are still checked by the schema. DNS-1123 and
+//     qualified-name rules are layered on metadata since Kubernetes schemas
+//     leave it effectively unconstrained. The metadata layer is skipped for
+//     Flux plugin API groups. Violations merge under ReasonSchemaViolation.
 //  7. CEL x-kubernetes-validations — runs only after steps 1-6 pass and
 //     unless Options.SkipCELRules is set or SkipJSONPathIfAbsent matched an
 //     absent path on the document. Rule compile errors and runtime violations

--- a/internal/validator/loader.go
+++ b/internal/validator/loader.go
@@ -158,6 +158,9 @@ func (l *SchemaLoader) loadAndCompile(ctx context.Context, location string) (loa
 	if err := yaml.Unmarshal(body, &doc); err != nil {
 		return r, fmt.Errorf("parse schema: %w", err)
 	}
+	if rootMap, ok := doc.(map[string]any); ok {
+		augmentRootObjectMetaSchema(rootMap)
+	}
 
 	r.schema, err = l.compileJSONSchema(baseURI, doc)
 	if err != nil {

--- a/internal/validator/loader.go
+++ b/internal/validator/loader.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/santhosh-tekuri/jsonschema/v6"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
 	"github.com/fluxcd/flux-schema/internal/tmpl"
@@ -132,8 +133,8 @@ func (l *SchemaLoader) cacheEntry(location string) *schemaCacheEntry {
 	return entry.(*schemaCacheEntry)
 }
 
-// loadAndCompile fetches location and compiles its contents as a JSON Schema,
-// then builds Kubernetes admission and CEL evaluators from the same document.
+// loadAndCompile fetches location, compiles its contents as a JSON Schema,
+// then builds Kubernetes admission and CEL evaluators from the source schema.
 // The returned loadResult has found=false when the location responded with
 // "not found", so the caller can fall through to the next template.
 //
@@ -158,11 +159,18 @@ func (l *SchemaLoader) loadAndCompile(ctx context.Context, location string) (loa
 	if err := yaml.Unmarshal(body, &doc); err != nil {
 		return r, fmt.Errorf("parse schema: %w", err)
 	}
+
+	jsonSchemaDoc := doc
 	if rootMap, ok := doc.(map[string]any); ok {
-		augmentRootObjectMetaSchema(rootMap)
+		// Root ObjectMeta completion is a JSON Schema compatibility layer.
+		// Kubernetes CEL only exposes its documented implicit fields through
+		// the source structural schema below.
+		jsonSchemaMap := runtime.DeepCopyJSON(rootMap)
+		augmentRootObjectMetaSchema(jsonSchemaMap)
+		jsonSchemaDoc = jsonSchemaMap
 	}
 
-	r.schema, err = l.compileJSONSchema(baseURI, doc)
+	r.schema, err = l.compileJSONSchema(baseURI, jsonSchemaDoc)
 	if err != nil {
 		return loadResult{}, err
 	}

--- a/internal/validator/loader_test.go
+++ b/internal/validator/loader_test.go
@@ -183,6 +183,18 @@ func TestSchemaLoader_Resolve_WithInternalRef(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(found).To(BeTrue())
 	g.Expect(resolved.JSON.Validate(map[string]any{"metadata": map[string]any{"name": "r1"}})).To(Succeed())
+	g.Expect(resolved.JSON.Validate(map[string]any{
+		"metadata": map[string]any{
+			"name":      "r1",
+			"namespace": "default",
+		},
+	})).To(Succeed())
+	g.Expect(resolved.JSON.Validate(map[string]any{
+		"metadata": map[string]any{
+			"name":      "r1",
+			"namepaceX": "default",
+		},
+	})).ToNot(Succeed())
 }
 
 func TestSchemaLoader_Resolve_CachesAcrossCalls(t *testing.T) {

--- a/internal/validator/metadata_test.go
+++ b/internal/validator/metadata_test.go
@@ -223,6 +223,31 @@ spec:
 	g.Expect(paths).To(HaveKey("/metadata/name"))
 }
 
+func TestValidateBytes_RejectsUnknownObjectMetaField(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchema(t, dir)
+	v := newLocalValidator(t, dir, false)
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+  namespace: default
+  namepaceX: default
+spec:
+  name: ok
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Reason).To(Equal(ReasonSchemaViolation))
+	g.Expect(results[0].Errors).To(ContainElement(ValidationError{
+		Path: "/metadata",
+		Msg:  "additional properties 'namepaceX' not allowed",
+	}))
+}
+
 // TestValidateBytes_SchemaAndMetadataViolations pins that both error sets
 // surface in one Result so users don't have to re-run after fixing one half.
 func TestValidateBytes_SchemaAndMetadataViolations(t *testing.T) {

--- a/internal/validator/metadata_test.go
+++ b/internal/validator/metadata_test.go
@@ -248,6 +248,30 @@ spec:
 	}))
 }
 
+func TestValidateBytes_AllowsNullOptionalObjectMetaFields(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchema(t, dir)
+	v := newLocalValidator(t, dir, false)
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+  namespace: null
+  labels: null
+  annotations: null
+  finalizers: null
+  managedFields: null
+spec:
+  name: ok
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusValid))
+	g.Expect(results[0].Errors).To(BeEmpty())
+}
+
 // TestValidateBytes_SchemaAndMetadataViolations pins that both error sets
 // surface in one Result so users don't have to re-run after fixing one half.
 func TestValidateBytes_SchemaAndMetadataViolations(t *testing.T) {

--- a/internal/validator/objectmeta_schema.go
+++ b/internal/validator/objectmeta_schema.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
@@ -29,6 +30,10 @@ func augmentRootObjectMetaSchema(schema map[string]any) {
 	metadata, _ := props["metadata"].(map[string]any)
 	if metadata == nil {
 		return
+	}
+	if inlined, ok := inlineLocalRef(schema, metadata); ok {
+		metadata = inlined
+		props["metadata"] = metadata
 	}
 	metadataProps, _ := metadata[jsonSchemaProperties].(map[string]any)
 	if metadataProps == nil {
@@ -54,7 +59,55 @@ func augmentRootObjectMetaSchema(schema map[string]any) {
 				existing[key] = value
 			}
 		}
+		if acceptsNull(objectMetaProp) {
+			addNullType(existing)
+		}
 	}
+}
+
+func inlineLocalRef(root, node map[string]any) (map[string]any, bool) {
+	ref, _ := node["$ref"].(string)
+	if ref == "" {
+		return nil, false
+	}
+	target, ok := resolveLocalRef(root, ref)
+	if !ok {
+		return nil, false
+	}
+	inlined := runtime.DeepCopyJSON(target)
+	for key, value := range node {
+		if key == "$ref" {
+			continue
+		}
+		inlined[key] = runtime.DeepCopyJSONValue(value)
+	}
+	return inlined, true
+}
+
+func resolveLocalRef(root map[string]any, ref string) (map[string]any, bool) {
+	pointer, ok := strings.CutPrefix(ref, "#/")
+	if !ok {
+		return nil, false
+	}
+	var node any = root
+	for _, segment := range strings.Split(pointer, "/") {
+		m, ok := node.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		node, ok = m[unescapeJSONPointer(segment)]
+		if !ok {
+			return nil, false
+		}
+	}
+	target, ok := node.(map[string]any)
+	return target, ok
+}
+
+func unescapeJSONPointer(s string) string {
+	s = strings.ReplaceAll(s, "~1", "/")
+	s = strings.ReplaceAll(s, "~0", "~")
+	return s
 }
 
 func objectMetaPropertySchemas() map[string]map[string]any {
@@ -153,8 +206,12 @@ func objectSchemaForGoStruct(t reflect.Type, seen map[reflect.Type]bool) map[str
 			}
 			continue
 		}
-		props[name] = schemaForGoType(field.Type, nextSeen)
-		if !slices.Contains(opts, "omitempty") && !slices.Contains(opts, "omitzero") {
+		fieldSchema := schemaForGoType(field.Type, nextSeen)
+		if optionalJSONField(opts) {
+			addNullType(fieldSchema)
+		}
+		props[name] = fieldSchema
+		if !optionalJSONField(opts) {
 			required = append(required, name)
 		}
 	}
@@ -168,6 +225,10 @@ func objectSchemaForGoStruct(t reflect.Type, seen map[reflect.Type]bool) map[str
 		schema["required"] = required
 	}
 	return schema
+}
+
+func optionalJSONField(opts []string) bool {
+	return slices.Contains(opts, "omitempty") || slices.Contains(opts, "omitzero")
 }
 
 func schemaPropertiesForGoType(t reflect.Type, seen map[reflect.Type]bool) map[string]any {
@@ -214,5 +275,16 @@ func addNullType(schema map[string]any) {
 		if !slices.Contains(typed, jsonNullType) {
 			schema["type"] = append(typed, jsonNullType)
 		}
+	}
+}
+
+func acceptsNull(schema map[string]any) bool {
+	switch typed := schema["type"].(type) {
+	case string:
+		return typed == jsonNullType
+	case []any:
+		return slices.Contains(typed, jsonNullType)
+	default:
+		return false
 	}
 }

--- a/internal/validator/objectmeta_schema.go
+++ b/internal/validator/objectmeta_schema.go
@@ -1,0 +1,218 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	jsonSchemaProperties = "properties"
+	jsonNullType         = "null"
+)
+
+// augmentRootObjectMetaSchema mirrors kube-apiserver's implicit ObjectMeta
+// handling in the in-memory schema used by validation. The loaded schema file
+// is not rewritten.
+func augmentRootObjectMetaSchema(schema map[string]any) {
+	props, _ := schema[jsonSchemaProperties].(map[string]any)
+	if props == nil {
+		return
+	}
+	metadata, _ := props["metadata"].(map[string]any)
+	if metadata == nil {
+		return
+	}
+	metadataProps, _ := metadata[jsonSchemaProperties].(map[string]any)
+	if metadataProps == nil {
+		metadataProps = map[string]any{}
+		metadata[jsonSchemaProperties] = metadataProps
+	}
+	if _, ok := metadata["type"]; !ok {
+		metadata["type"] = "object"
+	}
+	if _, ok := metadata["additionalProperties"]; !ok {
+		metadata["additionalProperties"] = false
+	}
+	for name, objectMetaProp := range objectMetaPropertySchemas() {
+		existing, ok := metadataProps[name].(map[string]any)
+		if !ok {
+			if _, exists := metadataProps[name]; !exists {
+				metadataProps[name] = objectMetaProp
+			}
+			continue
+		}
+		for key, value := range objectMetaProp {
+			if _, exists := existing[key]; !exists {
+				existing[key] = value
+			}
+		}
+	}
+}
+
+func objectMetaPropertySchemas() map[string]map[string]any {
+	props, _ := objectSchemaForGoType(reflect.TypeOf(metav1.ObjectMeta{}), nil)[jsonSchemaProperties].(map[string]any)
+	out := make(map[string]map[string]any, len(props))
+	for name, prop := range props {
+		if propMap, ok := prop.(map[string]any); ok {
+			out[name] = propMap
+		}
+	}
+	return out
+}
+
+func schemaForGoType(t reflect.Type, seen map[reflect.Type]bool) map[string]any {
+	nullable := false
+	for t.Kind() == reflect.Pointer {
+		nullable = true
+		t = t.Elem()
+	}
+
+	schema := objectSchemaForGoType(t, seen)
+	if nullable {
+		addNullType(schema)
+	}
+	return schema
+}
+
+func objectSchemaForGoType(t reflect.Type, seen map[reflect.Type]bool) map[string]any {
+	t = derefGoType(t)
+	if t == reflect.TypeOf(metav1.Time{}) || t == reflect.TypeOf(metav1.MicroTime{}) {
+		return map[string]any{"type": []any{"string", jsonNullType}, "format": "date-time"}
+	}
+
+	switch t.Kind() {
+	case reflect.Bool:
+		return map[string]any{"type": "boolean"}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		schema := map[string]any{"type": "integer"}
+		if t.Kind() == reflect.Int32 || t.Kind() == reflect.Int64 {
+			schema["format"] = fmt.Sprintf("int%d", t.Bits())
+		}
+		return schema
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		schema := map[string]any{"type": "integer", "minimum": 0}
+		if t.Kind() == reflect.Uint32 || t.Kind() == reflect.Uint64 {
+			schema["format"] = fmt.Sprintf("int%d", t.Bits())
+		}
+		return schema
+	case reflect.Float32, reflect.Float64:
+		return map[string]any{"type": "number"}
+	case reflect.String:
+		return map[string]any{"type": "string"}
+	case reflect.Slice, reflect.Array:
+		if t.Elem().Kind() == reflect.Uint8 {
+			return map[string]any{"type": "string", "format": "byte"}
+		}
+		return map[string]any{"type": "array", "items": schemaForGoType(t.Elem(), seen)}
+	case reflect.Map:
+		return map[string]any{
+			"type":                 "object",
+			"additionalProperties": schemaForGoType(t.Elem(), seen),
+		}
+	case reflect.Struct:
+		return objectSchemaForGoStruct(t, seen)
+	case reflect.Interface:
+		return map[string]any{}
+	default:
+		return map[string]any{"type": "object"}
+	}
+}
+
+func objectSchemaForGoStruct(t reflect.Type, seen map[reflect.Type]bool) map[string]any {
+	if seen == nil {
+		seen = map[reflect.Type]bool{}
+	}
+	if seen[t] {
+		return map[string]any{"type": "object"}
+	}
+	nextSeen := maps.Clone(seen)
+	nextSeen[t] = true
+
+	props := map[string]any{}
+	var required []any
+	for i := range t.NumField() {
+		field := t.Field(i)
+		if field.PkgPath != "" && !field.Anonymous {
+			continue
+		}
+		name, opts, skip := jsonField(field)
+		if skip {
+			continue
+		}
+		if slices.Contains(opts, "inline") {
+			for nestedName, nestedSchema := range schemaPropertiesForGoType(field.Type, nextSeen) {
+				props[nestedName] = nestedSchema
+			}
+			continue
+		}
+		props[name] = schemaForGoType(field.Type, nextSeen)
+		if !slices.Contains(opts, "omitempty") && !slices.Contains(opts, "omitzero") {
+			required = append(required, name)
+		}
+	}
+
+	schema := map[string]any{"type": "object"}
+	if len(props) > 0 {
+		schema[jsonSchemaProperties] = props
+		schema["additionalProperties"] = false
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+func schemaPropertiesForGoType(t reflect.Type, seen map[reflect.Type]bool) map[string]any {
+	schema := objectSchemaForGoType(t, seen)
+	props, _ := schema[jsonSchemaProperties].(map[string]any)
+	return props
+}
+
+func jsonField(field reflect.StructField) (string, []string, bool) {
+	tag := field.Tag.Get("json")
+	if tag == "-" {
+		return "", nil, true
+	}
+	if tag == "" {
+		return field.Name, nil, false
+	}
+	parts := strings.Split(tag, ",")
+	name := parts[0]
+	if name == "" {
+		name = field.Name
+	}
+	return name, parts[1:], false
+}
+
+func derefGoType(t reflect.Type) reflect.Type {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return t
+}
+
+func addNullType(schema map[string]any) {
+	typeValue, ok := schema["type"]
+	if !ok {
+		schema["type"] = []any{"object", jsonNullType}
+		return
+	}
+	switch typed := typeValue.(type) {
+	case string:
+		if typed != jsonNullType {
+			schema["type"] = []any{typed, jsonNullType}
+		}
+	case []any:
+		if !slices.Contains(typed, jsonNullType) {
+			schema["type"] = append(typed, jsonNullType)
+		}
+	}
+}

--- a/internal/validator/objectmeta_schema_test.go
+++ b/internal/validator/objectmeta_schema_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestAugmentRootObjectMetaSchema_FillsCompactMetadata(t *testing.T) {
+	g := NewWithT(t)
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"metadata": map[string]any{"type": "object"},
+		},
+	}
+
+	augmentRootObjectMetaSchema(schema)
+
+	metadata := schema["properties"].(map[string]any)["metadata"].(map[string]any)
+	g.Expect(metadata["additionalProperties"]).To(BeFalse())
+
+	metadataProps := metadata["properties"].(map[string]any)
+	g.Expect(metadataProps).To(HaveKey("name"))
+	g.Expect(metadataProps).To(HaveKey("generateName"))
+	g.Expect(metadataProps).To(HaveKey("namespace"))
+	g.Expect(metadataProps).To(HaveKey("labels"))
+	g.Expect(metadataProps).To(HaveKey("annotations"))
+	g.Expect(metadataProps).To(HaveKey("ownerReferences"))
+	g.Expect(metadataProps).To(HaveKey("managedFields"))
+}
+
+func TestAugmentRootObjectMetaSchema_PreservesAuthoredConstraints(t *testing.T) {
+	g := NewWithT(t)
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"metadata": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{
+						"type":      "string",
+						"maxLength": 63,
+					},
+					"generateName": map[string]any{
+						"type":      "string",
+						"maxLength": 40,
+					},
+				},
+			},
+		},
+	}
+
+	augmentRootObjectMetaSchema(schema)
+
+	metadata := schema["properties"].(map[string]any)["metadata"].(map[string]any)
+	metadataProps := metadata["properties"].(map[string]any)
+	g.Expect(metadataProps["name"].(map[string]any)).To(HaveKeyWithValue("maxLength", 63))
+	g.Expect(metadataProps["generateName"].(map[string]any)).To(HaveKeyWithValue("maxLength", 40))
+	g.Expect(metadataProps).To(HaveKey("namespace"))
+}

--- a/internal/validator/objectmeta_schema_test.go
+++ b/internal/validator/objectmeta_schema_test.go
@@ -31,6 +31,9 @@ func TestAugmentRootObjectMetaSchema_FillsCompactMetadata(t *testing.T) {
 	g.Expect(metadataProps).To(HaveKey("annotations"))
 	g.Expect(metadataProps).To(HaveKey("ownerReferences"))
 	g.Expect(metadataProps).To(HaveKey("managedFields"))
+	g.Expect(metadataProps["namespace"].(map[string]any)).To(HaveKeyWithValue("type", ConsistOf("string", jsonNullType)))
+	g.Expect(metadataProps["labels"].(map[string]any)).To(HaveKeyWithValue("type", ConsistOf("object", jsonNullType)))
+	g.Expect(metadataProps["finalizers"].(map[string]any)).To(HaveKeyWithValue("type", ConsistOf("array", jsonNullType)))
 }
 
 func TestAugmentRootObjectMetaSchema_PreservesAuthoredConstraints(t *testing.T) {
@@ -59,6 +62,40 @@ func TestAugmentRootObjectMetaSchema_PreservesAuthoredConstraints(t *testing.T) 
 	metadata := schema["properties"].(map[string]any)["metadata"].(map[string]any)
 	metadataProps := metadata["properties"].(map[string]any)
 	g.Expect(metadataProps["name"].(map[string]any)).To(HaveKeyWithValue("maxLength", 63))
+	g.Expect(metadataProps["name"].(map[string]any)).To(HaveKeyWithValue("type", ConsistOf("string", jsonNullType)))
 	g.Expect(metadataProps["generateName"].(map[string]any)).To(HaveKeyWithValue("maxLength", 40))
+	g.Expect(metadataProps["generateName"].(map[string]any)).To(HaveKeyWithValue("type", ConsistOf("string", jsonNullType)))
 	g.Expect(metadataProps).To(HaveKey("namespace"))
+}
+
+func TestAugmentRootObjectMetaSchema_InlinesLocalRef(t *testing.T) {
+	g := NewWithT(t)
+	schema := map[string]any{
+		"type": "object",
+		"definitions": map[string]any{
+			"ObjectMeta": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+				},
+			},
+		},
+		"properties": map[string]any{
+			"metadata": map[string]any{"$ref": "#/definitions/ObjectMeta"},
+		},
+	}
+
+	augmentRootObjectMetaSchema(schema)
+
+	metadata := schema["properties"].(map[string]any)["metadata"].(map[string]any)
+	g.Expect(metadata).ToNot(HaveKey("$ref"))
+	g.Expect(metadata["additionalProperties"]).To(BeFalse())
+	metadataProps := metadata["properties"].(map[string]any)
+	g.Expect(metadataProps).To(HaveKey("name"))
+	g.Expect(metadataProps).To(HaveKey("namespace"))
+
+	definition := schema["definitions"].(map[string]any)["ObjectMeta"].(map[string]any)
+	definitionProps := definition["properties"].(map[string]any)
+	g.Expect(definitionProps).ToNot(HaveKey("namespace"), "only root metadata should be inlined and augmented")
 }

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -341,6 +341,42 @@ func writeWidgetSchemaWithOptionalIntCEL(t *testing.T, dir string) {
 	}
 }
 
+func writeWidgetSchemaWithRootObjectMetaCEL(t *testing.T, dir, rule string, metadataProps map[string]any) {
+	t.Helper()
+	schema := map[string]any{
+		"type":     "object",
+		"required": []any{"apiVersion", "kind", "spec"},
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"type": "string"},
+			"kind":       map[string]any{"type": "string"},
+			"metadata": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties":           metadataProps,
+			},
+			"spec": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"required":             []any{"name"},
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+				},
+			},
+		},
+		"x-kubernetes-validations": []any{
+			map[string]any{"rule": rule},
+		},
+	}
+	b, err := json.MarshalIndent(schema, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	path := filepath.Join(dir, "widget-example-v1.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+}
+
 // Regression: a CEL rule that references an integer field used to fail with
 // "invalid data, expected int, got float64" because sigs.k8s.io/yaml decoded
 // JSON numbers via stdlib encoding/json (float64 by default for any).
@@ -388,6 +424,58 @@ spec:
 	g.Expect(results[0].Reason).To(Equal(ReasonCELViolation))
 	g.Expect(results[0].Errors).ToNot(BeEmpty())
 	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("port must be positive"))
+}
+
+func TestValidateBytes_CELSeesImplicitObjectMetaFields(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchemaWithRootObjectMetaCEL(
+		t,
+		dir,
+		"has(self.metadata.name) || has(self.metadata.generateName)",
+		map[string]any{},
+	)
+	v := newLocalValidator(t, dir, false)
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+  namespace: default
+spec:
+  name: my-widget
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusValid), "errors: %+v", results[0].Errors)
+	g.Expect(results[0].Errors).To(BeEmpty())
+}
+
+func TestValidateBytes_CELDoesNotSeeAugmentedObjectMetaFields(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeWidgetSchemaWithRootObjectMetaCEL(
+		t,
+		dir,
+		"has(self.metadata.namespace)",
+		map[string]any{"name": map[string]any{"type": "string"}},
+	)
+	v := newLocalValidator(t, dir, false)
+
+	doc := []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w1
+  namespace: default
+spec:
+  name: my-widget
+`)
+	results := v.ValidateBytes(context.Background(), "test.yaml", doc)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Status).To(Equal(StatusInvalid))
+	g.Expect(results[0].Reason).To(Equal(ReasonCELViolation))
+	g.Expect(results[0].Errors).ToNot(BeEmpty())
+	g.Expect(results[0].Errors[0].Msg).To(ContainSubstring("undefined field 'namespace'"))
 }
 
 func TestValidateBytes_SkipJSONPathIfAbsent_SkipsCELWhenPathAbsent(t *testing.T) {


### PR DESCRIPTION
Closes: #94

Only during validation (not during extraction!), inject the implicit ObjectMeta fields in the schema. Fields already in the schema (e.g. crossplane shortening `metadata.name`) are respected. Using reflection so that we don't have to hardcode the fields, and a bump on `k8s.io/apimachinery` includes new fields seamlessly.